### PR TITLE
feat(editor): eyedropper tool + functional layer visibility + lock

### DIFF
--- a/apps/maker-gjs/src/services/engine-controller.ts
+++ b/apps/maker-gjs/src/services/engine-controller.ts
@@ -1,4 +1,7 @@
+import { EngineEvent, type EngineEventMap } from '@pixelrpg/engine'
 import { Engine } from '@pixelrpg/gjs'
+
+type TilePickedPayload = EngineEventMap[EngineEvent.TILE_PICKED]
 
 /**
  * Slot the engine widget gets attached to once it's been (re)created.
@@ -36,6 +39,8 @@ export class EngineController {
   private _zoomListener: ((zoom: number) => void) | null = null
   private _undoHookAttached = false
   private _undoListener: ((state: { canUndo: boolean; canRedo: boolean }) => void) | null = null
+  private _tilePickedHookAttached = false
+  private _tilePickedListener: ((payload: TilePickedPayload) => void) | null = null
 
   constructor(private readonly slot: EngineSlot) {}
 
@@ -66,6 +71,23 @@ export class EngineController {
    */
   onUndoChanged(listener: (state: { canUndo: boolean; canRedo: boolean }) => void): void {
     this._undoListener = listener
+  }
+
+  /**
+   * Register a listener for the engine's `TILE_PICKED` event (emitted
+   * by `TileEditorSystem` when the user clicks while the eyedropper
+   * tool is active). Mirrors {@link onZoomChanged} — listener is
+   * stored once on the controller and re-attached lazily after each
+   * `ensureForMap` via {@link _attachTilePickedHook}.
+   *
+   * The host typically responds by routing the picked tile through
+   * its existing tile-palette state (so palette highlight + context
+   * chip + engine `ActiveTileComponent` all stay in sync) and by
+   * switching the tool action back to `pencil` for a Tiled-style
+   * "pick then immediately paint" workflow.
+   */
+  onTilePicked(listener: (payload: TilePickedPayload) => void): void {
+    this._tilePickedListener = listener
   }
 
   /**
@@ -103,6 +125,7 @@ export class EngineController {
 
     this._attachZoomHook()
     this._attachUndoHook()
+    this._attachTilePickedHook()
   }
 
   /**
@@ -124,6 +147,7 @@ export class EngineController {
     this._mapId = null
     this._zoomHookAttached = false
     this._undoHookAttached = false
+    this._tilePickedHookAttached = false
     // Drop the cached undo state on the host side too — without an
     // engine, both actions should be disabled regardless of what the
     // last loaded scene reported.
@@ -167,5 +191,16 @@ export class EngineController {
     this._undoHookAttached = this._engine.onUndoStackChanged((state) => {
       this._undoListener?.(state)
     })
+  }
+
+  private _attachTilePickedHook(): void {
+    if (this._tilePickedHookAttached || !this._engine) return
+    // The gjs Engine widget owns the EventEmitter; on dispose the
+    // widget is dropped and its emitter is GC'd along with this
+    // closure, so we don't track an explicit Subscription handle.
+    this._engine.events.on(EngineEvent.TILE_PICKED, (payload) => {
+      this._tilePickedListener?.(payload)
+    })
+    this._tilePickedHookAttached = true
   }
 }

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -44,6 +44,12 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
   private signals = new SignalScope()
   private _scenesById = new Map<string, SampleScene>(SAMPLE_SCENES.map((s) => [s.id, s]))
   private _loadedProject: LoadedProject | null = null
+  /**
+   * Which map the scene editor is currently editing. Tracks
+   * `_showSceneEditor` so the persist-requested handler knows which
+   * MapResource to serialise.
+   */
+  private _currentSceneId: string | null = null
   private _engineCtl = new EngineController((engine) => {
     if (engine) this._scene_editor_view.setEngineWidget(engine, engine)
     else this._scene_editor_view.setEngineWidget(null)
@@ -97,6 +103,30 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
         this._persistAtlasPosition(id, x, y)
       },
     )
