### PR TITLE
feat(engine): SessionState foundation + mode-marker components (Phase 1)

### DIFF
--- a/packages/engine/src/components/editor-mode.component.ts
+++ b/packages/engine/src/components/editor-mode.component.ts
@@ -1,0 +1,14 @@
+import { Component } from 'excalibur'
+
+/**
+ * Marker component — when present on the session-singleton entity,
+ * the editor's tool systems run. When absent, tool systems short-
+ * circuit on their first guard. No fields; the *presence* of the
+ * component is the entire signal.
+ *
+ * See `docs/concepts/runtime-modes.md` and
+ * `docs/concepts/editor-architecture.md`. Combined with
+ * `RuntimeModeComponent`, both can be present at once for the
+ * Mario-Maker-style "Live Run" (edit while playing).
+ */
+export class EditorModeComponent extends Component {}

--- a/packages/engine/src/components/ghost-spawn.component.ts
+++ b/packages/engine/src/components/ghost-spawn.component.ts
@@ -1,0 +1,27 @@
+import { Component } from 'excalibur'
+import type { Facing } from '../types/data/index.ts'
+
+/**
+ * Runtime-only override for the player's spawn position.
+ *
+ * When present on the session-singleton entity, `PlayerSpawnSystem`
+ * uses `tileX/tileY` instead of looking for a
+ * `kind: 'spawn-point'` placement on the map. Used to start Live
+ * Run / Test Run at whatever tile the editor user is currently
+ * focused on (Mario-Maker-style "play from here").
+ *
+ * **In-memory only** — never modifies the project's map data. The
+ * map's real spawn-point placement stays untouched and is what
+ * Full Run uses.
+ *
+ * See `docs/concepts/runtime-modes.md`.
+ */
+export class GhostSpawnComponent extends Component {
+  constructor(
+    public tileX: number,
+    public tileY: number,
+    public facing?: Facing,
+  ) {
+    super()
+  }
+}

--- a/packages/engine/src/components/index.ts
+++ b/packages/engine/src/components/index.ts
@@ -2,9 +2,12 @@
 
 export * from './collision.component'
 export * from './custom-data.component'
+export * from './editor-mode.component'
+export * from './ghost-spawn.component'
 export * from './item.component'
 export * from './map-editor.component'
 export * from './npc.component'
+export * from './runtime-mode.component'
 export * from './spawn-point.component'
 export * from './sprite-ref.component'
 export * from './teleport.component'

--- a/packages/engine/src/components/runtime-mode.component.ts
+++ b/packages/engine/src/components/runtime-mode.component.ts
@@ -1,0 +1,14 @@
+import { Component } from 'excalibur'
+
+/**
+ * Marker component — when present on the session-singleton entity,
+ * runtime systems run (player movement, trigger effects, audio,
+ * animations advance, etc.). When absent, those systems short-
+ * circuit on their first guard so the engine renders but doesn't
+ * "play".
+ *
+ * No fields; presence-as-signal. Combined with `EditorModeComponent`
+ * for Live Run, or alone for Full Run / Test Run. See
+ * `docs/concepts/runtime-modes.md`.
+ */
+export class RuntimeModeComponent extends Component {}

--- a/packages/engine/src/scenes/map.scene.ts
+++ b/packages/engine/src/scenes/map.scene.ts
@@ -1,4 +1,5 @@
 import { type EventEmitter, Logger, Scene } from 'excalibur'
