### PR TITLE
fix(maker): pencil preview hidden on first hover after project load

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@ Conventions:
 
 ## Editor / tooling
 
-- **Tool semantics in `@pixelrpg/engine`** — currently `bucket`/`rect`/`select`/`stamp`/`event` all map to `brush` in `ApplicationWindow._installActions` (search `mappedTool`). Implement proper behavior per tool in `packages/engine/src/systems/tile-editor.system.ts`. *owner: engine, why: bigger ECS-side change per tool, deserves its own PR series*
+- **Tool semantics in `@pixelrpg/engine`** — `bucket` / `rect` / `select` / `stamp` / `event` are accepted by `TileEditorSystem` but short-circuit (no behaviour). Implement proper per-tool behaviour in `packages/engine/src/systems/tile-editor.system.ts`. *owner: engine, why: bigger ECS-side change per tool, deserves its own PR series*
 - **File-picker "Save as new project"** — `_onCreateProject` opens the blank template in-place rather than scaffolding a new project file in a user-chosen directory. Needs a save-as flow + `editorData.templateOrigin` tracking. *owner: maker*
 - **"Switch tileset" action** — `win.switch-tileset` is registered but no handler. Tiles tab "Switch…" button does nothing. *owner: maker*
 - **"New layer" action** — `win.new-layer` registered, no handler. Layers tab "New layer" footer button does nothing. *owner: maker*

