### PR TITLE
chore: flatten nested CSS in sprite-sheet widget

### DIFF
--- a/packages/gjs/src/widgets/sprite/sprite-sheet.widget.css
+++ b/packages/gjs/src/widgets/sprite/sprite-sheet.widget.css
@@ -1,40 +1,35 @@
-#sprite-sheet-widget {
-    flowbox {
-        flowboxchild {
-            /* Reset all spacing for tight packing */
-            padding: 0;
-            margin: 0;
-            border: none;
-            border-radius: 0;
-            min-width: 0;
-            min-height: 0;
+/* Flat CSS — GTK4's CSS parser does not support nested rules, so all
+ * selectors are written fully qualified. Keep this flat to avoid
+ * "Expected ';' at end of block" theme-parser warnings at runtime. */
 
-            /* SpriteWidget (Adw.Bin) inside FlowBoxChild */
-            > bin {
-                /* Reset all spacing and borders for tight packing */
-                padding: 0;
-                margin: 0;
-                border: 1px solid black;
-                border-radius: 0;
-                min-width: 0;
-                min-height: 0;
-            }
+#sprite-sheet-widget flowbox flowboxchild {
+  /* Reset all spacing for tight packing. */
+  padding: 0;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  min-width: 0;
+  min-height: 0;
+}
 
-            /* Selection State - bright highlight without affecting layout */
-            &:selected {
-                outline: var(--sprite-selection-width) solid var(--sprite-selection-color);
-                outline-offset: calc(-1 * var(--sprite-selection-width));
-            }
+/* SpriteWidget (Adw.Bin) inside FlowBoxChild — reset spacing & add hairline border. */
+#sprite-sheet-widget flowbox flowboxchild > bin {
+  padding: 0;
+  margin: 0;
+  border: 1px solid black;
+  border-radius: 0;
+  min-width: 0;
+  min-height: 0;
+}
 
-            /* Hover State - subtle preview of selection */
-            &:hover:not(:selected) {
-                /* Use rgba() instead of color-mix() for better GTK compatibility */
-                outline: 1px solid rgba(53, 132, 228, var(--sprite-hover-opacity));
-                outline-offset: -1px;
-            }
-        }
-    }
-} 
+/* Selection — bright outline that does not affect layout. */
+#sprite-sheet-widget flowbox flowboxchild:selected {
+  outline: var(--sprite-selection-width) solid var(--sprite-selection-color);
+  outline-offset: calc(-1 * var(--sprite-selection-width));
+}
 
-
-
+/* Hover — subtle preview of selection. */
+#sprite-sheet-widget flowbox flowboxchild:hover:not(:selected) {
+  outline: 1px solid rgba(53, 132, 228, var(--sprite-hover-opacity));
+  outline-offset: -1px;
+}


### PR DESCRIPTION
## Summary

GTK4's CSS parser does not support nested rules (CSS Nesting Module) — only plain flat selectors. The sprite-sheet widget CSS used nesting with `>` combinators and `&:pseudo-class` prefixes, which produced runtime theme-parser warnings:

```
Gtk-WARNING: Theme parser error: No property named "flowbox"
Gtk-WARNING: Theme parser warning: Expected ';' at end of block
```

These warnings were hidden before #8 because `@import` resolution failed first and the CSS never reached the GTK parser. Once imports started working in that PR, the nesting issue became visible.

## Changes

Flattened all rules in [packages/gjs/src/widgets/sprite/sprite-sheet.widget.css](packages/gjs/src/widgets/sprite/sprite-sheet.widget.css) to fully-qualified selectors:

- `#sprite-sheet-widget flowbox flowboxchild { … }`
- `#sprite-sheet-widget flowbox flowboxchild > bin { … }`
- `#sprite-sheet-widget flowbox flowboxchild:selected { … }`
- `#sprite-sheet-widget flowbox flowboxchild:hover:not(:selected) { … }`

Semantics unchanged — same selector specificity, same rules, same cascade.

## Test plan

- [x] `yarn workspaces foreach -v -W -t run build` — green
- [x] `yarn workspace @pixelrpg/maker-gjs start` — no theme-parser warnings
- [x] `yarn workspace @pixelrpg/storybook-gjs start` — no theme-parser warnings
- [ ] Manual: open a project in maker-gjs, verify sprite-sheet widget rendering (tight packing, selection outline, hover outline)

## Follow-up (separate)

For a future upstream contribution: teach `@gjsify/esbuild-plugin-css` to lower modern CSS (nesting, `@layer`, `color-mix()`, …) to GTK4-compatible syntax via an opt-in lightningcss transform step. That would let consumers write nested CSS while still shipping flat output. Scope stays tight here since we're the only known consumer hitting this — a local fix is the right-sized step.