### PR TITLE
fix(gjs): use Gdk.MemoryTexture instead of deprecated new_for_pixbuf

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "refs/Game-Dev-Library"]
+	path = refs/Game-Dev-Library
+	url = git@github.com:jyoung4242/Game-Dev-Library.git

--- a/packages/gjs/src/sprite/resource/GdkSpriteSetResource.ts
+++ b/packages/gjs/src/sprite/resource/GdkSpriteSetResource.ts
@@ -1,4 +1,6 @@
 import Gio from '@girs/gio-2.0'
+import Gdk from '@girs/gdk-4.0'
+import type GdkPixbuf from '@girs/gdkpixbuf-2.0'
 import type { SpriteSetData } from '@pixelrpg/engine'
 import { SpriteSetFormat } from '@pixelrpg/engine'
 import type { SpriteSetResource } from '@pixelrpg/engine'
@@ -71,11 +73,37 @@ export class GdkSpriteSetResource {
   ): Promise<void> {
     if (!this._data.image) return
 
-    // TODO: Pixbuf-sharing via Gdk.Texture.new_for_pixbuf(htmlImage._pixbuf)
-    // is possible (gjsify's HTMLImageElement polyfill stores a GdkPixbuf
-    // internally) but causes rendering issues with some textures. For now,
-    // fall back to disk loading. The parsed SpriteSetData is still shared.
-    await this._loadFromDisk()
+    const imageSource = engineResource.getImageSource(this._data.image.id)
+    // _pixbuf is protected on gjsify's HTMLImageElement — access via cast.
+    const pixbuf = (imageSource?.data as any)?._pixbuf as
+      | GdkPixbuf.Pixbuf
+      | undefined
+
+    if (pixbuf) {
+      // Ensure RGBA — GdkPixbuf may be RGB-only for JPEG sources.
+      const rgbaPixbuf = pixbuf.get_has_alpha()
+        ? pixbuf
+        : (pixbuf.add_alpha(false, 0, 0, 0) ?? pixbuf)
+
+      // GTK4-native: explicit format avoids the deprecated
+      // Gdk.Texture.new_for_pixbuf() and its colour-space/alpha ambiguity.
+      // GdkPixbuf stores pixels as R, G, B, A bytes = MemoryFormat.R8G8B8A8.
+      const texture = Gdk.MemoryTexture['new'](
+        rgbaPixbuf.get_width(),
+        rgbaPixbuf.get_height(),
+        Gdk.MemoryFormat.R8G8B8A8,
+        rgbaPixbuf.get_pixels(),
+        rgbaPixbuf.get_rowstride(),
+      )
+      this._imageTexture = GdkImageTexture.fromTexture(texture)
+      this._spriteSheet = new GdkSpriteSheet(this._data, this._imageTexture)
+      this._sprites = this._buildNamedSprites()
+    } else {
+      console.warn(
+        `[GdkSpriteSetResource] No _pixbuf on HTMLImageElement for "${this._data.image.id}" — falling back to disk load`,
+      )
+      await this._loadFromDisk()
+    }
   }
 
   /** Load the image from disk (standalone path or fallback). */


### PR DESCRIPTION
## Problem

`Gdk.Texture.new_for_pixbuf()` is a GTK3 compatibility shim. In GTK4's GL backend it causes silent rendering failures: the first SpriteSet in the tile palette was invisible while subsequent ones rendered correctly.

Root cause: `new_for_pixbuf()` does not specify a pixel format explicitly, leaving GTK4 to guess colour-space and alpha interpretation. The result is a texture that the GL renderer uploads incorrectly for at least some pixbuf configurations.

## Solution

Replace with `Gdk.MemoryTexture.new()` and explicit `Gdk.MemoryFormat.R8G8B8A8`:

- `GdkPixbuf` stores pixels as R, G, B, A bytes in memory (straight alpha) — this maps exactly to `R8G8B8A8`.
- GTK4 now knows the exact format and handles the GPU upload correctly.
- RGB-only pixbufs (e.g. JPEG sources) are promoted to RGBA via `add_alpha()` before passing to `MemoryTexture`.

The pixbuf itself comes from gjsify's `HTMLImageElement` polyfill (which stores it as `_pixbuf` internally after loading via Excalibur), so **the image is still never read from disk a second time**.

## Changes

| File | Change |
|---|---|
| `packages/gjs/src/sprite/resource/GdkSpriteSetResource.ts` | Replace `_buildFromEngineResource` body: `MemoryTexture` instead of disk load + deprecated `new_for_pixbuf` |

## Test plan

- [ ] `yarn workspace @pixelrpg/maker-gjs start` → load example project → both SpriteSets visible in tile palette
- [ ] `yarn workspace @pixelrpg/storybook-gjs start` → sprite stories still render correctly (these use `fromPath`, not the pixbuf path)
- [ ] Type-check: `yarn workspace @pixelrpg/gjs check` exits 0