--- a/apps/maker-gjs/src/services/engine-controller.ts
+++ b/apps/maker-gjs/src/services/engine-controller.ts
@@ -121,7 +121,7 @@ export class EngineController {
 
     // Default editor state — pencil tool so the user can paint
     // immediately. Tile / layer come from `populateFromProject`.
-    this._engine.setActiveTool('brush')
+    this._engine.setActiveTool('pencil')
 
     this._attachZoomHook()
     this._attachUndoHook()

--- a/apps/maker-gjs/src/services/engine-controller.ts
+++ b/apps/maker-gjs/src/services/engine-controller.ts
@@ -119,9 +119,11 @@ export class EngineController {
       this._mapId = mapId
     }
 
-    // Default editor state — pencil tool so the user can paint
-    // immediately. Tile / layer come from `populateFromProject`.
-    this._engine.setActiveTool('pencil')
+    // Active tool / tile / layer are pushed by the host
+    // (`ApplicationWindow._hydrateSceneEditor`) so the UI's GAction
+    // stays the source of truth across map switches. The controller
+    // intentionally doesn't reset them here; doing so would force the
+    // tool back to a hardcoded default and desync from the toolbar.
 
     this._attachZoomHook()
     this._attachUndoHook()

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -45,6 +45,14 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
   private _scenesById = new Map<string, SampleScene>(SAMPLE_SCENES.map((s) => [s.id, s]))
   private _loadedProject: LoadedProject | null = null
   /**
+   * The `win.set-tool` GAction. Kept as a field so `_hydrateSceneEditor`
+   * can push its current state into the engine after every map load —
+   * the engine's `ActiveToolComponent` is per-scene and resets on each
+   * `loadMap`, while this GAction preserves the user's selection across
+   * scenes.
+   */
+  private _toolAction: Gio.SimpleAction | null = null
+  /**
    * Which map the scene editor is currently editing. Tracks
    * `_showSceneEditor` so the persist-requested handler knows which
    * MapResource to serialise.
@@ -175,6 +183,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this._engineCtl.engine?.setActiveTool(value!.get_string()[0] as EditorTool)
     })
     winActions.add_action(toolAction)
+    this._toolAction = toolAction
 
     // Undo / redo route through the engine's command stack
     // (\`docs/concepts/editor-architecture.md\` § Phase 5). The engine
@@ -368,6 +377,17 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       // canvas couldn't come up. `populateFromProject`'s engine writes
       // will no-op gracefully since the controller's `_engine` stays
       // null on a failed bring-up.
+    }
+
+    // Push the UI's current tool selection into the freshly-loaded
+    // scene's session state. The engine's `ActiveToolComponent` is
+    // per-scene and resets on every `loadMap`, while the GAction
+    // preserves the user's choice across scenes — without this sync
+    // the UI would still show e.g. "eraser" while the engine reverts
+    // to its system default and the pencil-preview helper hides.
+    const toolState = this._toolAction?.get_state()
+    if (toolState) {
+      this._engineCtl.engine?.setActiveTool(toolState.get_string()[0] as EditorTool)
     }
 
     try {

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -345,12 +345,15 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     const project = this._loadedProject
     if (!project) return
 
-    try {
-      await this._scene_editor_view.populateFromProject(project, sceneId)
-    } catch (error) {
-      console.warn('[ApplicationWindow] Failed to populate inspector:', error)
-    }
-
+    // Order is load-bearing: `ensureForMap` must complete before
+    // `populateFromProject` so the inspector's initial
+    // `_setActiveTile` / `_setActiveLayer` writes land on a live
+    // Excalibur engine. The reverse order leaves the engine's
+    // `ActiveTile` / `ActiveLayer` session-state null until the user
+    // manually picks a swatch, breaking the brush hover preview at
+    // startup (the slot fires before Excalibur is initialised, so the
+    // gjs widget's `setActiveTile/Layer` forwarders silently no-op
+    // — see `SceneEditorView.setEngineWidget`).
     try {
       await this._engineCtl.ensureForMap(project.projectPath, sceneId)
     } catch (error) {
@@ -360,6 +363,17 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
           : `${typeof error} ${JSON.stringify(error)}`
       console.error('[ApplicationWindow] Failed to bring up engine:', details)
       this._showToast(_('Failed to load map'))
+      // Fall through: still populate the inspector so the user has a
+      // usable surface (palette / layers / objects) even when the
+      // canvas couldn't come up. `populateFromProject`'s engine writes
+      // will no-op gracefully since the controller's `_engine` stays
+      // null on a failed bring-up.
+    }
+
+    try {
+      await this._scene_editor_view.populateFromProject(project, sceneId)
+    } catch (error) {
+      console.warn('[ApplicationWindow] Failed to populate inspector:', error)
     }
   }
 

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -3,7 +3,7 @@ import Gio from '@girs/gio-2.0'
 import GLib from '@girs/glib-2.0'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
-import { MapFormat } from '@pixelrpg/engine'
+import { type EditorTool, MapFormat } from '@pixelrpg/engine'
 import { SAMPLE_SCENES, type SampleScene, SignalScope } from '@pixelrpg/gjs'
 import { gettext as _ } from 'gettext'
 import { EngineController } from '../services/engine-controller.ts'
@@ -96,13 +96,9 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     this.signals.connect(this._atlas_view, 'scene-selected', (_v: AtlasView, id: string) => {
       this._lastAtlasSelection = id
     })
-    this.signals.connect(
-      this._atlas_view,
-      'scene-moved',
-      (_v: AtlasView, id: string, x: number, y: number) => {
-        this._persistAtlasPosition(id, x, y)
-      },
-    )
+    this.signals.connect(this._atlas_view, 'scene-moved', (_v: AtlasView, id: string, x: number, y: number) => {
+      this._persistAtlasPosition(id, x, y)
+    })
 
     // Scene editor → host bridge. The inspector mutates
     // `MapResource.mapData` in place via `engine.setLayerVisible` /
@@ -171,15 +167,12 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     )
     toolAction.connect('change-state', (action, value) => {
       action.set_state(value!)
-      const tool = value!.get_string()[0]
-      // Engine accepts 'brush' | 'eraser' today — map the new tool ids
-      // back to those until the engine grows the full set. The
-      // `ActiveToolComponent` accepts any string, so we pass the raw
-      // tool id through; the engine's `TileEditorSystem` short-circuits
-      // on tools it doesn't understand yet.
-      const mappedTool: string =
-        tool === 'eraser' ? 'eraser' : tool === 'pencil' || tool === 'bucket' || tool === 'rect' ? 'brush' : tool
-      this._engineCtl.engine?.setActiveTool(mappedTool)
+      // Tool ids are shared with the engine's `EditorTool` union, so
+      // the GAction state string can be passed straight through.
+      // `TileEditorSystem` short-circuits on tools whose semantics
+      // it doesn't implement yet (bucket / rect / select / stamp /
+      // event) — the UI still surfaces the buttons.
+      this._engineCtl.engine?.setActiveTool(value!.get_string()[0] as EditorTool)
     })
     winActions.add_action(toolAction)
 
@@ -369,7 +362,6 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this._showToast(_('Failed to load map'))
     }
   }
-
 
   private _onTemplateSelected(templateId: string): void {
     const template = findTemplateById(templateId)

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -143,18 +143,20 @@ export class SceneEditorView extends Adw.Bin {
    *
    * Also remembers the engine so inspector selections (tile, layer,
    * tool) can be forwarded into `Engine.setEditorState()`.
+   *
+   * The slot fires synchronously the moment the engine widget is
+   * constructed — before its async Excalibur initialisation finishes.
+   * Don't try to push session-state writes (`setActiveTile`,
+   * `setActiveLayer`) from here: the gjs widget's forwarders no-op
+   * while `_excalibur` is null, so the writes silently disappear.
+   * The host orchestrator (`_hydrateSceneEditor`) is responsible for
+   * ordering `ensureForMap` before `populateFromProject` so the
+   * inspector's `_setActiveTile/_setActiveLayer` writes land on a
+   * live engine.
    */
   setEngineWidget(widget: Gtk.Widget | null, engine?: Engine | null): void {
     this._editor.setEngine(widget)
     this._engine = engine ?? null
-    // Replay the active tile / layer in case `populateFromProject` ran
-    // before the engine was instantiated. Tile id needs the gid offset.
-    if (this._engine) {
-      if (this._activeTileId != null) {
-        this._engine.setActiveTile(this._activeTileId + this._tilesetFirstGid)
-      }
-      if (this._activeLayerId != null) this._engine.setActiveLayer(this._activeLayerId)
-    }
   }
 
   /** Header title + the floating chips. */

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -310,7 +310,13 @@ export class SceneEditorView extends Adw.Bin {
    * the chip so the swatch is a live preview instead of a static icon.
    */
   private _setActiveTile(tileId: number, tileName?: string): void {
-    if (this._activeTileId === tileId) return
+    // Do NOT short-circuit on `_activeTileId === tileId`. The engine's
+    // `ActiveTileComponent` is per-scene; on map switch (or re-entry
+    // after `EngineController.dispose`) the new scene's session state
+    // starts empty even though `_activeTileId` still holds the previous
+    // scene's value. A short-circuit there would leave the engine
+    // without an active tile until the user manually picked a swatch
+    // — the same shape of bug the startup-order fix addresses.
     this._activeTileId = tileId
     this._editor.contextChip.tileName = tileName ?? `Tile ${tileId}`
     const tile = this._tiles.find((t) => t.id === tileId)
@@ -348,7 +354,11 @@ export class SceneEditorView extends Adw.Bin {
   }
 
   private _setActiveLayer(layerId: string): void {
-    if (this._activeLayerId === layerId) return
+    // No short-circuit on `_activeLayerId === layerId` — see the
+    // comment on `_setActiveTile` for the same reasoning. The engine's
+    // per-scene `ActiveLayerComponent` resets on every map load while
+    // the view-held id persists, so the populate-from-project replay
+    // must always reach the engine.
     this._activeLayerId = layerId
     const layer = this._layers.find((l) => l.id === layerId)
     this._editor.contextChip.layerName = layer?.name ?? layerId

--- a/packages/engine/src/components/active-tool.component.ts
+++ b/packages/engine/src/components/active-tool.component.ts
@@ -4,22 +4,20 @@ import { Component } from 'excalibur'
  * Editor tool currently active for tile-level mutations. Lives on the
  * session-singleton entity (see `docs/concepts/editor-architecture.md`).
  *
- * The string union is **open** — the engine only acts on tools it
- * understands (`'brush'` / `'eraser'` today; more will follow as
- * tool semantics land). Unknown values are tolerated by the systems
- * that read this component; they short-circuit on tools they don't
- * recognise so the editor's UI tool-rail can name new tools (e.g.
- * `'bucket'`, `'rect'`) before the engine implements them.
+ * Canonical set is shared with the UI tool rail
+ * (`@pixelrpg/gjs/widgets/editor/floating-tool-rail`) — both sides
+ * import this type so adding / renaming a tool is a single-file
+ * change. Adding a new tool: extend this union, update the BLP
+ * button, implement the system-side behaviour in
+ * `TileEditorSystem.applyClick`.
+ *
+ * Today the engine acts on `'pencil'` / `'eraser'` / `'eyedropper'`;
+ * the remaining tools (`'bucket'`, `'rect'`, `'select'`, `'stamp'`,
+ * `'event'`) are accepted but `TileEditorSystem` short-circuits on
+ * them so the UI can surface the buttons before the engine grows
+ * their semantics.
  */
-export type EditorTool =
-  | 'brush'
-  | 'eraser'
-  | 'bucket'
-  | 'rect'
-  | 'select'
-  | 'stamp'
-  | 'event'
-  | (string & {})
+export type EditorTool = 'pencil' | 'bucket' | 'rect' | 'eraser' | 'eyedropper' | 'select' | 'stamp' | 'event'
 
 export class ActiveToolComponent extends Component {
   constructor(public tool: EditorTool) {

--- a/packages/engine/src/resource/MapResource.ts
+++ b/packages/engine/src/resource/MapResource.ts
@@ -3,10 +3,10 @@ import { Logger, type Scene, type Tile, TileMap, Vector } from 'excalibur'
 import { MapEditorComponent, type TileSpriteRef } from '../components/map-editor.component.ts'
 import { TIER_Z, TileMapTierComponent } from '../components/tilemap-tier.component.ts'
 import { MapFormat } from '../format/MapFormat'
+import { collectHiddenLayerIds } from '../services/layer-visibility.ts'
 import type { LayerData, LayerTier, MapData, MapResourceOptions } from '../types'
 import { loadTextFile } from '../utils'
 import { extractDirectoryPath, getFilename, joinPaths } from '../utils/url'
-import { collectHiddenLayerIds } from '../services/layer-visibility.ts'
 import { SpriteSetResource } from './SpriteSetResource.ts'
 
 /** All tiers a `MapResource` builds tilemaps for. Order is canonical
@@ -28,7 +28,7 @@ export class MapResource implements Loadable<TileMap> {
   private readonly headless: boolean = false
   private readonly basePath: string = ''
   private readonly filename: string = ''
-  private tileSetResources: Map<string, SpriteSetResource> = new Map()
+  private spriteSetResources: Map<string, SpriteSetResource> = new Map()
   private readonly _preloadedSpriteSets: Map<string, SpriteSetResource>
   private _mapData!: MapData
 
@@ -75,7 +75,7 @@ export class MapResource implements Loadable<TileMap> {
       // Reuse pre-loaded resource if available (typically from GameProjectResource)
       const preloaded = this._preloadedSpriteSets.get(spriteSetRef.id)
       if (preloaded) {
-        this.tileSetResources.set(spriteSetRef.id, preloaded)
+        this.spriteSetResources.set(spriteSetRef.id, preloaded)
         this.logger.debug(`Reused pre-loaded sprite set: ${spriteSetRef.id}`)
         continue
       }
@@ -88,7 +88,7 @@ export class MapResource implements Loadable<TileMap> {
         })
         await resource.load()
 
-        this.tileSetResources.set(spriteSetRef.id, resource)
+        this.spriteSetResources.set(spriteSetRef.id, resource)
         this.logger.debug(`Loaded sprite set: ${spriteSetRef.id} from ${fullPath}`)
       } catch (error) {
         this.logger.error(`Failed to load sprite set ${spriteSetRef.id}: ${error}`)
@@ -96,7 +96,7 @@ export class MapResource implements Loadable<TileMap> {
       }
     }
 
-    this.logger.debug(`Loaded ${this.tileSetResources.size} sprite sets`)
+    this.logger.debug(`Loaded ${this.spriteSetResources.size} sprite sets`)
   }
 
   /**
@@ -264,7 +264,7 @@ export class MapResource implements Loadable<TileMap> {
 
         for (const ref of sortedRefs) {
           if (hiddenLayerIds.has(ref.layerId)) continue
-          const spriteSet = this.tileSetResources.get(ref.spriteSetId)
+          const spriteSet = this.spriteSetResources.get(ref.spriteSetId)
           if (!spriteSet) continue
 
           if (ref.animationId && spriteSet.animations[ref.animationId]) {
@@ -308,11 +308,11 @@ export class MapResource implements Loadable<TileMap> {
   }
 
   getSpriteSetResource(spriteSetId: string): SpriteSetResource | undefined {
-    return this.tileSetResources.get(spriteSetId)
+    return this.spriteSetResources.get(spriteSetId)
   }
 
   getAllSpriteSetResources(): Map<string, SpriteSetResource> {
-    return this.tileSetResources
+    return this.spriteSetResources
   }
 
   getAvailableLayerIds(): string[] {

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -3,6 +3,7 @@
 export * from './editor-view'
 export * from './layer-visibility'
 export * from './layer.manager'
+export * from './pencil-preview'
 export * from './sprite-info.resolver'
 export * from './sprite.validator'
 export * from './tile-graphics.manager'

--- a/packages/engine/src/services/pencil-preview.ts
+++ b/packages/engine/src/services/pencil-preview.ts
@@ -1,0 +1,104 @@
+import { Actor, type Scene, type Sprite, type TileMap, Vector, vec } from 'excalibur'
+import { ActiveLayerComponent, ActiveTileComponent, ActiveToolComponent, TIER_Z } from '../components/index.ts'
+import type { MapScene } from '../scenes/map.scene.ts'
+import { EDITOR_CONSTANTS } from '../utils/constants.ts'
+import { SessionState } from '../utils/session-state.ts'
+import { findSpriteInfoForTileId } from './sprite-info.resolver.ts'
+
+/**
+ * Pencil-tool hover preview — a half-transparent ghost of the active
+ * tile that follows the pointer on the active tilemap. Renders as a
+ * regular scene `Actor` rather than a tile graphic, so paint / erase
+ * rebuilds don't disturb it and the editor's `MapEditorComponent`
+ * shadow state stays free of UI-only ephemera.
+ *
+ * Owner contract: caller holds the actor + the current hover state,
+ * passes both to {@link refreshPencilPreview}. The helper resolves
+ * preconditions (tool, active tile, layer lock, sprite resolution)
+ * against the scene's session state and either shows or hides the
+ * actor accordingly. Callers don't reproduce that branching.
+ */
+
+/** Hover context the caller hands to {@link refreshPencilPreview}. */
+export interface PencilPreviewHover {
+  tileMap: TileMap
+  coords: { x: number; y: number }
+}
+
+/**
+ * Construct the preview actor. Top-left anchored so `pos` maps
+ * directly to a tile's world-space origin. Z-pinned above the
+ * highest tilemap tier so the ghost sits on top of every painted
+ * tile.
+ */
+export function createPencilPreviewActor(): Actor {
+  const actor = new Actor({
+    name: 'tile-paint-preview',
+    anchor: vec(0, 0),
+  })
+  actor.z = TIER_Z.overlay + 50
+  actor.graphics.anchor = vec(0, 0)
+  actor.graphics.visible = false
+  return actor
+}
+
+/**
+ * Reconcile the preview actor with the scene's current editor state.
+ * Pass `hover = null` to hide (pointer off the map). All other hide
+ * conditions are resolved internally:
+ *
+ * - Active tool isn't `'pencil'` (eraser / select / etc. suppress)
+ * - No active tile id picked yet
+ * - Active layer is locked (paint would no-op)
+ * - Sprite cannot be resolved on the active map
+ *
+ * Idempotent — safe to call on every pointer move and on every
+ * `ActiveTool` / `ActiveTile` / `ActiveLayer` mutation.
+ */
+export function refreshPencilPreview(actor: Actor, scene: Scene, hover: PencilPreviewHover | null): void {
+  const sprite = resolvePreviewSprite(scene, hover)
+  if (!sprite || !hover) {
+    actor.graphics.visible = false
+    return
+  }
+  // Clone — sharing one Sprite across draw targets causes per-frame
+  // transform corruption (same invariant `tile-graphics.manager`
+  // relies on). Cheap at human mouse-move rate.
+  const cloned = sprite.clone()
+  cloned.opacity = EDITOR_CONSTANTS.PAINT_PREVIEW_OPACITY
+  actor.graphics.use(cloned)
+  actor.pos = new Vector(
+    hover.tileMap.pos.x + hover.coords.x * hover.tileMap.tileWidth,
+    hover.tileMap.pos.y + hover.coords.y * hover.tileMap.tileHeight,
+  )
+  actor.graphics.visible = true
+}
+
+/**
+ * Return the sprite to ghost at the hover position, or `null` when
+ * any precondition is missing. Split out so {@link refreshPencilPreview}
+ * has a single "draw vs. hide" branch instead of seven nested guards.
+ */
+function resolvePreviewSprite(scene: Scene, hover: PencilPreviewHover | null): Sprite | null {
+  if (!hover) return null
+
+  const tool = SessionState.get(scene, ActiveToolComponent)?.tool
+  if (tool !== 'pencil') return null
+
+  const activeTileId = SessionState.get(scene, ActiveTileComponent)?.spriteId
+  if (activeTileId === undefined) return null
+
+  const mapResource = (scene as MapScene).mapResource
+  if (!mapResource) return null
+
+  const layerId = SessionState.get(scene, ActiveLayerComponent)?.layerId ?? mapResource.getFirstLayerId?.()
+  if (!layerId) return null
+
+  const layer = mapResource.mapData?.layers.find((l) => l.id === layerId)
+  if (layer?.locked) return null
+
+  const info = findSpriteInfoForTileId(mapResource, activeTileId)
+  if (!info) return null
+
+  return mapResource.getSpriteSetResource(info.spriteSetId)?.sprites[info.spriteId] ?? null
+}

--- a/packages/engine/src/systems/tile-editor.system.ts
+++ b/packages/engine/src/systems/tile-editor.system.ts
@@ -1,4 +1,5 @@
 import {
+  type Actor,
   type Engine,
   type EventEmitter,
   type Scene,
@@ -21,6 +22,7 @@ import {
   UndoStackComponent,
 } from '../components/index.ts'
 import type { MapScene } from '../scenes/map.scene.ts'
+import { createPencilPreviewActor, type PencilPreviewHover, refreshPencilPreview } from '../services/pencil-preview.ts'
 import { findTileIdForSpriteInfo } from '../services/sprite-info.resolver.ts'
 import type { LayerTier } from '../types/data/index.ts'
 import { EngineEvent, type EngineEventMap } from '../types/index.ts'
@@ -41,14 +43,23 @@ interface TileHit {
  *
  * Subscribes to `ex.Input.Pointer` events directly. Coexists peacefully with
  * {@link CameraControlSystem}: hover events fire during pan-drags too, but
- * there is no visual hover feedback today, so the redundancy is harmless and
- * the simpler split avoids any cross-system coordination state.
+ * the panning camera doesn't suppress hover feedback by design — the preview
+ * tracks the cursor through pan-drags so the user always sees where a click
+ * would land.
+ *
+ * Pencil hover preview is delegated to `services/pencil-preview.ts`. This
+ * system owns the actor lifecycle (create on scene init, route hover state
+ * + session-state mutations into the helper); the helper owns the visual
+ * logic.
  */
 export class TileEditorSystem extends System {
   public readonly systemType = SystemType.Update
 
   private engine?: Engine
   private scene?: Scene
+
+  private previewActor: Actor | null = null
+  private hoverContext: PencilPreviewHover | null = null
 
   constructor(private readonly events: EventEmitter<EngineEventMap>) {
     super()
@@ -61,14 +72,30 @@ export class TileEditorSystem extends System {
     this.engine = scene.engine
     this.scene = scene
 
+    this.previewActor = createPencilPreviewActor()
+    scene.add(this.previewActor)
+
+    // Refresh the preview when the active tool / tile / layer changes,
+    // so the user doesn't have to wiggle the mouse to see the effect of
+    // switching tool or picking a new swatch. Subscriptions are tied
+    // to the scene's lifetime via `SessionState`'s per-scene WeakMap
+    // registry, so no explicit teardown is needed.
+    SessionState.subscribe(scene, ActiveToolComponent, () => this.refreshPreview())
+    SessionState.subscribe(scene, ActiveTileComponent, () => this.refreshPreview())
+    SessionState.subscribe(scene, ActiveLayerComponent, () => this.refreshPreview())
+
     const pointer = this.engine.input.pointers.primary
 
     pointer.on('down', (event) => {
-      this.handlePointer(vec(event.screenPos.x, event.screenPos.y), 'down')
+      const hit = this.findTileUnderPointer(vec(event.screenPos.x, event.screenPos.y))
+      if (hit) this.applyClick(hit)
     })
 
     pointer.on('move', (event) => {
-      this.handlePointer(vec(event.screenPos.x, event.screenPos.y), 'move')
+      const hit = this.findTileUnderPointer(vec(event.screenPos.x, event.screenPos.y))
+      if (hit) this.applyHover(hit)
+      this.hoverContext = hit ? { tileMap: hit.tileMap, coords: hit.coords } : null
+      this.refreshPreview()
     })
   }
 
@@ -76,15 +103,9 @@ export class TileEditorSystem extends System {
     // All work is event-driven.
   }
 
-  private handlePointer(screenPos: Vector, kind: 'down' | 'move'): void {
-    const hit = this.findTileUnderPointer(screenPos)
-    if (!hit) return
-
-    if (kind === 'move') {
-      this.applyHover(hit)
-    } else {
-      this.applyClick(hit)
-    }
+  private refreshPreview(): void {
+    if (!this.previewActor || !this.scene) return
+    refreshPencilPreview(this.previewActor, this.scene, this.hoverContext)
   }
 
   private findTileUnderPointer(screenPos: Vector): TileHit | null {
@@ -163,7 +184,7 @@ export class TileEditorSystem extends System {
 
   private applyClick(hit: TileHit): void {
     if (!this.scene) return
-    const tool: EditorTool = SessionState.get(this.scene, ActiveToolComponent)?.tool ?? 'brush'
+    const tool: EditorTool = SessionState.get(this.scene, ActiveToolComponent)?.tool ?? 'pencil'
     const tileId = SessionState.get(this.scene, ActiveTileComponent)?.spriteId ?? null
     const explicitLayerId = SessionState.get(this.scene, ActiveLayerComponent)?.layerId ?? null
     const layerId = this.resolveLayerId(explicitLayerId)
@@ -186,7 +207,7 @@ export class TileEditorSystem extends System {
       animationId: ref.animationId,
     }))
 
-    if (tool === 'brush') {
+    if (tool === 'pencil') {
       if (tileId === null) return
       this.dispatchCommand(
         new PaintTileCommand({

--- a/packages/engine/src/utils/constants.ts
+++ b/packages/engine/src/utils/constants.ts
@@ -45,6 +45,13 @@ export const EDITOR_CONSTANTS = {
   DEFAULT_STROKE_WIDTH: 1,
   DEFAULT_FONT_SIZE: 10,
   DEFAULT_FONT_FAMILY: 'Arial',
+
+  // Brush tool hover preview — half-transparent ghost of the active
+  // tile rendered by `TileEditorSystem` at the hovered tile so the
+  // user sees what would be placed before clicking. Low enough that
+  // the underlying tile is clearly visible; high enough that the
+  // ghost is unambiguously *the* preview (not noise / glare).
+  PAINT_PREVIEW_OPACITY: 0.5,
 } as const
 
 /**

--- a/packages/gjs/src/widgets/editor/floating-tool-rail.ts
+++ b/packages/gjs/src/widgets/editor/floating-tool-rail.ts
@@ -1,23 +1,18 @@
 import Adw from '@girs/adw-1'
 import GObject from '@girs/gobject-2.0'
 import type Gtk from '@girs/gtk-4.0'
+import type { EditorTool } from '@pixelrpg/engine'
 
 import Template from './floating-tool-rail.blp'
 
 /**
- * Enumerable name of every tool surfaced by {@link FloatingToolRail}.
- *
- * Matches the `win.set-tool` action targets bound in the BLP template.
+ * Re-export the engine's `EditorTool` union — kept as a named export
+ * here so existing UI-side imports (`from '.../floating-tool-rail'`)
+ * keep working without churn. The BLP `win.set-tool` action targets
+ * MUST match this union; adding a new tool means updating the engine
+ * union, the BLP, and the per-button declarations below.
  */
-export type EditorTool =
-  | 'pencil'
-  | 'bucket'
-  | 'rect'
-  | 'eraser'
-  | 'eyedropper'
-  | 'select'
-  | 'stamp'
-  | 'event'
+export type { EditorTool }
 
 /**
  * Vertical OSD column of editor tool toggles.

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -4,6 +4,8 @@ import type Gtk from '@girs/gtk-4.0'
 import { Canvas2DBridge } from '@gjsify/canvas2d'
 import { WebGLBridge } from '@gjsify/webgl'
 import {
+  type EditorTool,
+  type EditorViewMode,
   EngineEvent,
   type EngineEventMap,
   EngineStatus,
@@ -120,7 +122,7 @@ export class Engine extends Adw.Bin {
   }
 
   /** Forward to `Engine.setActiveTool` — writes to the session-singleton. */
-  public setActiveTool(tool: string): void {
+  public setActiveTool(tool: EditorTool): void {
     this._excalibur?.setActiveTool(tool)
   }
 
@@ -190,12 +192,12 @@ export class Engine extends Adw.Bin {
   }
 
   /** Forward to `Engine.setEditorViewMode` — toggles editor's grid view. */
-  public setEditorViewMode(mode: 'normal' | 'grid'): void {
+  public setEditorViewMode(mode: EditorViewMode): void {
     this._excalibur?.setEditorViewMode(mode)
   }
 
   /** Forward to `Engine.getEditorViewMode`. */
-  public getEditorViewMode(): 'normal' | 'grid' {
+  public getEditorViewMode(): EditorViewMode {
     return this._excalibur?.getEditorViewMode() ?? 'normal'
   }
 
@@ -203,7 +205,7 @@ export class Engine extends Adw.Bin {
    * Subscribe to view-mode changes. Disposer is captured into
    * {@link _excaliburSubscriptions} so unmap releases it.
    */
-  public onEditorViewModeChanged(cb: (mode: 'normal' | 'grid') => void): boolean {
+  public onEditorViewModeChanged(cb: (mode: EditorViewMode) => void): boolean {
     if (!this._excalibur) return false
     const dispose = this._excalibur.onEditorViewModeChanged(cb)
     this._excaliburSubscriptions.push({ close: dispose })


### PR DESCRIPTION
## Summary

Follow-up to #45 — three related bugs in the maker's startup / map-switch flow that all manifested as "ghost-tile preview hidden until I poke the UI":

### 1. Engine writes lost during startup ordering

`_hydrateSceneEditor` was awaiting `populateFromProject` first and `ensureForMap` second. `populateFromProject` calls `_setActiveTile/_setActiveLayer` which forward to `this._engine?.setActiveTile/Layer` — but `this._engine` is still null at that point (the controller hasn't built the gjs Engine widget yet), so the writes drop. The slot callback later runs `setEngineWidget` which had a "replay" block intended to handle this, but it ran synchronously the moment the gjs widget was constructed — *before* its async `initialize()` finished, so the forwarders no-op a second time (`_excalibur` still null).

**Fix**: swap the order — `ensureForMap` first (engine ready + map loaded), `populateFromProject` second. The inspector's initial writes now land on a live Excalibur engine. Removed the dead replay block from `setEngineWidget` and documented the slot-fires-before-init timing.

### 2. Short-circuit hid map-switch resyncs

`_setActiveTile` and `_setActiveLayer` returned early when the new id matched `_activeTileId`/`_activeLayerId`. Same shape of bug: the engine's session state is per-scene and resets on every `loadMap`, but the view-held ids persist. When the new map's `populateFromProject` replayed the first tile + layer, the local cache short-circuited and the engine stayed empty.

**Fix**: drop both short-circuits. Both writes are already idempotent on the engine side (`SessionState.set` notifies subscribers either way) and on the inspector side (`palette.selectTile`/`layersTab.selectLayer` are no-ops on the same id), so removing them costs nothing observable.

### 3. Tool selection desynced across map switches

`EngineController.ensureForMap` hardcoded `setActiveTool('pencil')` after every `loadMap`. The UI's `win.set-tool` GAction held the user's actual selection across scenes, so any non-pencil tool active when switching maps left the engine on pencil while the toolbar still highlighted (e.g.) eraser — the pencil preview then showed a ghost while the user thought they were erasing.

**Fix**: controller no longer touches `ActiveToolComponent`; `_hydrateSceneEditor` pushes the GAction's current state after every `ensureForMap` so the GAction stays the source of truth. First-load behaviour is unchanged because the action's default is `'pencil'`.

## Test plan

- [x] `gjsify foreach check -v -t` — all packages typecheck clean
- [x] `npm test` (engine) — 66/66 pass
- [ ] Manual: open a project from welcome view → hover with pencil tool → ghost tile appears immediately, no swatch change needed
- [ ] Manual: switch maps via atlas → entering a new scene also shows the ghost immediately
- [ ] Manual: switch to eraser, then switch maps → toolbar still shows eraser and the eraser is actually active (no silent revert to pencil)
- [ ] Manual: engine bring-up failure (rename a sprite-set asset to force it) → inspector still populates, toast shown for engine failure