+import { EditorModeComponent } from '../components/index.ts'
 import type { MapResource } from '../resource/MapResource.ts'
 import {
   CameraControlSystem,
@@ -11,6 +12,7 @@ import {
   WalkOnTileSystem,
 } from '../systems/index.ts'
 import type { EditorState, EngineEventMap, ObjectDefinition } from '../types/index.ts'
+import { SessionState } from '../utils/session-state.ts'
 
 /**
  * Per-map scene. Composes the editor + runtime systems that
@@ -25,6 +27,13 @@ import type { EditorState, EngineEventMap, ObjectDefinition } from '../types/ind
  * Spawn-system order matters: `ObjectSpawnSystem` runs first so the
  * spawn-point entity exists in the world before `PlayerSpawnSystem`
  * queries for it.
+ *
+ * Session-state: each scene gets its own session-singleton entity
+ * via `SessionState.ensure(this)` plus an `EditorModeComponent`
+ * marker by default. The maker (or the future runtime entry point)
+ * mutates these markers to toggle Live Run / Test Run / Full Run.
+ * See `docs/concepts/runtime-modes.md` and
+ * `docs/concepts/editor-architecture.md`.
  */
 export class MapScene extends Scene {
   private logger = Logger.getInstance()
@@ -44,6 +53,12 @@ export class MapScene extends Scene {
     this.world.add(new TeleportSystem(events))
     this.world.add(new ItemPickupSystem(events))
     this.world.add(new WalkOnTileSystem(mapResource, events))
+
+    // Bootstrap the session-singleton + default to editor mode.
+    // Hosts that want to start in pure runtime (Full Run window) can
+    // call `SessionState.unset(scene, EditorModeComponent)` and add a
+    // `RuntimeModeComponent` right after construction.
+    SessionState.set(this, new EditorModeComponent())
 
     mapResource.addToScene(this)
     this.logger.debug('MapScene initialized')

--- a/packages/engine/src/utils/index.ts
+++ b/packages/engine/src/utils/index.ts
@@ -1,4 +1,6 @@
 export * from './constants.ts'
 export * from './file.ts'
+export * from './session-state.ts'
 export * from './sprite-set.utils.ts'
+export * from './subscription-registry.ts'
 export * from './url.ts'

--- a/packages/engine/src/utils/session-state.ts
+++ b/packages/engine/src/utils/session-state.ts
@@ -1,0 +1,147 @@
+import { Entity, type Scene } from 'excalibur'
+import type { Component, ComponentCtor } from 'excalibur'
+import { SubscriptionRegistry } from './subscription-registry.ts'
+
+/**
+ * Helper around the per-scene **session-singleton entity** that holds
+ * editor + runtime mode state and (over time) every other piece of
+ * "per-user, per-scene" state the editor cares about.
+ *
+ * One singleton per `Scene`. The same `Scene` instance always
+ * resolves to the same singleton — that's the load-bearing
+ * invariant for the subscription bridge.
+ *
+ * Components attached to the singleton are observed by the GTK
+ * widgets via {@link subscribe}; the bridge fires with the current
+ * value at subscribe time and again on add / remove / explicit
+ * mutation notify.
+ *
+ * See `docs/concepts/editor-architecture.md` for the architectural
+ * justification + the relationship between this helper, the
+ * Operation-oriented mutation API, and the future Undo system.
+ */
+
+/** Stable name used for the singleton entity in `scene.world`. */
+export const SESSION_ENTITY_NAME = 'session-state'
+
+type Listener<C extends Component> = (component: C | null) => void
+type Unsubscribe = () => void
+
+// Per-Scene subscription registries. WeakMap keys on the Scene so the
+// registry disappears when the scene itself is garbage-collected.
+const registries = new WeakMap<Scene, SubscriptionRegistry<ComponentCtor<Component>, Component>>()
+
+function getRegistry(scene: Scene): SubscriptionRegistry<ComponentCtor<Component>, Component> {
+  let reg = registries.get(scene)
+  if (!reg) {
+    reg = new SubscriptionRegistry()
+    registries.set(scene, reg)
+  }
+  return reg
+}
+
+// biome-ignore lint/complexity/noStaticOnlyClass: Used as a namespace for cohesive helpers; conversion would break the typed-key/value API and barrel exports.
+export class SessionState {
+  /**
+   * Get-or-create the singleton entity on `scene`. Idempotent —
+   * second + later calls return the existing entity. Called by
+   * `MapScene`'s constructor; widgets call it as well so they don't
+   * need to know whether the maker already initialised it.
+   */
+  static ensure(scene: Scene): Entity {
+    const existing = SessionState._find(scene)
+    if (existing) return existing
+    const entity = new Entity({ name: SESSION_ENTITY_NAME })
+    scene.add(entity)
+    return entity
+  }
+
+  /**
+   * Read the current value of a component on the singleton, or
+   * `null` when not present. Convenience around `entity.get(...)`
+   * that also normalises `undefined → null` so callers can `??`
+   * cleanly.
+   */
+  static get<C extends Component>(scene: Scene, ctor: ComponentCtor<C>): C | null {
+    const entity = SessionState._find(scene)
+    return (entity?.get(ctor) ?? null) as C | null
+  }
+
+  /**
+   * Attach (or replace) a component on the singleton. Fires
+   * subscribers with the new component. Use this for *adding* a
+   * mode marker / state component to the singleton — for editing a
+   * field on an existing component in place, call
+   * {@link notifyMutation} after the mutation.
+   */
+  static set<C extends Component>(scene: Scene, component: C): void {
+    const entity = SessionState.ensure(scene)
+    const ctor = component.constructor as ComponentCtor<C>
+    const existing = entity.get(ctor)
+    if (existing) entity.removeComponent(ctor)
+    entity.addComponent(component)
+    getRegistry(scene).notify(ctor as ComponentCtor<Component>, component)
+  }
+
+  /**
+   * Remove a component from the singleton if present. Fires
+   * subscribers with `null`. No-op when the component isn't
+   * attached.
+   */
+  static unset<C extends Component>(scene: Scene, ctor: ComponentCtor<C>): void {
+    const entity = SessionState._find(scene)
+    if (!entity?.get(ctor)) return
+    entity.removeComponent(ctor)
+    getRegistry(scene).notify(ctor as ComponentCtor<Component>, null)
+  }
+
+  /**
+   * Subscribe to changes of a component on the singleton. Fires
+   * once synchronously with the current value (or `null`), then
+   * again on each `set` / `unset` / `notifyMutation` for that
+   * component type.
+   *
+   * Returns a `disconnect` function — callers stash it in their
+   * per-widget disposables bag and release it from `vfunc_unmap`.
+   */
+  static subscribe<C extends Component>(
+    scene: Scene,
+    ctor: ComponentCtor<C>,
+    listener: Listener<C>,
+  ): Unsubscribe {
+    SessionState.ensure(scene) // make sure the singleton exists so latest-value semantics work
+    const reg = getRegistry(scene)
+    return reg.subscribe(ctor as ComponentCtor<Component>, (value) => {
+      listener((value as C | null) ?? SessionState.get(scene, ctor))
+    })
+  }
+
+  /**
+   * Notify subscribers that a component's fields changed in place.
+   * Systems that mutate component state (e.g. updating
+   * `ActiveToolComponent.tool`) call this after the mutation —
+   * Excalibur doesn't observe per-field changes, so this is the
+   * explicit "fence" around mutations.
+   *
+   * Workspace rule: every system that writes to a component on the
+   * session-singleton MUST follow the write with a `notifyMutation`
+   * call. See `AGENTS.md` § "Engine patterns — ECS".
+   */
+  static notifyMutation<C extends Component>(scene: Scene, component: C): void {
+    const ctor = component.constructor as ComponentCtor<Component>
+    getRegistry(scene).notify(ctor, component)
+  }
+
+  /**
+   * Internal — find the singleton entity if it exists; returns
+   * `null` when the scene hasn't been initialised yet. Used by
+   * `get` / `unset` so they don't accidentally construct the
+   * singleton just to read it.
+   */
+  private static _find(scene: Scene): Entity | null {
+    for (const entity of scene.entities) {
+      if (entity.name === SESSION_ENTITY_NAME) return entity
+    }
+    return null
+  }
+}

--- a/packages/engine/src/utils/subscription-registry.test.ts
+++ b/packages/engine/src/utils/subscription-registry.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest'
+import { SubscriptionRegistry } from './subscription-registry.ts'
+
+describe('SubscriptionRegistry', () => {
+  it('primes new subscribers with the latest cached value (null if never set)', () => {
+    const reg = new SubscriptionRegistry<string, number>()
+    const listener = vi.fn()
+    reg.subscribe('a', listener)
+    expect(listener).toHaveBeenCalledTimes(1)
+    expect(listener).toHaveBeenCalledWith(null)
+  })
+
+  it('primes new subscribers with the cached value when one exists', () => {
+    const reg = new SubscriptionRegistry<string, number>()
+    reg.notify('a', 7)
+    const listener = vi.fn()
+    reg.subscribe('a', listener)
+    expect(listener).toHaveBeenCalledWith(7)
+  })
+
+  it('broadcasts on notify to every subscriber for the same key', () => {
+    const reg = new SubscriptionRegistry<string, number>()
+    const a = vi.fn()
+    const b = vi.fn()
+    reg.subscribe('x', a)
+    reg.subscribe('x', b)
+    a.mockClear()
+    b.mockClear()
+    reg.notify('x', 42)
+    expect(a).toHaveBeenCalledWith(42)
+    expect(b).toHaveBeenCalledWith(42)
+  })
+
+  it('isolates broadcasts by key', () => {
+    const reg = new SubscriptionRegistry<string, number>()
+    const a = vi.fn()
+    const b = vi.fn()
+    reg.subscribe('one', a)
+    reg.subscribe('two', b)
+    a.mockClear()
+    b.mockClear()
+    reg.notify('one', 1)
+    expect(a).toHaveBeenCalledWith(1)
+    expect(b).not.toHaveBeenCalled()
+  })
+
+  it('supports null as the cleared-value marker', () => {
+    const reg = new SubscriptionRegistry<string, number>()
+    reg.notify('k', 5)
+    const listener = vi.fn()
+    reg.subscribe('k', listener)
+    listener.mockClear()
+    reg.notify('k', null)
+    expect(listener).toHaveBeenCalledWith(null)
+  })
+
+  it('disconnects via the returned function', () => {
+    const reg = new SubscriptionRegistry<string, number>()
+    const listener = vi.fn()
+    const dispose = reg.subscribe('k', listener)
+    listener.mockClear()
+    dispose()
+    reg.notify('k', 1)
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('cleans empty buckets so size reflects real subscribers', () => {
+    const reg = new SubscriptionRegistry<string, number>()
+    const a = vi.fn()
+    const dispose = reg.subscribe('k', a)
+    expect(reg.size).toBe(1)
+    dispose()
+    expect(reg.size).toBe(0)
+  })
+
+  it('tolerates a listener that disposes itself during its callback', () => {
+    const reg = new SubscriptionRegistry<string, number>()
+    let dispose: (() => void) | null = null
+    const a = vi.fn(() => dispose?.())
+    const b = vi.fn()
+    dispose = reg.subscribe('k', a)
+    reg.subscribe('k', b)
+    a.mockClear()
+    b.mockClear()
+    reg.notify('k', 1)
+    expect(a).toHaveBeenCalledWith(1)
+    expect(b).toHaveBeenCalledWith(1)
+  })
+
+  it('peek returns the cached value without subscribing', () => {
+    const reg = new SubscriptionRegistry<string, number>()
+    expect(reg.peek('k')).toBeNull()
+    reg.notify('k', 9)
+    expect(reg.peek('k')).toBe(9)
+    expect(reg.size).toBe(0)
+  })
+
+  it('clear drops listeners + cache; registry remains usable', () => {
+    const reg = new SubscriptionRegistry<string, number>()
+    const a = vi.fn()
+    reg.subscribe('k', a)
+    reg.notify('k', 1)
+    a.mockClear()
+    reg.clear()
+    expect(reg.size).toBe(0)
+    expect(reg.peek('k')).toBeNull()
+
+    // The original listener is gone — re-notifying isn't broadcast to it.
+    reg.notify('k', 2)
+    expect(a).not.toHaveBeenCalled()
+
+    // A fresh subscriber after clear+notify sees the most recent value (2),
+    // proving the registry rebuilt its cache via the post-clear notify.
+    const b = vi.fn()
+    reg.subscribe('k', b)
+    expect(b).toHaveBeenCalledWith(2)
+  })
+})

--- a/packages/engine/src/utils/subscription-registry.ts
+++ b/packages/engine/src/utils/subscription-registry.ts
@@ -1,0 +1,78 @@
+/**
+ * Tiny pub/sub registry keyed by an arbitrary "type" token.
+ *
+ * Pure data — no engine dependencies, fully testable under
+ * vitest's `node` environment without pulling in Excalibur's
+ * browser polyfills. {@link SessionState} composes one of these
+ * per scene to dispatch component-add / -remove / -mutate
+ * notifications to subscribers.
+ *
+ * Listeners receive the current value as the registry sees it
+ * (set by the host calling `notify`). Subscribers never observe
+ * the previous value as a separate parameter — the latest value
+ * is the contract.
+ */
+export class SubscriptionRegistry<KeyT, ValueT> {
+  private readonly listeners = new Map<KeyT, Set<(value: ValueT | null) => void>>()
+  private readonly latest = new Map<KeyT, ValueT | null>()
+
+  /**
+   * Subscribe to changes for a given key. Fires the listener once
+   * synchronously with the current value (which is `null` if the
+   * key has never been notified). Returns a `disconnect` function;
+   * call it to stop receiving updates.
+   */
+  subscribe(key: KeyT, listener: (value: ValueT | null) => void): () => void {
+    let bucket = this.listeners.get(key)
+    if (!bucket) {
+      bucket = new Set()
+      this.listeners.set(key, bucket)
+    }
+    bucket.add(listener)
+
+    // Sync prime — listener sees the current value (or `null`) on
+    // subscribe. Mirrors RxJS BehaviorSubject semantics.
+    listener(this.latest.has(key) ? (this.latest.get(key) ?? null) : null)
+
+    return () => {
+      const set = this.listeners.get(key)
+      if (!set) return
+      set.delete(listener)
+      if (set.size === 0) this.listeners.delete(key)
+    }
+  }
+
+  /**
+   * Broadcast a new value (or `null` for "removed / absent") to
+   * every listener subscribed to `key`. Stores the value so
+   * future subscribers get it on prime.
+   */
+  notify(key: KeyT, value: ValueT | null): void {
+    this.latest.set(key, value)
+    const bucket = this.listeners.get(key)
+    if (!bucket) return
+    // Snapshot the bucket so a listener can unsubscribe inside its
+    // own callback without breaking iteration.
+    for (const listener of [...bucket]) {
+      listener(value)
+    }
+  }
+
+  /** Current cached value for `key`, or `null` if never set / cleared. */
+  peek(key: KeyT): ValueT | null {
+    return this.latest.get(key) ?? null
+  }
+
+  /** Number of active subscribers across all keys — useful for leak tests. */
+  get size(): number {
+    let total = 0
+    for (const bucket of this.listeners.values()) total += bucket.size
+    return total
+  }
+
+  /** Drop every subscriber + cached value. The registry is reusable after. */
+  clear(): void {
+    this.listeners.clear()
+    this.latest.clear()
+  }
+}


### PR DESCRIPTION
First implementation PR after the merge of the object-system stack (#19-#26). Lays the foundation for editor-architecture Phase 2+ and runtime-modes.

## What lands

**Three pure-data components** (`packages/engine/src/components/`):
- `EditorModeComponent` — marker
- `RuntimeModeComponent` — marker
- `GhostSpawnComponent` — `{ tileX, tileY, facing? }`

**`SubscriptionRegistry`** (`packages/engine/src/utils/subscription-registry.ts`) — pure pub/sub keyed by arbitrary token, BehaviorSubject-style prime semantics. Engine-free, fully unit-tested (11 cases).

**`SessionState`** (`packages/engine/src/utils/session-state.ts`) — per-scene singleton entity manager. API:
- `ensure / get / set / unset / subscribe / notifyMutation`
- Per-scene registries in `WeakMap<Scene, …>` for auto-cleanup

**`MapScene` integration** — every new scene gets the singleton + `EditorModeComponent` as default.

## What's NOT in this PR

- No tool/system migration yet (that's Phase 2)
- No actual mode-switching UI (that's runtime-modes Phase 2)
- No code that reads the markers — the systems still gate on `getEditorState` callback as before

This is **substrate only**. Concept doc references it as Phase 1 of the editor-architecture migration; status will flip `planned → landed` on merge.

## Test plan

- [x] `npx vitest run` in `packages/engine` — 59/59 pass (48 existing + 11 new `SubscriptionRegistry` cases)
- [x] `gjsify foreach check -v -t` — clean
- [x] `gjsify foreach build -v -t` — clean

See `docs/concepts/editor-architecture.md` § "Migration strategy" → Phase 1 for full rationale.