### PR TITLE
fix(engine): every-other-click drop + broken undo — same-instance SessionState.set

### DIFF
--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -235,11 +235,15 @@ export class Engine {
     if (!(scene instanceof MapScene)) return
     command.apply(scene)
 
-    const stack = SessionState.get(scene, UndoStackComponent) ?? new UndoStackComponent()
-    stack.commands = stack.commands.slice(0, stack.cursor)
-    stack.commands.push(command)
-    stack.cursor = stack.commands.length
-    SessionState.set(scene, stack)
+    const existing = SessionState.get(scene, UndoStackComponent)
+    if (existing) {
+      existing.commands = existing.commands.slice(0, existing.cursor)
+      existing.commands.push(command)
+      existing.cursor = existing.commands.length
+      SessionState.notifyMutation(scene, existing)
+    } else {
+      SessionState.set(scene, new UndoStackComponent([command], 1))
+    }
   }
 
   /**

--- a/packages/engine/src/systems/tile-editor.system.ts
+++ b/packages/engine/src/systems/tile-editor.system.ts
@@ -187,15 +187,26 @@ export class TileEditorSystem extends System {
    * but inline because the system already has the `scene` reference
    * and we want to avoid the indirection through the engine class
    * for hot paths (one paint per click).
+   *
+   * Distinguishes between "first command in the scene" (create + set)
+   * and "stack already exists" (mutate + notify). Calling
+   * `SessionState.set` with the existing instance after mutation
+   * works thanks to its same-instance fast path, but the explicit
+   * branch is documentation about the intent and one fewer remove +
+   * add to handle in the engine.
    */
   private dispatchCommand(command: PaintTileCommand | EraseTileCommand): void {
     if (!this.scene) return
     command.apply(this.scene)
-    const stack = SessionState.get(this.scene, UndoStackComponent) ?? new UndoStackComponent()
-    stack.commands = stack.commands.slice(0, stack.cursor)
-    stack.commands.push(command)
-    stack.cursor = stack.commands.length
-    SessionState.set(this.scene, stack)
+    const existing = SessionState.get(this.scene, UndoStackComponent)
+    if (existing) {
+      existing.commands = existing.commands.slice(0, existing.cursor)
+      existing.commands.push(command)
+      existing.cursor = existing.commands.length
+      SessionState.notifyMutation(this.scene, existing)
+    } else {
+      SessionState.set(this.scene, new UndoStackComponent([command], 1))
+    }
   }
 
   private resolveLayerId(layerId: string | null): string | null {

--- a/packages/engine/src/utils/session-state.ts
+++ b/packages/engine/src/utils/session-state.ts
@@ -73,11 +73,29 @@ export class SessionState {
    * mode marker / state component to the singleton — for editing a
    * field on an existing component in place, call
    * {@link notifyMutation} after the mutation.
+   *
+   * **Same-instance fast path**: when the caller passes the exact
+   * same instance that's already attached (common when systems do
+   * `get → mutate → set` to push the change through), skip the
+   * `removeComponent` + `addComponent` round-trip. Excalibur's
+   * component removal is partially deferred and re-adding the same
+   * instance in the same tick can leave the component half-removed
+   * by the next frame — observably "every second click silently
+   * drops the new state". Treating same-instance as "just notify"
+   * is both faster and dodges that lifecycle hazard. Callers doing
+   * in-place updates should still prefer {@link notifyMutation};
+   * this fast path is a belt for the suspenders.
    */
   static set<C extends Component>(scene: Scene, component: C): void {
     const entity = SessionState.ensure(scene)
     const ctor = component.constructor as ComponentCtor<C>
     const existing = entity.get(ctor)
+
+    if (existing === component) {
+      getRegistry(scene).notify(ctor as ComponentCtor<Component>, component)
+      return
+    }
+
     if (existing) entity.removeComponent(ctor)
     entity.addComponent(component)
     getRegistry(scene).notify(ctor as ComponentCtor<Component>, component)


### PR DESCRIPTION
Hotfix for two reported bugs after Phase-5 Undo: 'only every second tile placement works' and 'Ctrl+Z / overflow undo does nothing'. Both caused by `get → mutate → set` pattern triggering Excalibur's deferred-remove hazard. Same-instance fast path in `SessionState.set` + dispatchCommand / executeCommand switched to `notifyMutation` for in-place updates.