+
+    // Scene editor → host bridge. The inspector mutates
+    // `MapResource.mapData` in place via `engine.setLayerVisible` /
+    // `setLayerLocked`, then asks the host to persist. Mirrors the
+    // existing `scene-moved` → `_persistAtlasPosition` flow.
+    this.signals.connect(this._scene_editor_view, 'persist-requested', () => {
+      this._persistCurrentMap()
+    })
+  }
+
+  /**
+   * Serialise the currently-edited map's `MapData` back to disk.
+   * Called by the scene editor's `persist-requested` signal after
+   * an in-place mutation (layer visibility, layer lock — and any
+   * future inspector-driven map mutation). Toasts on failure but
+   * keeps the in-memory state so the user can retry.
+   */
+  private _persistCurrentMap(): void {
+    const sceneId = this._currentSceneId
+    if (!sceneId) return
+    const mapResource = this._loadedProject?.resource.maps.get(sceneId)
+    if (!mapResource?.mapData) return
+    const ok = writeTextFile(mapResource.sourcePath, MapFormat.serialize(mapResource.mapData))
+    if (!ok) this._showToast(_('Could not save layer changes'))
   }
 
   /**
@@ -180,6 +210,18 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     this._engineCtl.onUndoChanged(({ canUndo, canRedo }) => {
       undoAction.set_enabled(canUndo)
       redoAction.set_enabled(canRedo)
+    })
+
+    // Eyedropper: the engine's `TileEditorSystem` emits `TILE_PICKED`
+    // when the user clicks a tile while the eyedropper tool is
+    // active. We route the picked tile back through the
+    // scene-editor's existing local-id flow (so palette highlight +
+    // context chip + engine's `ActiveTileComponent` stay in lock-step)
+    // and then flip the tool action back to `pencil` for a Tiled-style
+    // "pick → paint immediately" workflow.
+    this._engineCtl.onTilePicked(({ globalTileId }) => {
+      this._scene_editor_view.selectTileByGlobalId(globalTileId)
+      toolAction.change_state(GLib.Variant.new_string('pencil'))
     })
 
     // Keyboard accelerators: Ctrl+Z = undo, Ctrl+Shift+Z = redo.
@@ -279,6 +321,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this._showToast(_('Scene not found'))
       return
     }
+    this._currentSceneId = sceneId
     this._scene_editor_view.setScene(scene)
     this._setView('scene-editor')
 

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -112,6 +112,12 @@ export class SceneEditorView extends Adw.Bin {
         },
         Signals: {
           'mode-changed': { param_types: [GObject.TYPE_STRING] },
+          // Fired when the active map's `MapData` was mutated in
+          // place (e.g. user toggled a layer's visibility or lock
+          // flag) and should be serialised back to disk. The host
+          // listens because it tracks the project + scene paths
+          // needed by `MapFormat.serialize` + `writeTextFile`.
+          'persist-requested': { param_types: [] },
         },
       },
       SceneEditorView,
@@ -191,7 +197,7 @@ export class SceneEditorView extends Adw.Bin {
       name: layer.name,
       tileCount: (layer.sprites?.length ?? 0) + (placementsByLayer.get(layer.id) ?? 0),
       visible: layer.visible ?? true,
-      locked: false,
+      locked: layer.locked ?? false,
     }))
     this._layers = layers
     this._inspector.layersTab.setLayers(layers)
@@ -277,6 +283,31 @@ export class SceneEditorView extends Adw.Bin {
     this._inspector.tilesTab.selectTile(tileId)
   }
 
+  /**
+   * Push a tile id given in **global** form (the engine's
+   * `ActiveTileComponent.spriteId` shape — `firstGid` already added)
+   * into the editor's active-tile state, syncing palette + context
+   * chip in the process.
+   *
+   * Used by the eyedropper: the engine emits `TILE_PICKED` carrying
+   * the global id, and the host funnels it back through the
+   * existing local-id flow (`_setActiveTile`) so there is exactly
+   * one place that drives the palette highlight + chip preview +
+   * engine write.
+   *
+   * Returns `true` when the global id mapped to a tile in the
+   * currently-loaded sheet; `false` otherwise (cross-sheet picking
+   * would need a sheet-switch step first — out of scope for the
+   * first iteration).
+   */
+  selectTileByGlobalId(globalTileId: number): boolean {
+    const localId = globalTileId - this._tilesetFirstGid
+    const tile = this._tiles.find((t) => t.id === localId)
+    if (!tile) return false
+    this._setActiveTile(localId, tile.name)
+    return true
+  }
+
   private _setActiveLayer(layerId: string): void {
     if (this._activeLayerId === layerId) return
     this._activeLayerId = layerId
@@ -285,6 +316,24 @@ export class SceneEditorView extends Adw.Bin {
     this._engine?.setActiveLayer(layerId)
     // Mirror selection back to the inspector layers tab.
     this._inspector.layersTab.selectLayer(layerId)
+    // Sync the toolbar's editing-tool sensitivity to the new active
+    // layer's lock state. Called on every active-layer change so
+    // switching to a locked layer immediately greys out the mutating
+    // tools, and switching away restores them.
+    this._editor.toolRail.setEditingToolsEnabled(!(layer?.locked ?? false))
+  }
+
+  /**
+   * Mark the active map's `MapData` as dirty + ask the host to
+   * persist. The engine widget owns the live `MapResource` whose
+   * `mapData` was just mutated in place (by `setLayerVisible` /
+   * `setLayerLocked`); the host has the project + scene paths
+   * needed for `MapFormat.serialize` + `writeTextFile` and already
+   * runs the same flow for atlas positions, so emitting a signal
+   * keeps file I/O out of this widget.
+   */
+  private _persistMapData(): void {
+    this.emit('persist-requested')
   }
 
   /**
@@ -398,6 +447,32 @@ export class SceneEditorView extends Adw.Bin {
     const layers: LayersTab = this._inspector.layersTab
     layers.connect('layer-selected', (_l: LayersTab, id: string) => {
       this._setActiveLayer(id)
+    })
+    // Layer flag toggles. Both signals carry (layerId, newValue). We
+    // forward to the engine (which mutates MapData + triggers any
+    // necessary graphics refresh), persist via the same flow as
+    // `_persistAtlasPosition`, and emit our own re-exported signal so
+    // `ApplicationWindow` can react (specifically: locking the active
+    // layer needs to disable the editing tool actions).
+    layers.connect('layer-visibility-toggled', (_l: LayersTab, layerId: string, visible: boolean) => {
+      this._engine?.setLayerVisible(layerId, visible)
+      // Mirror the new flag into the local cache so subsequent
+      // `_setActiveLayer` reads see the up-to-date value (the
+      // inspector's own state already updated via property binding).
+      const idx = this._layers.findIndex((l) => l.id === layerId)
+      if (idx >= 0) this._layers[idx] = { ...this._layers[idx], visible }
+      this._persistMapData()
+    })
+    layers.connect('layer-lock-toggled', (_l: LayersTab, layerId: string, locked: boolean) => {
+      this._engine?.setLayerLocked(layerId, locked)
+      const idx = this._layers.findIndex((l) => l.id === layerId)
+      if (idx >= 0) this._layers[idx] = { ...this._layers[idx], locked }
+      this._persistMapData()
+      // The toolbar's editing tool buttons mirror the active layer's
+      // lock state — re-check when the toggle hits the active layer.
+      if (layerId === this._activeLayerId) {
+        this._editor.toolRail.setEditingToolsEnabled(!locked)
+      }
     })
 
     // Object placements: forward inspector selection into the engine's

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1,4 +1,4 @@
-import { Color, DisplayMode, EventEmitter, Engine as ExcaliburEngine, Loader, Logger } from 'excalibur'
+import { Color, DisplayMode, EventEmitter, Engine as ExcaliburEngine, Loader, Logger, TileMap } from 'excalibur'
 import type { Command } from './commands/index.ts'
 import {
   ActiveLayerComponent,
@@ -10,6 +10,7 @@ import {
 } from './components/index.ts'
 import { GameProjectResource } from './resource/GameProjectResource.ts'
 import { MapScene } from './scenes/map.scene.ts'
+import { refreshAllTileGraphics } from './services/tile-graphics.manager.ts'
 import { EngineEvent, type EngineEventMap, EngineStatus, type ProjectLoadOptions } from './types/index.ts'
 import { SessionState } from './utils/session-state.ts'
 
@@ -291,6 +292,74 @@ export class Engine {
     const scene = this.excalibur.currentScene
     if (!(scene instanceof MapScene)) return false
     return SessionState.get(scene, UndoStackComponent)?.canRedo ?? false
+  }
+
+  /**
+   * Toggle a layer's `visible` flag on the active map. Persists the
+   * change in-memory only (the host is responsible for serialising
+   * `MapResource.mapData` back to disk via `MapFormat.serialize`),
+   * then re-builds the tile graphics on every tile in the map so the
+   * change is visible on the canvas immediately.
+   *
+   * Returns `true` on success, `false` if there is no active
+   * `MapScene` / no layer matches the id.
+   *
+   * The graphics rebuild is O(columns × rows × sprites-per-tile) so
+   * keep this off any hot path — it's only called on explicit user
+   * toggles.
+   */
+  setLayerVisible(layerId: string, visible: boolean): boolean {
+    const scene = this.excalibur.currentScene
+    if (!(scene instanceof MapScene)) return false
+    const mapResource = scene.mapResource
+    if (!mapResource?.mapData) return false
+    const layer = mapResource.mapData.layers.find((l) => l.id === layerId)
+    if (!layer) return false
+    if (layer.visible === visible) return true
+    layer.visible = visible
+    for (const entity of scene.world.entityManager.entities) {
+      if (entity instanceof TileMap) {
+        refreshAllTileGraphics(entity, mapResource)
+      }
+    }
+    return true
+  }
+
+  /**
+   * Toggle a layer's `locked` flag on the active map. Pure editor
+   * state — no graphics rebuild needed because rendering doesn't
+   * care about lock. Consumers (host + `TileEditorSystem`) check the
+   * flag at the start of their edit paths and short-circuit when
+   * the active layer is locked.
+   *
+   * Returns `true` on success, `false` if there is no active
+   * `MapScene` / no layer matches the id.
+   */
+  setLayerLocked(layerId: string, locked: boolean): boolean {
+    const scene = this.excalibur.currentScene
+    if (!(scene instanceof MapScene)) return false
+    const mapResource = scene.mapResource
+    if (!mapResource?.mapData) return false
+    const layer = mapResource.mapData.layers.find((l) => l.id === layerId)
+    if (!layer) return false
+    if ((layer.locked ?? false) === locked) return true
+    layer.locked = locked
+    return true
+  }
+
+  /**
+   * Read the `locked` flag on a specific layer. Used by the host to
+   * decide whether to enable the editing tool actions in response to
+   * an `ActiveLayerComponent` change. Returns `false` on missing
+   * layer / scene — "treat as editable" is the safer default for an
+   * unknown id (the paint path will then no-op via
+   * `TileEditorSystem`'s own checks).
+   */
+  isLayerLocked(layerId: string): boolean {
+    const scene = this.excalibur.currentScene
+    if (!(scene instanceof MapScene)) return false
+    const layer = scene.mapResource?.mapData?.layers.find((l) => l.id === layerId)
+    return layer?.locked ?? false
   }
 
   /**

--- a/packages/engine/src/resource/MapResource.ts
+++ b/packages/engine/src/resource/MapResource.ts
@@ -110,9 +110,14 @@ export class MapResource implements Loadable<TileMap> {
     // placements (NPCs, items, teleports, …) live on
     // `MapData.objectPlacements` and are spawned by the engine's
     // `ObjectSpawnSystem`, not at resource-load time.
-    sortedLayers
-      .filter((layer) => layer.visible)
-      .forEach((layer) => this.processTileLayer(tileMap, layer))
+    //
+    // We process ALL layers (even invisible ones) so the editor's
+    // shadow-state (`MapEditorComponent`) holds a complete picture of
+    // every layer's content. The visibility filter has moved to the
+    // *render* path (`applyInitialGraphics` + `rebuildAllTileGraphics`)
+    // so toggling `layer.visible` at runtime is a pure graphics
+    // refresh — no re-loading of sprites from the JSON.
+    sortedLayers.forEach((layer) => this.processTileLayer(tileMap, layer))
   }
 
   private processTileLayer(tileMap: TileMap, layer: LayerData): void {
@@ -192,6 +197,13 @@ export class MapResource implements Loadable<TileMap> {
   }
 
   private applyInitialGraphics(): void {
+    // Cache layer visibility so we don't .find() per sprite — for a
+    // large map this is the hot loop on first render.
+    const hiddenLayerIds = new Set<string>()
+    for (const layer of this._mapData?.layers ?? []) {
+      if (layer.visible === false) hiddenLayerIds.add(layer.id)
+    }
+
     this.initialSprites.forEach((refs, tile) => {
       const sortedRefs = [...refs].sort((a, b) => {
         const aZ = a.zIndex ?? 0
@@ -200,6 +212,7 @@ export class MapResource implements Loadable<TileMap> {
       })
 
       for (const ref of sortedRefs) {
+        if (hiddenLayerIds.has(ref.layerId)) continue
         const spriteSet = this.tileSetResources.get(ref.spriteSetId)
         if (!spriteSet) continue
 

--- a/packages/engine/src/services/sprite-info.resolver.ts
+++ b/packages/engine/src/services/sprite-info.resolver.ts
@@ -65,3 +65,31 @@ export function findSpriteInfoForTileId(
   console.warn(`[SpriteInfoResolver] Could not find sprite info for tileId ${tileId} in any sprite set`)
   return null
 }
+
+/**
+ * Inverse of {@link findSpriteInfoForTileId}: turn a `(spriteSetId,
+ * localSpriteId)` pair back into the global tile id used by
+ * `ActiveTileComponent` / paint commands.
+ *
+ * Used by the eyedropper path: when the user clicks a tile we have
+ * the sprite ref from `MapEditorComponent` (which stores local ids
+ * + sprite-set id), and need to push it back into
+ * `ActiveTileComponent` whose `spriteId` is the *global* form.
+ *
+ * Returns `null` when the map data doesn't reference the requested
+ * sprite set, or when the sprite set's `firstGid` is missing /
+ * non-numeric (malformed project file).
+ */
+export function findTileIdForSpriteInfo(
+  mapResource: MapResource,
+  spriteSetId: string,
+  localSpriteId: number,
+): number | null {
+  const mapData = mapResource.mapData
+  if (!mapData?.spriteSets) return null
+  const ref = mapData.spriteSets.find((r: SpriteSetReferenceLike) => r?.id === spriteSetId) as
+    | SpriteSetReferenceLike
+    | undefined
+  if (typeof ref?.firstGid !== 'number') return null
+  return ref.firstGid + localSpriteId
+}

--- a/packages/engine/src/services/tile-graphics.manager.ts
+++ b/packages/engine/src/services/tile-graphics.manager.ts
@@ -20,12 +20,34 @@ export function getSpriteFromResource(
   return spriteSetResource.sprites[spriteInfo.spriteId] ?? null
 }
 
+/**
+ * Build the set of layer ids whose `visible` flag is explicitly
+ * `false` on the supplied resource. `undefined` counts as visible
+ * (matches the old default + the `LayerDescriptor`'s `visible ?? true`
+ * fallback used by the inspector).
+ *
+ * Cached as a `Set` because the caller is typically inside a per-tile
+ * loop and a linear `.find()` per sprite would scale badly.
+ */
+function collectHiddenLayerIds(mapResource: MapResource): Set<string> {
+  const hidden = new Set<string>()
+  for (const layer of mapResource.mapData?.layers ?? []) {
+    if (layer.visible === false) hidden.add(layer.id)
+  }
+  return hidden
+}
+
 export function rebuildAllTileGraphics(tileMap: TileMap, mapResource: MapResource, tile: Tile): void {
   const editorComponent = tileMap.get(MapEditorComponent)
   if (!editorComponent) return
 
+  const hiddenLayerIds = collectHiddenLayerIds(mapResource)
   const allSprites = editorComponent.getSpritesForTileAndLayer(tile)
-  const sortedSprites = [...allSprites].sort((a, b) => (a?.zIndex || 0) - (b?.zIndex || 0))
+  // Filter out sprites whose layer is hidden — they stay in the
+  // shadow state (so toggling visibility back on is a pure graphics
+  // rebuild without re-loading from JSON) but we skip them at render.
+  const visibleSprites = allSprites.filter((s) => !hiddenLayerIds.has(s.layerId))
+  const sortedSprites = [...visibleSprites].sort((a, b) => (a?.zIndex || 0) - (b?.zIndex || 0))
 
   tile.clearGraphics()
 
@@ -46,6 +68,28 @@ export function rebuildAllTileGraphics(tileMap: TileMap, mapResource: MapResourc
       }
     }
   }
