### PR TITLE
ci: bump checkout@v4 + setup-node@v4 → v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install GNOME dev libs
         # `blueprint-compiler` needs the `.gir` introspection files for the
@@ -50,7 +50,7 @@ jobs:
           blueprint-compiler --version
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 


### PR DESCRIPTION
Silences the Node.js 20 deprecation warning. Drop-in version bumps matching the fix in [gjsify/types#10](https://github.com/gjsify/types/pull/10) and [gjsify/gjsify#238](https://github.com/gjsify/gjsify/pull/238).