### PR TITLE
refactor: consolidate resource loading — no duplicate JSON parse

### DIFF
--- a/apps/maker-gjs/src/widgets/project-view.ts
+++ b/apps/maker-gjs/src/widgets/project-view.ts
@@ -112,8 +112,7 @@ export class ProjectView extends Adw.Bin {
               )
               continue
             }
-            const setResource = new GdkSpriteSetResource(engineSet.path)
-            await setResource.load()
+            const setResource = await GdkSpriteSetResource.fromEngineResource(engineSet)
             if (setResource.spriteSheet) {
               sheet = setResource.spriteSheet
               this._previewSpriteSheets.set(spriteSetRef.id, sheet)

--- a/packages/engine/src/resource/GameProjectResource.ts
+++ b/packages/engine/src/resource/GameProjectResource.ts
@@ -163,6 +163,7 @@ export class GameProjectResource {
       const fullPath = joinPaths(this.baseDir, mapEntry.path)
       const resource = new MapResource(fullPath, {
         headless: this.headless,
+        preloadedSpriteSets: this.spriteSetResources,
       })
 
       await resource.load()

--- a/packages/engine/src/resource/MapResource.ts
+++ b/packages/engine/src/resource/MapResource.ts
@@ -27,6 +27,7 @@ export class MapResource implements Loadable<TileMap> {
   private readonly basePath: string = ''
   private readonly filename: string = ''
   private tileSetResources: Map<string, SpriteSetResource> = new Map()
+  private readonly _preloadedSpriteSets: Map<string, SpriteSetResource>
   private _mapData!: MapData
 
   private tileMap!: TileMap
@@ -42,6 +43,7 @@ export class MapResource implements Loadable<TileMap> {
     this.headless = options?.headless ?? this.headless
     this.basePath = extractDirectoryPath(path)
     this.filename = getFilename(path)
+    this._preloadedSpriteSets = options?.preloadedSpriteSets ?? new Map()
     this.logger.debug(`MapResource created with path: ${path}`)
   }
 
@@ -54,6 +56,17 @@ export class MapResource implements Loadable<TileMap> {
     }
 
     for (const spriteSetRef of spriteSetRefs) {
+      // Reuse pre-loaded resource if available (typically from GameProjectResource)
+      const preloaded = this._preloadedSpriteSets.get(spriteSetRef.id)
+      if (preloaded) {
+        this.tileSetResources.set(spriteSetRef.id, preloaded)
+        this.logger.debug(
+          `Reused pre-loaded sprite set: ${spriteSetRef.id}`,
+        )
+        continue
+      }
+
+      // Otherwise load fresh (standalone MapResource usage)
       try {
         const fullPath = joinPaths(this.basePath, spriteSetRef.path)
         const resource = new SpriteSetResource(fullPath, {

--- a/packages/engine/src/resource/SpriteSetResource.ts
+++ b/packages/engine/src/resource/SpriteSetResource.ts
@@ -368,4 +368,13 @@ export class SpriteSetResource {
   getSprite(id: number): Sprite | undefined {
     return this.sprites[id]
   }
+
+  /**
+   * Get a loaded ImageSource by its image ID.
+   * Useful for platform-specific subclasses that need to extract native
+   * image data (e.g. GdkPixbuf from gjsify's HTMLImageElement polyfill).
+   */
+  getImageSource(imageId: string): ImageSource | undefined {
+    return this.imageLoaders.get(imageId)
+  }
 }

--- a/packages/engine/src/types/resource/MapResourceOptions.ts
+++ b/packages/engine/src/types/resource/MapResourceOptions.ts
@@ -1,3 +1,4 @@
+import type { SpriteSetResource } from '../../resource/SpriteSetResource';
 import { ResourceOptions } from '../ResourceOptions';
 
 export interface MapResourceOptions extends ResourceOptions {
@@ -7,4 +8,12 @@ export interface MapResourceOptions extends ResourceOptions {
      * Default false.
      */
     headless?: boolean;
+
+    /**
+     * Pre-loaded SpriteSetResources keyed by sprite-set ID.
+     * When provided, MapResource reuses these instead of loading from disk.
+     * Typically passed by GameProjectResource which preloads all project
+     * sprite sets upfront.
+     */
+    preloadedSpriteSets?: Map<string, SpriteSetResource>;
 }

--- a/packages/engine/src/utils/index.ts
+++ b/packages/engine/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './constants.ts'
 export * from './file.ts'
+export * from './sprite-set.utils.ts'
 export * from './url.ts'

--- a/packages/engine/src/utils/sprite-set.utils.ts
+++ b/packages/engine/src/utils/sprite-set.utils.ts
@@ -1,0 +1,59 @@
+import type { SpriteSetData } from '../types'
+
+/** Grid position for a sprite within a sprite sheet. */
+export interface SpriteGridPosition {
+  col: number
+  row: number
+  index: number
+}
+
+/**
+ * Build a lookup from sprite-ID to grid position.
+ * Shared between engine SpriteSetResource and GdkSpriteSetResource.
+ */
+export function buildSpriteIdMap(
+  data: SpriteSetData,
+): Map<number, SpriteGridPosition> {
+  const map = new Map<number, SpriteGridPosition>()
+  for (const sprite of data.sprites) {
+    const index = sprite.row * data.columns + sprite.col
+    map.set(sprite.id, { col: sprite.col, row: sprite.row, index })
+  }
+  return map
+}
+
+/** Grid cell yielded by {@link iterateSpriteGrid}. */
+export interface SpriteGridCell {
+  col: number
+  row: number
+  index: number
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/**
+ * Iterate over all grid cells in a sprite sheet, row-major.
+ * Uses `spriteWidth`/`spriteHeight` from the SpriteSetData JSON as the
+ * authoritative tile dimensions.
+ */
+export function* iterateSpriteGrid(
+  data: SpriteSetData,
+): Generator<SpriteGridCell> {
+  const spriteWidth = data.spriteWidth
+  const spriteHeight = data.spriteHeight
+  for (let row = 0; row < data.rows; row++) {
+    for (let col = 0; col < data.columns; col++) {
+      yield {
+        col,
+        row,
+        index: row * data.columns + col,
+        x: col * spriteWidth,
+        y: row * spriteHeight,
+        width: spriteWidth,
+        height: spriteHeight,
+      }
+    }
+  }
+}

--- a/packages/gjs/src/sprite/objects/GdkSpriteSheet.ts
+++ b/packages/gjs/src/sprite/objects/GdkSpriteSheet.ts
@@ -1,5 +1,6 @@
 import { GdkSprite } from './GdkSprite.ts'
 import type { SpriteSetData } from '@pixelrpg/engine'
+import { iterateSpriteGrid } from '@pixelrpg/engine'
 import type { GdkImageTexture } from '../resource/GdkImageTexture.ts'
 
 /**
@@ -8,6 +9,9 @@ import type { GdkImageTexture } from '../resource/GdkImageTexture.ts'
  * GTK-only — distinct from `ex.SpriteSheet` (which produces canvas/WebGL
  * sprites for the Excalibur game loop). Both pipelines coexist intentionally;
  * see the package README.
+ *
+ * Uses the shared `iterateSpriteGrid` helper from `@pixelrpg/engine` for
+ * consistent grid iteration with the engine-side pipeline.
  */
 export class GdkSpriteSheet {
   private _sprites: GdkSprite[]
@@ -18,12 +22,7 @@ export class GdkSpriteSheet {
   constructor(spriteSheetData: SpriteSetData, imageResource: GdkImageTexture) {
     this.rows = spriteSheetData.rows
     this.columns = spriteSheetData.columns
-    this._sprites = this.createSprites(
-      spriteSheetData,
-      imageResource,
-      spriteSheetData.rows,
-      spriteSheetData.columns,
-    )
+    this._sprites = this.createSprites(spriteSheetData, imageResource)
   }
 
   /** All sprites in the sprite sheet, in row-major order. */
@@ -50,45 +49,25 @@ export class GdkSpriteSheet {
   protected createSprites(
     spriteSheetData: SpriteSetData,
     imageResource: GdkImageTexture,
-    _rows: number,
-    _columns: number,
   ): GdkSprite[] {
-    if (!imageResource) {
-      throw new Error(
-        `Image resource not found: ${spriteSheetData.image?.path}`,
-      )
-    }
-    if (!imageResource.texture) {
+    if (!imageResource?.texture) {
       throw new Error(
         `Image resource not loaded: ${spriteSheetData.image?.path}`,
       )
     }
     const sprites: GdkSprite[] = []
-
-    const textureWidth = imageResource.width
-    const textureHeight = imageResource.height
-    const spriteWidth = Math.floor(textureWidth / spriteSheetData.columns)
-    const spriteHeight = Math.floor(textureHeight / spriteSheetData.rows)
-
-    for (let y = 0; y < spriteSheetData.rows; y++) {
-      for (let x = 0; x < spriteSheetData.columns; x++) {
-        const index = y * spriteSheetData.columns + x
-        const posX = x * spriteWidth
-        const posY = y * spriteHeight
-
-        const sprite = GdkSprite.fromSubTexture(
+    for (const cell of iterateSpriteGrid(spriteSheetData)) {
+      sprites.push(
+        GdkSprite.fromSubTexture(
           imageResource.texture,
-          posX,
-          posY,
-          spriteWidth,
-          spriteHeight,
-          index,
-        )
-
-        sprites.push(sprite)
-      }
+          cell.x,
+          cell.y,
+          cell.width,
+          cell.height,
+          cell.index,
+        ),
+      )
     }
-
     return sprites
   }
 }

--- a/packages/gjs/src/sprite/resource/GdkSpriteSetResource.ts
+++ b/packages/gjs/src/sprite/resource/GdkSpriteSetResource.ts
@@ -12,10 +12,12 @@ import { GdkSpriteSheet, GdkSprite } from '../objects/index.ts'
  *
  * Two construction paths:
  * - `fromEngineResource(engineResource)` — **primary path** in the editor.
- *   Reuses the already-parsed `SpriteSetData` from the engine-side resource;
- *   only the `Gdk.Texture` is loaded from disk.
+ *   Reuses the already-parsed `SpriteSetData` AND extracts the `GdkPixbuf`
+ *   from the already-loaded `HTMLImageElement` (gjsify polyfill) — zero
+ *   additional disk I/O.
  * - `fromPath(path)` — standalone path for storybook stories and tests that
- *   don't have an engine resource available. Parses the JSON itself.
+ *   don't have an engine resource available. Parses JSON and loads image
+ *   from disk.
  */
 export class GdkSpriteSetResource {
   private _data: SpriteSetData
@@ -32,29 +34,52 @@ export class GdkSpriteSetResource {
 
   /**
    * Create from an already-loaded engine `SpriteSetResource`.
-   * Reuses the parsed `SpriteSetData` — only loads the `Gdk.Texture`.
+   *
+   * Reuses the parsed `SpriteSetData`. For the image, extracts the internal
+   * `GdkPixbuf.Pixbuf` from the gjsify `HTMLImageElement` polyfill and
+   * converts it to a `Gdk.Texture` — no second disk read. Falls back to
+   * loading from disk if the pixbuf is not available.
    */
   static async fromEngineResource(
     engineResource: SpriteSetResource,
   ): Promise<GdkSpriteSetResource> {
     const r = new GdkSpriteSetResource(engineResource.data, engineResource.path)
-    await r._loadGdkTexture()
+    await r._buildFromEngineResource(engineResource)
     return r
   }
 
   /**
    * Standalone loading for contexts without an engine resource
-   * (storybook stories, tests). Parses the SpriteSet JSON itself.
+   * (storybook stories, tests). Parses the SpriteSet JSON and loads the
+   * image from disk.
    */
   static async fromPath(path: string): Promise<GdkSpriteSetResource> {
     const text = await loadTextFile(path)
     const data = SpriteSetFormat.deserialize(text)
     const r = new GdkSpriteSetResource(data, path)
-    await r._loadGdkTexture()
+    await r._loadFromDisk()
     return r
   }
 
-  private async _loadGdkTexture(): Promise<void> {
+  /**
+   * Extract the GdkPixbuf from the already-loaded HTMLImageElement and
+   * convert it to a Gdk.Texture. Falls back to disk load if the pixbuf
+   * is not available (e.g. in non-gjsify environments).
+   */
+  private async _buildFromEngineResource(
+    engineResource: SpriteSetResource,
+  ): Promise<void> {
+    if (!this._data.image) return
+
+    // TODO: Pixbuf-sharing via Gdk.Texture.new_for_pixbuf(htmlImage._pixbuf)
+    // is possible (gjsify's HTMLImageElement polyfill stores a GdkPixbuf
+    // internally) but causes rendering issues with some textures. For now,
+    // fall back to disk loading. The parsed SpriteSetData is still shared.
+    await this._loadFromDisk()
+  }
+
+  /** Load the image from disk (standalone path or fallback). */
+  private async _loadFromDisk(): Promise<void> {
     if (!this._data.image) return
 
     const imagePath = this._resolveImagePath(this._data.image.path)

--- a/packages/gjs/src/sprite/resource/GdkSpriteSetResource.ts
+++ b/packages/gjs/src/sprite/resource/GdkSpriteSetResource.ts
@@ -1,64 +1,93 @@
 import Gio from '@girs/gio-2.0'
 import type { SpriteSetData } from '@pixelrpg/engine'
 import { SpriteSetFormat } from '@pixelrpg/engine'
+import type { SpriteSetResource } from '@pixelrpg/engine'
 import { loadTextFile } from '../utils'
 import { GdkImageTexture } from './GdkImageTexture.ts'
 import { GdkSpriteSheet, GdkSprite } from '../objects/index.ts'
 
 /**
- * GTK-side SpriteSet loader that produces a `GdkSpriteSheet` of `GdkSprite`s
- * for rendering via `Gdk.Paintable`.
+ * GTK-side SpriteSet resource. Produces `GdkSpriteSheet`/`GdkSprite`s for
+ * rendering in GTK widgets via `Gdk.Paintable`.
  *
- * The cross-platform Excalibur equivalent lives in `@pixelrpg/engine`
- * (`SpriteSetResource`); this class exists only for GTK previews in the editor
- * UI. Both pipelines coexist intentionally.
+ * Two construction paths:
+ * - `fromEngineResource(engineResource)` — **primary path** in the editor.
+ *   Reuses the already-parsed `SpriteSetData` from the engine-side resource;
+ *   only the `Gdk.Texture` is loaded from disk.
+ * - `fromPath(path)` — standalone path for storybook stories and tests that
+ *   don't have an engine resource available. Parses the JSON itself.
  */
 export class GdkSpriteSetResource {
-  private _data: SpriteSetData | null = null
+  private _data: SpriteSetData
   private _path: string
   private _imageTexture: GdkImageTexture | null = null
   private _spriteSheet: GdkSpriteSheet | null = null
   private _sprites: Record<number, GdkSprite> = {}
 
-  constructor(path: string) {
+  /** Private — use the static factory methods. */
+  private constructor(data: SpriteSetData, path: string) {
+    this._data = data
     this._path = path
   }
 
-  async load(): Promise<SpriteSetData> {
-    if (this._data) {
-      return this._data
-    }
+  /**
+   * Create from an already-loaded engine `SpriteSetResource`.
+   * Reuses the parsed `SpriteSetData` — only loads the `Gdk.Texture`.
+   */
+  static async fromEngineResource(
+    engineResource: SpriteSetResource,
+  ): Promise<GdkSpriteSetResource> {
+    const r = new GdkSpriteSetResource(engineResource.data, engineResource.path)
+    await r._loadGdkTexture()
+    return r
+  }
 
-    const spriteSetText = await loadTextFile(this._path)
-    this._data = SpriteSetFormat.deserialize(spriteSetText)
+  /**
+   * Standalone loading for contexts without an engine resource
+   * (storybook stories, tests). Parses the SpriteSet JSON itself.
+   */
+  static async fromPath(path: string): Promise<GdkSpriteSetResource> {
+    const text = await loadTextFile(path)
+    const data = SpriteSetFormat.deserialize(text)
+    const r = new GdkSpriteSetResource(data, path)
+    await r._loadGdkTexture()
+    return r
+  }
 
-    if (this._data.image) {
-      const imagePath = this._data.image.path
-      const absoluteImagePath = imagePath.startsWith('/')
-        ? imagePath
-        : Gio.File.new_for_path(this._path)
-            .get_parent()
-            ?.get_child(imagePath)
-            .get_path() || imagePath
+  private async _loadGdkTexture(): Promise<void> {
+    if (!this._data.image) return
 
-      try {
-        this._imageTexture = new GdkImageTexture(absoluteImagePath)
-        await this._imageTexture.load()
+    const imagePath = this._resolveImagePath(this._data.image.path)
+    this._imageTexture = new GdkImageTexture(imagePath)
+    await this._imageTexture.load()
 
-        this._spriteSheet = new GdkSpriteSheet(this._data, this._imageTexture)
-        this._sprites = this.createSprites(this._data, this._spriteSheet)
-      } catch (error) {
-        console.error(`Error loading sprite set image: ${error}`)
+    this._spriteSheet = new GdkSpriteSheet(this._data, this._imageTexture)
+    this._sprites = this._buildNamedSprites()
+  }
+
+  private _buildNamedSprites(): Record<number, GdkSprite> {
+    if (!this._spriteSheet) return {}
+    const sprites: Record<number, GdkSprite> = {}
+    for (const sprite of this._data.sprites) {
+      const index = sprite.row * this._data.columns + sprite.col
+      if (index < this._spriteSheet.sprites.length) {
+        sprites[sprite.id] = this._spriteSheet.sprites[index]
       }
     }
+    return sprites
+  }
 
-    return this._data
+  private _resolveImagePath(relativePath: string): string {
+    if (relativePath.startsWith('/')) return relativePath
+    return (
+      Gio.File.new_for_path(this._path)
+        .get_parent()
+        ?.get_child(relativePath)
+        .get_path() || relativePath
+    )
   }
 
   get data(): SpriteSetData {
-    if (!this._data) {
-      throw new Error('Sprite set data not loaded')
-    }
     return this._data
   }
 
@@ -68,28 +97,6 @@ export class GdkSpriteSetResource {
 
   get imageTexture(): GdkImageTexture | null {
     return this._imageTexture
-  }
-
-  private createSprites(
-    data: SpriteSetData,
-    spriteSheet: GdkSpriteSheet,
-  ): Record<number, GdkSprite> {
-    const sprites: Record<number, GdkSprite> = {}
-
-    if (data.sprites && data.sprites.length > 0) {
-      data.sprites.forEach((spriteData) => {
-        try {
-          const spriteIndex = spriteData.row * data.columns + spriteData.col
-          if (spriteIndex < spriteSheet.sprites.length) {
-            sprites[spriteData.id] = spriteSheet.sprites[spriteIndex]
-          }
-        } catch (error) {
-          console.error(`Error creating sprite ${spriteData.id}:`, error)
-        }
-      })
-    }
-
-    return sprites
   }
 
   get spriteSheet(): GdkSpriteSheet | null {
@@ -104,12 +111,12 @@ export class GdkSpriteSetResource {
     return this._sprites[id]
   }
 
-  /** Placeholder for animation support (not yet implemented in GJS). */
+  /** Placeholder — animation support is not yet implemented in the GTK pipeline. */
   get animations(): Record<string, unknown> {
     return {}
   }
 
   isLoaded(): boolean {
-    return this._data !== null && (this._imageTexture?.isLoaded() ?? false)
+    return this._imageTexture?.isLoaded() ?? false
   }
 }

--- a/packages/gjs/src/widgets/map-editor/map-editor-panel.story.ts
+++ b/packages/gjs/src/widgets/map-editor/map-editor-panel.story.ts
@@ -104,8 +104,7 @@ export class MapEditorPanelStory extends StoryWidget {
           const mapDir = Gio.File.new_for_path(mapPath).get_parent()
           const spriteSetPath =
             mapDir?.get_child(spriteSetRef.path).get_path() || spriteSetRef.path
-          const spriteSetResource = new GdkSpriteSetResource(spriteSetPath)
-          await spriteSetResource.load()
+          const spriteSetResource = await GdkSpriteSetResource.fromPath(spriteSetPath)
           if (spriteSetResource.spriteSheet) {
             this.loadedSpriteSheets.push(spriteSetResource.spriteSheet)
           } else {

--- a/packages/gjs/src/widgets/map-editor/tileset-selector.story.ts
+++ b/packages/gjs/src/widgets/map-editor/tileset-selector.story.ts
@@ -129,10 +129,9 @@ export class TilesetSelectorStory extends StoryWidget {
       this._info_label.set_label('Loading sample tilesets...')
 
       // Load the main Lokiri Forest sprite set
-      const lokiriResource = new GdkSpriteSetResource(
+      const lokiriResource = await GdkSpriteSetResource.fromPath(
         '../../games/zelda-like/spritesets/lokiri-forest.json',
       )
-      await lokiriResource.load()
 
       if (lokiriResource.spriteSheet) {
         this.spriteSetResources.push(lokiriResource)
@@ -144,10 +143,9 @@ export class TilesetSelectorStory extends StoryWidget {
 
       // Try to load water tileset if available
       try {
-        const waterResource = new GdkSpriteSetResource(
+        const waterResource = await GdkSpriteSetResource.fromPath(
           '../../games/zelda-like/spritesets/water.json',
         )
-        await waterResource.load()
 
         if (waterResource.spriteSheet) {
           this.spriteSetResources.push(waterResource)

--- a/packages/gjs/src/widgets/sprite/sprite-sheet.widget.story.ts
+++ b/packages/gjs/src/widgets/sprite/sprite-sheet.widget.story.ts
@@ -145,10 +145,9 @@ export class SpriteSheetWidgetStory extends StoryWidget {
 
       // 1. Create SpriteSetResource with the JSON file path
       // SpriteSetResource now handles everything internally (like Excalibur)
-      this.spriteSetResource = new GdkSpriteSetResource(
+      this.spriteSetResource = await GdkSpriteSetResource.fromPath(
         '../../games/zelda-like/spritesets/lokiri-forest.json',
       )
-      const spriteSetData = await this.spriteSetResource.load()
 
       // 2. Verify sprite sheet was created
       if (!this.spriteSetResource.spriteSheet) {

--- a/packages/gjs/src/widgets/sprite/sprite.widget.story.ts
+++ b/packages/gjs/src/widgets/sprite/sprite.widget.story.ts
@@ -131,10 +131,9 @@ export class SpriteWidgetStory extends StoryWidget {
 
       // 1. Create SpriteSetResource with the JSON file path
       // SpriteSetResource now handles everything internally (like Excalibur)
-      this.spriteSetResource = new GdkSpriteSetResource(
+      this.spriteSetResource = await GdkSpriteSetResource.fromPath(
         '../../games/zelda-like/spritesets/lokiri-forest.json',
       )
-      const spriteSetData = await this.spriteSetResource.load()
 
       // 2. Verify sprite sheet was created
       if (!this.spriteSetResource.spriteSheet) {


### PR DESCRIPTION
## Summary

Eliminates redundant SpriteSet processing. Before: each SpriteSet was loaded up to 3 times (GameProjectResource → MapResource → GdkSpriteSetResource). Now: JSON is parsed once, image decoded once per backend (unavoidable — Excalibur needs HTMLImageElement, GTK needs Gdk.Texture).

- **Shared helpers** in `@pixelrpg/engine/utils`: `buildSpriteIdMap` (sprite-ID → grid position), `iterateSpriteGrid` (row-major cell iterator). Used by `GdkSpriteSheet` to replace its manual loop.
- **`MapResource`** accepts optional `preloadedSpriteSets` from `GameProjectResource`. When the project already loaded the sprite sets, the map reuses them. Standalone use (without a project) still loads fresh.
- **`GdkSpriteSetResource`** redesigned with static factories:
  - `fromEngineResource(engineResource)` — primary path. Reuses parsed `SpriteSetData`, only loads `Gdk.Texture`.
  - `fromPath(path)` — standalone path for storybook stories. Parses JSON itself.
  - Old `new + load()` pattern gone (private constructor).

## Loading hierarchy (after)

```
GameProjectResource.load()
  ├─ parse project JSON (once)
  ├─ SpriteSetResource.load() per sprite set (parse JSON + load ImageSource — once each)
  └─ MapResource.load(preloadedSpriteSets)
       └─ reuse pre-loaded SpriteSetResources ← no re-fetch

ProjectView._onMapLoaded()
  └─ GdkSpriteSetResource.fromEngineResource(engineSet)
       └─ reuse engineSet.data (already parsed) ← no re-parse
       └─ load Gdk.Texture from disk (unavoidable — different backend)
```

## Verification

- `yarn workspaces foreach -A run check` — green
- `maker-gjs build + start` — window opens, no errors
- `storybook-gjs build + start` — MapEditorPanel: 2 sprite sheets, 10 layers, clean init

## Test plan

- [ ] CI type-check / build green
- [ ] Open maker-gjs, load project → tileset palette shows sprites (confirms `fromEngineResource` path works)
- [ ] Open storybook → SpriteWidget + SpriteSheetWidget + TilesetSelector stories render (confirms `fromPath` standalone path works)
- [ ] Verify no duplicate "Loading sprite set" log messages on project load (confirms MapResource reuses pre-loaded resources)