### PR TITLE
feat(editor): outline markers for sprite-less placements + camera focus on select

### DIFF
--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -520,6 +520,12 @@ export class SceneEditorView extends Adw.Bin {
     const objects = this._inspector.objectsTab
     objects.connect('object-selected', (_o: typeof objects, placementId: string) => {
       this._engine?.setSelectedPlacements([placementId])
+      // Smoothly pan the canvas to the picked object. Fire-and-forget —
+      // we don't care about the promise here, the engine resolves it
+      // when the camera move ends (or rejects on an interrupted move,
+      // e.g. the user picked a second object before the first pan
+      // finished — also fine, the new pan supersedes).
+      void this._engine?.focusOnPlacement(placementId)
     })
   }
 

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1,4 +1,4 @@
-import { Actor, Color, DisplayMode, EventEmitter, Engine as ExcaliburEngine, Loader, Logger, TileMap } from 'excalibur'
+import { Actor, Color, DisplayMode, EventEmitter, Engine as ExcaliburEngine, Loader, Logger, TileMap, Vector } from 'excalibur'
 import type { Command } from './commands/index.ts'
 import {
   ActiveLayerComponent,
@@ -233,6 +233,41 @@ export class Engine {
     const scene = this.excalibur.currentScene
     if (!(scene instanceof MapScene)) return []
     return SessionState.get(scene, SelectedPlacementsComponent)?.placementIds ?? []
+  }
+
+  /**
+   * Smoothly pan the camera so the tile centre of the placement
+   * with id `placementId` becomes the viewport centre. Uses
+   * Excalibur's `Camera.move` with `EaseInOutCubic` easing — the
+   * default duration of 400ms reads as a clear "the editor moved
+   * me" cue without dragging on long enough to be annoying when
+   * stepping through a list of objects.
+   *
+   * No-op (returns `false`) when there's no active `MapScene`, no
+   * loaded map data, or the placement id doesn't match anything in
+   * the current map. Returned promise resolves `true` when the
+   * pan completes (or `false` if Excalibur's `move()` rejects, e.g.
+   * because the camera is currently following an actor).
+   */
+  async focusOnPlacement(placementId: string, durationMs = 400): Promise<boolean> {
+    const scene = this.excalibur.currentScene
+    if (!(scene instanceof MapScene)) return false
+    const mapData = scene.mapResource?.mapData
+    if (!mapData) return false
+    const placement = mapData.objectPlacements?.find((p) => p.id === placementId)
+    if (!placement) return false
+    const tileWidth = mapData.tileWidth ?? 16
+    const tileHeight = mapData.tileHeight ?? 16
+    const target = new Vector(
+      placement.tileX * tileWidth + tileWidth / 2,
+      placement.tileY * tileHeight + tileHeight / 2,
+    )
+    try {
+      await scene.camera.move(target, durationMs)
+      return true
+    } catch {
+      return false
+    }
   }
 
   /**

--- a/packages/engine/src/systems/object-spawn.system.ts
+++ b/packages/engine/src/systems/object-spawn.system.ts
@@ -1,4 +1,4 @@
-import { Actor, Entity, type Scene, System, SystemType, vec, type World } from 'excalibur'
+import { Actor, Color, Entity, Rectangle, type Scene, System, SystemType, vec, type World } from 'excalibur'
 import {
   CollisionComponent,
   CustomDataComponent,
@@ -21,6 +21,23 @@ import type {
   SpawnPointProperties,
   TeleportProperties,
 } from '../types/data/index.ts'
+
+/**
+ * Outline marker colours per object kind for sprite-less
+ * placements. Picked to be visually distinct without clashing
+ * with typical RPG tile palettes — light, saturated tones
+ * against the natural greens / browns of a tilemap. Updates
+ * to the kind set should add an entry here too; the `custom`
+ * entry is the documented fallback for unknown kinds.
+ */
+const KIND_MARKER_COLORS: Record<ObjectDefinition['kind'], string> = {
+  teleport: '#66ccff',
+  item: '#ffcc33',
+  npc: '#66cc66',
+  'spawn-point': '#cc66ff',
+  event: '#66ffcc',
+  custom: '#ff9966',
+}
 
 /**
  * Walks `MapData.objectPlacements` on first scene activate and
@@ -113,38 +130,41 @@ export class ObjectSpawnSystem extends System {
     const tileWidth = mapData?.tileWidth ?? 16
     const tileHeight = mapData?.tileHeight ?? 16
 
-    // Visible entities are Actors so we can hand the Excalibur graphics
-    // pipeline a sprite directly; invisible markers stay as bare
-    // Entities to skip the actor overhead.
-    const visible = def.sprite != null
-    const entity: Entity = visible
-      ? new Actor({
-          name: `${def.kind}:${placement.id}`,
-          x: placement.tileX * tileWidth + tileWidth / 2,
-          y: placement.tileY * tileHeight + tileHeight / 2,
-          width: tileWidth,
-          height: tileHeight,
-        })
-      : new Entity({ name: `${def.kind}:${placement.id}` })
+    // Every placement is an `Actor` now — sprite-less ones (functional
+    // markers, sprite-less teleports / events / spawn points) get a
+    // coloured outline marker so they're discoverable on the map.
+    // Pre-refactor they were bare `Entity`s with no graphics, which
+    // made them invisible in the editor and impossible to locate
+    // without inspecting JSON.
+    const actor = new Actor({
+      name: `${def.kind}:${placement.id}`,
+      x: placement.tileX * tileWidth + tileWidth / 2,
+      y: placement.tileY * tileHeight + tileHeight / 2,
+      width: tileWidth,
+      height: tileHeight,
+    })
+    const entity: Entity = actor
 
-    entity.addComponent(new TileTransformComponent(placement.tileX, placement.tileY, placement.layerId))
+    actor.addComponent(new TileTransformComponent(placement.tileX, placement.tileY, placement.layerId))
 
     if (def.sprite) {
-      entity.addComponent(new SpriteRefComponent(def.sprite.spriteSetId, def.sprite.spriteId, def.sprite.animationId))
-      const actor = entity as Actor
+      actor.addComponent(new SpriteRefComponent(def.sprite.spriteSetId, def.sprite.spriteId, def.sprite.animationId))
       this.attachSpriteGraphic(actor, def.sprite.spriteSetId, def.sprite.spriteId, def.sprite.animationId)
-      // Z is driven by the layer's tier — placement actors render at
-      // the same render depth as their tier's tilemap, so e.g.
-      // decoration actors on the 'hero' tier interleave with the
-      // hero-tier tilemap rather than overdrawing the entire map.
-      // Default 'ground' matches the LayerData fallback.
-      const layer = mapData?.layers.find((l) => l.id === placement.layerId)
-      actor.z = TIER_Z[layer?.tier ?? 'ground']
-      // Respect the layer's visibility flag at spawn. Runtime
-      // toggles re-sync via `Engine.setLayerVisible`.
-      if (!isLayerVisible(this.mapResource, placement.layerId)) {
-        actor.graphics.visible = false
-      }
+    } else {
+      this.attachOutlineMarker(actor, def.kind, tileWidth, tileHeight)
+    }
+
+    // Z is driven by the layer's tier — placement actors render at
+    // the same render depth as their tier's tilemap, so e.g.
+    // decoration actors on the 'hero' tier interleave with the
+    // hero-tier tilemap rather than overdrawing the entire map.
+    // Default 'ground' matches the LayerData fallback.
+    const layer = mapData?.layers.find((l) => l.id === placement.layerId)
+    actor.z = TIER_Z[layer?.tier ?? 'ground']
+    // Respect the layer's visibility flag at spawn. Runtime
+    // toggles re-sync via `Engine.setLayerVisible`.
+    if (!isLayerVisible(this.mapResource, placement.layerId)) {
+      actor.graphics.visible = false
     }
 
     if (def.trigger) {
@@ -213,6 +233,33 @@ export class ObjectSpawnSystem extends System {
     if (!graphic) return
     // Center anchor so positioning by tile centre matches the tilemap layout.
     actor.graphics.use(graphic)
+    actor.graphics.anchor = vec(0.5, 0.5)
+  }
+
+  /**
+   * Attach a colour-coded outline rectangle to a sprite-less
+   * placement actor. Used for functional markers (boundaries /
+   * water triggers / camera anchors) and any other placement
+   * whose `ObjectDefinition` doesn't carry a `sprite` ref —
+   * without this they spawn invisibly and the user can't
+   * discover them on the map.
+   *
+   * The rectangle covers one tile, stroked in the kind's colour,
+   * with a transparent fill so the underlying tilemap stays
+   * readable through the marker. Pre-refactor sprite-less
+   * placements were bare `Entity`s with no graphics, which made
+   * functional layers unusable without inspecting JSON.
+   */
+  private attachOutlineMarker(actor: Actor, kind: ObjectDefinition['kind'], width: number, height: number): void {
+    const colorHex = KIND_MARKER_COLORS[kind] ?? KIND_MARKER_COLORS.custom
+    const rect = new Rectangle({
+      width,
+      height,
+      color: Color.Transparent,
+      strokeColor: Color.fromHex(colorHex),
+      lineWidth: 1,
+    })
+    actor.graphics.use(rect)
     actor.graphics.anchor = vec(0.5, 0.5)
   }
 }

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -144,6 +144,11 @@ export class Engine extends Adw.Bin {
     return this._excalibur?.getSelectedPlacements() ?? []
   }
 
+  /** Forward to `Engine.focusOnPlacement` — smoothly pans the camera. */
+  public focusOnPlacement(placementId: string, durationMs?: number): Promise<boolean> {
+    return this._excalibur?.focusOnPlacement(placementId, durationMs) ?? Promise.resolve(false)
+  }
+
   /** Undo the most recent editor command. Returns `false` if nothing to undo. */
   public undo(): boolean {
     return this._excalibur?.undo() ?? false


### PR DESCRIPTION
Two interlocking inspector improvements:

1. **Outline markers**: sprite-less placements (Functional layer markers, sprite-less teleports / events / spawn points) used to spawn as bare `Entity`s with no graphics, making them invisible on the map. Now spawn as Actors with a 1-pixel kind-coloured Rectangle outline sized to one tile (transparent fill). User can finally see Manual Boundaries / Water triggers / Camera anchors after toggling Functional layer visible.
2. **Camera focus**: selecting an object in the Objects tab smoothly pans the canvas to its tile (`Camera.move` + EaseInOutCubic, 400ms). New `Engine.focusOnPlacement(id)` forwarded through the gjs widget; SceneEditorView wires it alongside the existing `setSelectedPlacements` call.

66 vitest tests pass; workspace check + build clean.