### PR TITLE
feat(editor): extend canvas behind transparent headerbar (Gradia pattern)

### DIFF
--- a/apps/maker-gjs/src/widgets/scene-editor-view.blp
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.blp
@@ -16,45 +16,69 @@ template $SceneEditorView : Adw.Bin {
     };
 
     content: Adw.ToolbarView {
+      // Gradia trick: let the canvas extend *behind* the headerbar so
+      // the map fills the entire frame and the header floats on top.
+      // Combined with `top-bar-style: flat` + the bar's
+      // `["flat", "header-osd"]` classes, the headerbar drops out
+      // entirely visually — only its buttons + windowcontrols
+      // remain, sitting on the canvas like the other OSD chrome.
+      top-bar-style: flat;
+      extend-content-to-top-edge: true;
+
       [top]
       Adw.HeaderBar {
         show-end-title-buttons: true;
         show-title: false;
         styles ["flat", "header-osd"]
 
+        // Left cluster: library toggle + back-to-atlas, grouped into
+        // one OSD pill so they read as a single floating widget
+        // alongside the canvas's other OSD overlays (tool rail,
+        // history, zoom). Single `Gtk.Box [start]` rather than two
+        // separate `[start]` slots — the wrapping pill IS the OSD
+        // container, the inner buttons stay borderless `flat`.
         [start]
-        Gtk.ToggleButton sidebar_toggle {
-          icon-name: "sidebar-show-symbolic";
-          tooltip-text: _("Toggle library");
-          active: bind template.show-library bidirectional;
-          styles ["flat"]
-        }
+        Gtk.Box {
+          spacing: 2;
+          styles ["toolbar", "osd"]
 
-        [start]
-        Gtk.Button back_button {
-          action-name: "win.back-to-atlas";
-          tooltip-text: _("Back to atlas");
-          styles ["flat"]
+          Gtk.ToggleButton sidebar_toggle {
+            icon-name: "sidebar-show-symbolic";
+            tooltip-text: _("Toggle library");
+            active: bind template.show-library bidirectional;
+            styles ["flat"]
+          }
 
-          child: Gtk.Box {
-            spacing: 4;
+          Gtk.Button back_button {
+            action-name: "win.back-to-atlas";
+            tooltip-text: _("Back to atlas");
+            styles ["flat"]
 
-            Gtk.Image {
-              icon-name: "go-previous-symbolic";
-            }
+            child: Gtk.Box {
+              spacing: 4;
 
-            Gtk.Label {
-              label: _("Atlas");
-            }
-          };
+              Gtk.Image {
+                icon-name: "go-previous-symbolic";
+              }
+
+              Gtk.Label {
+                label: _("Atlas");
+              }
+            };
+          }
         }
 
         [end]
-        Gtk.ToggleButton inspector_toggle {
-          icon-name: "sidebar-show-right-symbolic";
-          tooltip-text: _("Toggle inspector");
-          active: bind template.show-inspector bidirectional;
-          styles ["flat"]
+        Gtk.Box {
+          spacing: 2;
+          styles ["toolbar", "osd"]
+
+          Gtk.ToggleButton inspector_toggle {
+            icon-name: "sidebar-show-right-symbolic";
+            tooltip-text: _("Toggle inspector");
+            active: bind template.show-inspector bidirectional;
+            styles ["flat"]
+          }
         }
       }
 

--- a/packages/gjs/src/widgets/editor/context-chip.blp
+++ b/packages/gjs/src/widgets/editor/context-chip.blp
@@ -4,7 +4,10 @@ using Adw 1;
 template $PixelRpgContextChip : Adw.Bin {
   halign: end;
   valign: start;
-  margin-top: 12;
+  // Clear the transparent floating headerbar (see floating-history).
+  // Symmetrical 60 px so the chip aligns horizontally with the
+  // history pill on the opposite side.
+  margin-top: 60;
   margin-end: 12;
 
   Gtk.Box {

--- a/packages/gjs/src/widgets/editor/floating-history.blp
+++ b/packages/gjs/src/widgets/editor/floating-history.blp
@@ -4,7 +4,11 @@ using Adw 1;
 template $PixelRpgFloatingHistory : Adw.Bin {
   halign: start;
   valign: start;
-  margin-top: 12;
+  // Clear the transparent floating headerbar which sits on top of
+  // the canvas now (see `Adw.ToolbarView.extend-content-to-top-edge`
+  // in `scene-editor-view.blp`). 60 px = header height + a 12 px
+  // breathing gap below it.
+  margin-top: 60;
   margin-start: 12;
 
   Gtk.Box {


### PR DESCRIPTION
Mirror Gradia's main canvas layout — header strip dissolves entirely visually so the map fills the window from edge to edge.

- `Adw.ToolbarView` gains `top-bar-style: flat` + `extend-content-to-top-edge: true` so the canvas extends *behind* the headerbar instead of being pushed below it.
- Headerbar buttons re-grouped into OSD pills (`["toolbar", "osd"]` boxes wrap library/back left + inspector toggle right) to match the existing FloatingHistory / FloatingZoom aesthetic.
- `FloatingHistory` + `ContextChip` margin-top bumped 12 → 60 so they don't render under the now-floating header clusters.

Window-control glyphs (close) still appear top-right with the `.header-osd` pill backing added in PR #44. Atlas view untouched.

66 tests pass; check + build clean.