### PR TITLE
feat(editor): object sprite previews + move primary menu into mode rail

### DIFF
--- a/apps/maker-gjs/src/widgets/atlas-view.blp
+++ b/apps/maker-gjs/src/widgets/atlas-view.blp
@@ -38,13 +38,6 @@ template $AtlasView : Adw.Bin {
           action-name: "win.new-scene";
           styles ["suggested-action", "pill"]
         }
-
-        [end]
-        Gtk.MenuButton menu_button {
-          icon-name: "open-menu-symbolic";
-          menu-model: primary_menu;
-          tooltip-text: _("Main Menu");
-        }
       }
 
       content: Adw.OverlaySplitView inner_split {
@@ -62,35 +55,3 @@ template $AtlasView : Adw.Bin {
   }
 }
 
-menu primary_menu {
-  section {
-    item {
-      label: _("Inspector");
-      action: "win.toggle-inspector";
-    }
-  }
-  section {
-    item {
-      label: _("Open Recent");
-      action: "win.open-recent-projects";
-    }
-    item {
-      label: _("Close Project");
-      action: "win.close-project";
-    }
-  }
-  section {
-    item {
-      label: _("Preferences");
-      action: "app.preferences";
-    }
-    item {
-      label: _("Keyboard Shortcuts");
-      action: "win.show-help-overlay";
-    }
-    item {
-      label: _("About PixelRPG Maker");
-      action: "app.about";
-    }
-  }
-}

