### PR TITLE
fix(maker): undo/redo buttons + Ctrl+Z stay disabled at stack boundaries

### DIFF
--- a/apps/maker-gjs/src/services/engine-controller.ts
+++ b/apps/maker-gjs/src/services/engine-controller.ts
@@ -34,6 +34,8 @@ export class EngineController {
   private _zoomHookAttached = false
   private _lastReportedZoom = 1
   private _zoomListener: ((zoom: number) => void) | null = null
+  private _undoHookAttached = false
+  private _undoListener: ((state: { canUndo: boolean; canRedo: boolean }) => void) | null = null
 
   constructor(private readonly slot: EngineSlot) {}
 
@@ -50,6 +52,20 @@ export class EngineController {
    */
   onZoomChanged(listener: (zoom: number) => void): void {
     this._zoomListener = listener
+  }
+
+  /**
+   * Register a listener that fires whenever the active scene's
+   * undo-stack mutates (paint / erase / undo / redo). Mirrors
+   * {@link onZoomChanged} — the listener is invoked once
+   * synchronously with the current `{ canUndo, canRedo }` snapshot
+   * once an engine + map are loaded, then again on every stack
+   * change. The maker uses this to keep `win.undo` / `win.redo`
+   * `GAction.enabled` in sync so the OSD buttons + Ctrl+Z grey out
+   * at stack boundaries.
+   */
+  onUndoChanged(listener: (state: { canUndo: boolean; canRedo: boolean }) => void): void {
+    this._undoListener = listener
   }
 
   /**
@@ -86,6 +102,7 @@ export class EngineController {
     this._engine.setActiveTool('brush')
 
     this._attachZoomHook()
+    this._attachUndoHook()
   }
 
   /**
@@ -106,6 +123,11 @@ export class EngineController {
     this._projectPath = null
     this._mapId = null
     this._zoomHookAttached = false
+    this._undoHookAttached = false
+    // Drop the cached undo state on the host side too — without an
+    // engine, both actions should be disabled regardless of what the
+    // last loaded scene reported.
+    this._undoListener?.({ canUndo: false, canRedo: false })
   }
 
   /** Read the current camera zoom (1 = 100%) or `null` if no engine. */
@@ -137,6 +159,13 @@ export class EngineController {
       if (Math.abs(zoom - this._lastReportedZoom) < 0.01) return
       this._lastReportedZoom = zoom
       this._zoomListener?.(zoom)
+    })
+  }
+
+  private _attachUndoHook(): void {
+    if (this._undoHookAttached || !this._engine) return
+    this._undoHookAttached = this._engine.onUndoStackChanged((state) => {
+      this._undoListener?.(state)
     })
   }
 }

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -170,6 +170,18 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     })
     winActions.add_action(redoAction)
 
+    // Default both to disabled — they switch on once a map is loaded
+    // and the engine reports `canUndo` / `canRedo` (see the
+    // `_engineCtl.onUndoChanged` registration below). Without this
+    // they would be enabled on the welcome view, where pressing
+    // Ctrl+Z is a no-op but the UI affordance suggests otherwise.
+    undoAction.set_enabled(false)
+    redoAction.set_enabled(false)
+    this._engineCtl.onUndoChanged(({ canUndo, canRedo }) => {
+      undoAction.set_enabled(canUndo)
+      redoAction.set_enabled(canRedo)
+    })
+
     // Keyboard accelerators: Ctrl+Z = undo, Ctrl+Shift+Z = redo.
     const app = this.get_application() as Adw.Application | null
     app?.set_accels_for_action('win.undo', ['<Primary>z'])

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -293,6 +293,42 @@ export class Engine {
     return SessionState.get(scene, UndoStackComponent)?.canRedo ?? false
   }
 
+  /**
+   * Subscribe to undo-stack changes on the **currently-active** scene.
+   * Fires once synchronously with the present `canUndo` / `canRedo`
+   * snapshot (or `false, false` when no `MapScene` is active yet), and
+   * again on every stack mutation. Also rebinds across map switches —
+   * subscribers do not need to re-register after a `loadMap` call.
+   *
+   * Returns a disposer that drops both the inner `SessionState`
+   * subscription and the `MAP_LOADED` listener.
+   *
+   * Use case: keeping `win.undo` / `win.redo` `GAction.enabled` in
+   * sync with the stack so the OSD buttons + accelerator keys grey
+   * out at the boundaries.
+   */
+  onUndoStackChanged(cb: (state: { canUndo: boolean; canRedo: boolean }) => void): () => void {
+    let inner: (() => void) | null = null
+    const rebind = () => {
+      inner?.()
+      inner = null
+      const scene = this.excalibur.currentScene
+      if (!(scene instanceof MapScene)) {
+        cb({ canUndo: false, canRedo: false })
+        return
+      }
+      inner = SessionState.subscribe(scene, UndoStackComponent, (stack) => {
+        cb({ canUndo: stack?.canUndo ?? false, canRedo: stack?.canRedo ?? false })
+      })
+    }
+    rebind()
+    const mapSub = this.events.on(EngineEvent.MAP_LOADED, () => rebind())
+    return () => {
+      inner?.()
+      mapSub.close()
+    }
+  }
+
   private setStatus(status: EngineStatus): void {
     if (this.status === status) return
     this.logger.info(`Engine status changed from ${this.status} to ${status}`)

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -162,6 +162,23 @@ export class Engine extends Adw.Bin {
     return this._excalibur?.canRedo() ?? false
   }
 
+  /**
+   * Subscribe to undo-stack changes on the underlying engine. The
+   * disposer is added to {@link _excaliburSubscriptions} so it is
+   * automatically released on `vfunc_unmap` alongside the other
+   * engine-scoped subscriptions; callers do not need to track it.
+   *
+   * Returns `true` when the subscription was attached, `false` when
+   * the engine is not running yet (caller should retry once the
+   * engine is ready).
+   */
+  public onUndoStackChanged(cb: (state: { canUndo: boolean; canRedo: boolean }) => void): boolean {
+    if (!this._excalibur) return false
+    const dispose = this._excalibur.onUndoStackChanged(cb)
+    this._excaliburSubscriptions.push({ close: dispose })
+    return true
+  }
+
   public get excalibur(): ExcaliburEngine | null {
     return this._excalibur
   }


### PR DESCRIPTION
OSD undo / redo and the Ctrl+Z accelerator were always active, even on welcome / atlas / empty stack. Now they react to `UndoStackComponent` mutations via a new `Engine.onUndoStackChanged` API forwarded through the gjs widget into the `EngineController`, which keeps the two `GAction.enabled` flags in sync. Both default to disabled and only switch on when the engine reports a non-empty stack.