### PR TITLE
fix(editor): move ModeRail menu button to top-right of sidebar

### DIFF
--- a/packages/gjs/src/widgets/editor/mode-rail.blp
+++ b/packages/gjs/src/widgets/editor/mode-rail.blp
@@ -15,16 +15,16 @@ template $PixelRpgModeRail : Adw.Bin {
       margin-end: 12;
       spacing: 4;
 
+      Gtk.Box {
+        hexpand: true;
+      }
+
       Gtk.MenuButton menu_button {
         icon-name: "open-menu-symbolic";
         menu-model: primary_menu;
         tooltip-text: _("Main Menu");
         valign: start;
         styles ["flat"]
-      }
-
-      Gtk.Box {
-        hexpand: true;
       }
     }
 


### PR DESCRIPTION
Per user feedback — flip the order of the hero_header children so the spacer comes first and the MenuButton sits on the right edge.