--- a/apps/maker-gjs/src/widgets/atlas-view.ts
+++ b/apps/maker-gjs/src/widgets/atlas-view.ts
@@ -36,7 +36,6 @@ export class AtlasView extends Adw.Bin {
   declare _atlas: AtlasCanvas
   declare _inspector: SceneInspector
   declare _new_scene_button: GObject.Object | undefined
-  declare _menu_button: GObject.Object | undefined
 
   private signals = new SignalScope()
   private _scenes: SampleScene[] = SAMPLE_SCENES

--- a/apps/maker-gjs/src/widgets/scene-editor-view.blp
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.blp
@@ -71,13 +71,6 @@ template $SceneEditorView : Adw.Bin {
         }
 
         [end]
-        Gtk.MenuButton menu_button {
-          icon-name: "open-menu-symbolic";
-          menu-model: scene_editor_menu;
-          tooltip-text: _("Main Menu");
-        }
-
-        [end]
         Gtk.ToggleButton inspector_toggle {
           icon-name: "sidebar-show-right-symbolic";
           tooltip-text: _("Toggle inspector");
@@ -100,25 +93,3 @@ template $SceneEditorView : Adw.Bin {
   }
 }
 
-menu scene_editor_menu {
-  section {
-    item {
-      label: _("Close Project");
-      action: "win.close-project";
-    }
-  }
-  section {
-    item {
-      label: _("Preferences");
-      action: "app.preferences";
-    }
-    item {
-      label: _("Keyboard Shortcuts");
-      action: "win.show-help-overlay";
-    }
-    item {
-      label: _("About PixelRPG Maker");
-      action: "app.about";
-    }
-  }
-}

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -211,16 +211,53 @@ export class SceneEditorView extends Adw.Bin {
     // (when present) or from the project's `objectLibrary` (when
     // referenced by `defId`); falling back to the placement id keeps
     // the row labelled even if the library lookup misses.
+    //
+    // Placements with a `sprite` ref additionally get a `Gdk.Paintable`
+    // preview attached so the Objects tab renders the actual sprite
+    // instead of the kind-fallback icon (decorations / NPCs gain a
+    // visible thumbnail). We deduplicate sprite-set loads — most
+    // decoration objects share one set, and `getSpriteSet` is async.
     const library = project.resource.data?.objectLibrary ?? []
-    const placements = (mapData.objectPlacements ?? []).map((p) => {
-      const def = p.inline ?? library.find((d) => d.id === p.defId) ?? null
+    const resolvedDefs = (mapData.objectPlacements ?? []).map((p) => ({
+      placement: p,
+      def: p.inline ?? library.find((d) => d.id === p.defId) ?? null,
+    }))
+    const objectSpriteSetIds = new Set<string>()
+    for (const { def } of resolvedDefs) {
+      if (def?.sprite?.spriteSetId) objectSpriteSetIds.add(def.sprite.spriteSetId)
+    }
+    const gdkSheets = new Map<string, GdkSpriteSheet | null>()
+    await Promise.all(
+      Array.from(objectSpriteSetIds).map(async (setId) => {
+        try {
+          const engineSet = await project.resource.getSpriteSet(setId)
+          if (!engineSet) {
+            gdkSheets.set(setId, null)
+            return
+          }
+          const gdkSet = await GdkSpriteSetResource.fromEngineResource(engineSet)
+          gdkSheets.set(setId, gdkSet.spriteSheet ?? null)
+        } catch (error) {
+          console.warn(`[SceneEditorView] Failed to load sprite set "${setId}" for objects tab:`, error)
+          gdkSheets.set(setId, null)
+        }
+      }),
+    )
+    const placements = resolvedDefs.map(({ placement, def }) => {
+      let paintable = null
+      if (def?.sprite) {
+        const sheet = gdkSheets.get(def.sprite.spriteSetId)
+        const sprite = sheet?.sprites[def.sprite.spriteId]
+        paintable = sprite?.createPaintable() ?? null
+      }
       return {
-        id: p.id,
-        name: def?.name ?? p.id,
+        id: placement.id,
+        name: def?.name ?? placement.id,
         kind: def?.kind ?? 'custom',
-        tileX: p.tileX,
-        tileY: p.tileY,
-        layerId: p.layerId,
+        tileX: placement.tileX,
+        tileY: placement.tileY,
+        layerId: placement.layerId,
+        paintable,
       }
     })
     this._inspector.objectsTab.setObjects(placements)

--- a/packages/gjs/src/widgets/editor/mode-rail.blp
+++ b/packages/gjs/src/widgets/editor/mode-rail.blp
@@ -8,10 +8,30 @@ template $PixelRpgModeRail : Adw.Bin {
     orientation: vertical;
     hexpand: true;
 
+    Gtk.Box hero_header {
+      orientation: horizontal;
+      margin-top: 12;
+      margin-start: 12;
+      margin-end: 12;
+      spacing: 4;
+
+      Gtk.MenuButton menu_button {
+        icon-name: "open-menu-symbolic";
+        menu-model: primary_menu;
+        tooltip-text: _("Main Menu");
+        valign: start;
+        styles ["flat"]
+      }
+
+      Gtk.Box {
+        hexpand: true;
+      }
+    }
+
     Gtk.Box hero {
       orientation: vertical;
       halign: fill;
-      margin-top: 28;
+      margin-top: 4;
       margin-bottom: 18;
       margin-start: 20;
       margin-end: 20;
@@ -180,6 +200,33 @@ template $PixelRpgModeRail : Adw.Bin {
           margin-end: 6;
         };
       }
+    }
+  }
+}
+
+menu primary_menu {
+  section {
+    item {
+      label: _("Open Recent");
+      action: "win.open-recent-projects";
+    }
+    item {
+      label: _("Close Project");
+      action: "win.close-project";
+    }
+  }
+  section {
+    item {
+      label: _("Preferences");
+      action: "app.preferences";
+    }
+    item {
+      label: _("Keyboard Shortcuts");
+      action: "win.show-help-overlay";
+    }
+    item {
+      label: _("About PixelRPG Maker");
+      action: "app.about";
     }
   }
 }

--- a/packages/gjs/src/widgets/editor/objects-tab.ts
+++ b/packages/gjs/src/widgets/editor/objects-tab.ts
@@ -1,4 +1,5 @@
 import Adw from '@girs/adw-1'
+import type Gdk from '@girs/gdk-4.0'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
 
@@ -10,13 +11,21 @@ export interface ObjectDescriptor {
   id: string
   /** Display name — comes from the resolved definition. */
   name: string
-  /** Object kind — drives the row icon. */
+  /** Object kind — drives the row icon when no sprite is available. */
   kind: 'event' | 'teleport' | 'item' | 'npc' | 'spawn-point' | 'custom'
   /** Tile-grid position, surfaced as a "(x, y)" caption. */
   tileX: number
   tileY: number
   /** Layer the placement is sorted under — shown as a tag. */
   layerId: string
+  /**
+   * Optional sprite preview. When supplied, the row renders this
+   * paintable as its prefix instead of the {@link KIND_ICONS}
+   * symbolic icon — useful for decoration / NPC placements with
+   * an actual sprite attached to their definition. Falls back to
+   * the kind icon when `null` / unavailable.
+   */
+  paintable?: Gdk.Paintable | null
 }
 
 /**
@@ -108,15 +117,40 @@ export class ObjectsTab extends Adw.Bin {
         subtitle: `(${placement.tileX}, ${placement.tileY}) · ${placement.layerId}`,
         activatable: true,
       })
-      row.add_prefix(
-        new Gtk.Image({
-          icon_name: KIND_ICONS[placement.kind] ?? KIND_ICONS.custom,
-          pixel_size: 18,
-        }),
-      )
+      row.add_prefix(this._buildPrefix(placement))
       ;(row as Adw.ActionRow & { objectId?: string }).objectId = placement.id
       this._list.append(row)
     }
+  }
+
+  /**
+   * Build the prefix widget shown to the left of an object row's
+   * title. Prefers the placement's `paintable` (the resolved sprite
+   * thumbnail) and falls back to the kind icon when no paintable is
+   * available — that way placements without an attached sprite
+   * still get a recognisable kind-specific badge.
+   *
+   * The sprite is rendered through a `Gtk.Picture` sized to roughly
+   * match the kind icon's footprint so rows stay vertically aligned.
+   * Pixel-art sprites stay crisp via `content-fit: scale-down` —
+   * smaller sprites render at native size + a transparent border,
+   * larger ones scale down preserving aspect.
+   */
+  private _buildPrefix(placement: ObjectDescriptor): Gtk.Widget {
+    if (placement.paintable) {
+      const picture = new Gtk.Picture({
+        paintable: placement.paintable,
+        content_fit: Gtk.ContentFit.SCALE_DOWN,
+        width_request: 28,
+        height_request: 28,
+      })
+      picture.add_css_class('object-sprite-preview')
+      return picture
+    }
+    return new Gtk.Image({
+      icon_name: KIND_ICONS[placement.kind] ?? KIND_ICONS.custom,
+      pixel_size: 18,
+    })
   }
 
   /** Programmatically set the active object. No-op if id not present. */


### PR DESCRIPTION
Two small editor UX wins:

1. **Sprite previews in the Objects tab.** Each placement with a `def.sprite` ref renders that sprite as the row's prefix (28x28 `Gtk.Picture`), instead of the kind-fallback icon. Decoration placements gain a recognisable thumbnail; kind icon stays as fallback for sprite-less objects.
2. **Primary menu moves into the ModeRail.** Hamburger button was duplicated in both atlas + scene-editor headers, each with its own menu definition. Now lives once in `ModeRail` (hero_header row at the top of the left sidebar), unified menu model.

66 vitest tests pass; workspace check + build clean.