+}
+
+/**
+ * Rebuild graphics on every tile in the supplied `TileMap`. Used after
+ * a global state change that affects rendering for many tiles at once
+ * — currently: toggling `layer.visible` on a layer. Pairs the per-tile
+ * rebuild with a single z-index pass at the end so the maximum
+ * z-index of the tilemap reflects all (visible) sprites.
+ *
+ * Hot for huge maps — O(columns × rows) tiles, each iterating its
+ * sprite list — but called only on explicit user toggles, not per
+ * frame.
+ */
+export function refreshAllTileGraphics(tileMap: TileMap, mapResource: MapResource): void {
+  for (let x = 0; x < tileMap.columns; x++) {
+    for (let y = 0; y < tileMap.rows; y++) {
+      const tile = tileMap.getTile(x, y)
+      if (!tile) continue
+      rebuildAllTileGraphics(tileMap, mapResource, tile)
+    }
+  }
+  updateTileMapZIndex(tileMap, mapResource)
 }
 
 export function updateTileMapZIndex(tileMap: TileMap, mapResource: MapResource): void {

--- a/packages/engine/src/systems/tile-editor.system.ts
+++ b/packages/engine/src/systems/tile-editor.system.ts
@@ -20,6 +20,7 @@ import {
   UndoStackComponent,
 } from '../components/index.ts'
 import type { MapScene } from '../scenes/map.scene.ts'
+import { findTileIdForSpriteInfo } from '../services/sprite-info.resolver.ts'
 import { EngineEvent, type EngineEventMap } from '../types/index.ts'
 import { EDITOR_CONSTANTS } from '../utils/constants.ts'
 import { SessionState } from '../utils/session-state.ts'
@@ -132,6 +133,12 @@ export class TileEditorSystem extends System {
     const layerId = this.resolveLayerId(explicitLayerId)
     if (!layerId) return
 
+    // Lock guard. Apply only to mutating tools — the eyedropper is a
+    // read-only sample so it still works on locked layers (matches
+    // most tile-editor UX: you can pick from a locked layer to use
+    // its tile elsewhere, you just can't paint into it).
+    if (tool !== 'eyedropper' && this.isLayerLocked(layerId)) return
+
     // Capture the previous sprites on this (tile, layer) so the command
     // can revert. `MapEditorComponent` holds the shadow-state — pull
     // from there before mutating.
@@ -173,6 +180,23 @@ export class TileEditorSystem extends System {
         tileId: 0,
         layerId,
       })
+    } else if (tool === 'eyedropper') {
+      // Pick the **top** sprite from the active layer at this tile —
+      // sprites on a single (tile, layer) slot are stacked back-to-front,
+      // so the last entry is what the user actually sees.
+      const top = previousSprites[previousSprites.length - 1]
+      if (!top) return
+      const mapResource = (this.scene as MapScene).mapResource
+      if (!mapResource) return
+      const globalTileId = findTileIdForSpriteInfo(mapResource, top.spriteSetId, top.spriteId)
+      if (globalTileId === null) return
+      this.events.emit(EngineEvent.TILE_PICKED, {
+        coords: hit.coords,
+        layerId,
+        spriteSetId: top.spriteSetId,
+        localSpriteId: top.spriteId,
+        globalTileId,
+      })
     }
 
     this.events.emit(EngineEvent.TILE_CLICKED, {
@@ -213,5 +237,11 @@ export class TileEditorSystem extends System {
     if (layerId) return layerId
     const mapResource = (this.scene as MapScene | undefined)?.mapResource
     return mapResource?.getFirstLayerId?.() ?? EDITOR_CONSTANTS.DEFAULT_LAYER_NAME
+  }
+
+  private isLayerLocked(layerId: string): boolean {
+    const mapResource = (this.scene as MapScene | undefined)?.mapResource
+    const layer = mapResource?.mapData?.layers.find((l) => l.id === layerId)
+    return layer?.locked ?? false
   }
 }

--- a/packages/engine/src/types/data/LayerData.ts
+++ b/packages/engine/src/types/data/LayerData.ts
@@ -19,6 +19,18 @@ export interface LayerData {
   /** Whether the layer should be rendered */
   visible: boolean
 
+  /**
+   * Whether the layer is locked against editing. When true, tile
+   * paint / erase commands targeting this layer are rejected by
+   * `TileEditorSystem`, and the host's editing tools (pencil /
+   * eraser / bucket / rect) grey out when this is the active layer.
+   * Pure editor concern — runtime systems ignore the flag.
+   *
+   * Optional + defaults to false so existing project files without
+   * the field continue to work.
+   */
+  locked?: boolean
+
   /** Optional opacity value (0-1) */
   opacity?: number
 

--- a/packages/engine/src/types/engine-events.ts
+++ b/packages/engine/src/types/engine-events.ts
@@ -13,6 +13,7 @@ export enum EngineEvent {
   TILE_CLICKED = 'tile-clicked',
   TILE_HOVERED = 'tile-hovered',
   TILE_PLACED = 'tile-placed',
+  TILE_PICKED = 'tile-picked',
   PLAYER_SPAWNED = 'player-spawned',
   PLAYER_TILE_CHANGED = 'player-tile-changed',
   PLAYER_ACTION_PRESSED = 'player-action-pressed',
@@ -30,6 +31,27 @@ export interface EngineEventMap {
   [EngineEvent.TILE_CLICKED]: { coords: { x: number; y: number }; tileMapId: string }
   [EngineEvent.TILE_HOVERED]: { coords: { x: number; y: number } | null; tileMapId: string }
   [EngineEvent.TILE_PLACED]: { coords: { x: number; y: number }; tileId: number; layerId: string }
+  /**
+   * Emitted by `TileEditorSystem` when the user clicks a tile with
+   * the eyedropper tool active. Carries enough info for the host to
+   * (a) push the picked sprite into `ActiveTileComponent` via its
+   * existing local→global flow and (b) optionally auto-switch back
+   * to a paint tool. Engine deliberately does NOT mutate
+   * `ActiveTileComponent` / `ActiveToolComponent` itself — the host
+   * owns the tile-palette UI sync (highlight + context chip
+   * preview) so it has to drive the write.
+   *
+   * `globalTileId` is provided for hosts that don't track the sheet's
+   * `firstGid` themselves; `spriteSetId` + `localSpriteId` for hosts
+   * that need to detect a sheet switch.
+   */
+  [EngineEvent.TILE_PICKED]: {
+    coords: { x: number; y: number }
+    layerId: string
+    spriteSetId: string
+    localSpriteId: number
+    globalTileId: number
+  }
   /**
    * Emitted by `PlayerSpawnSystem` once per scene activate after
    * resolving the player's spawn-point. `tileX/Y` default to (0, 0)

--- a/packages/gjs/src/widgets/editor/floating-tool-rail.ts
+++ b/packages/gjs/src/widgets/editor/floating-tool-rail.ts
@@ -74,6 +74,27 @@ export class FloatingToolRail extends Adw.Bin {
     }
     map[tool].set_active(true)
   }
+
+  /**
+   * Enable / disable the **mutating** editing tools (pencil, bucket,
+   * rect, eraser). Non-mutating tools — eyedropper, select, stamp,
+   * event — stay enabled because they're either read-only or
+   * concern higher-level placements rather than tile sprites, and
+   * thus aren't blocked by a locked layer.
+   *
+   * Uses `sensitive` rather than disabling the `win.set-tool` action,
+   * because the action is shared by all buttons and we only want a
+   * subset greyed out. The buttons keep their radio-group membership
+   * — so disabling the active button while it's selected leaves it
+   * visually pressed (Gtk behavior) until the host switches to
+   * another tool.
+   */
+  setEditingToolsEnabled(enabled: boolean): void {
+    this._btn_pencil.set_sensitive(enabled)
+    this._btn_bucket.set_sensitive(enabled)
+    this._btn_rect.set_sensitive(enabled)
+    this._btn_eraser.set_sensitive(enabled)
+  }
 }
 
 GObject.type_ensure(FloatingToolRail.$gtype)

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -179,6 +179,21 @@ export class Engine extends Adw.Bin {
     return true
   }
 
+  /** Forward to `Engine.setLayerVisible` — toggles render visibility + triggers a graphics rebuild. */
+  public setLayerVisible(layerId: string, visible: boolean): boolean {
+    return this._excalibur?.setLayerVisible(layerId, visible) ?? false
+  }
+
+  /** Forward to `Engine.setLayerLocked` — toggles editor lock; no render change. */
+  public setLayerLocked(layerId: string, locked: boolean): boolean {
+    return this._excalibur?.setLayerLocked(layerId, locked) ?? false
+  }
+
+  /** Read whether a specific layer is locked on the active map. */
+  public isLayerLocked(layerId: string): boolean {
+    return this._excalibur?.isLayerLocked(layerId) ?? false
+  }
+
   public get excalibur(): ExcaliburEngine | null {
     return this._excalibur
   }
@@ -345,6 +360,9 @@ export class Engine extends Adw.Bin {
       }),
       engine.events.on(EngineEvent.TILE_PLACED, (p) => {
         this.events.emit(EngineEvent.TILE_PLACED, p)
+      }),
+      engine.events.on(EngineEvent.TILE_PICKED, (p) => {
+        this.events.emit(EngineEvent.TILE_PICKED, p)
       }),
     )
   }


### PR DESCRIPTION
Three features bundled (shared plumbing):

- **Eyedropper**: `TileEditorSystem` handles `'eyedropper'` tool, emits new `TILE_PICKED` engine event with global + local sprite info. Host (`ApplicationWindow` via `EngineController.onTilePicked`) selects the picked tile and auto-switches back to `pencil` for a Tiled-style workflow.
- **Layer visibility**: visibility filter moved from load-time (`MapResource.processLayers`) to render-time (`rebuildAllTileGraphics` + new `refreshAllTileGraphics`), so toggling is a pure graphics refresh. `Engine.setLayerVisible` + `LayersTab` signal wiring + persist via new `persist-requested` signal.
- **Layer lock**: added `LayerData.locked?: boolean`. `TileEditorSystem.applyClick` short-circuits paint/erase on locked layer (eyedropper bypasses — read-only). `FloatingToolRail.setEditingToolsEnabled` greys out pencil/bucket/rect/eraser; `SceneEditorView` flips it on every active-layer change + lock toggle hitting the active layer.

59 vitest tests pass; workspace check + build clean.