### PR TITLE
feat(editor): unify floating OSD chrome — sidebar drag regions + consolidated pills

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -209,6 +209,35 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     // Ctrl+Z is a no-op but the UI affordance suggests otherwise.
     undoAction.set_enabled(false)
     redoAction.set_enabled(false)
+
+    // Sidebar toggle actions. PropertyAction wraps the
+    // SceneEditorView's boolean `show-library` / `show-inspector`
+    // properties bi-directionally — the floating OSD toggle buttons
+    // (FloatingHistory's library_toggle on the left, ContextChip's
+    // inspector_toggle on the right) drive these actions via
+    // `action-name`, and the action state follows the property
+    // automatically if the split-view changes the property through
+    // any other path (swipe-to-close on collapsed mobile, etc.).
+    //
+    // Pre-refactor these toggles were `Gtk.ToggleButton`s in the
+    // central headerbar with direct `bind template.show-library`
+    // bindings. Moving them into widgets in a different package
+    // (`packages/gjs`) means the template binding can no longer
+    // reach across — PropertyAction is the action-shaped bridge.
+    winActions.add_action(
+      new Gio.PropertyAction({
+        name: 'toggle-library',
+        object: this._scene_editor_view,
+        property_name: 'show-library',
+      }),
+    )
+    winActions.add_action(
+      new Gio.PropertyAction({
+        name: 'toggle-inspector',
+        object: this._scene_editor_view,
+        property_name: 'show-inspector',
+      }),
+    )
     this._engineCtl.onUndoChanged(({ canUndo, canRedo }) => {
       undoAction.set_enabled(canUndo)
       redoAction.set_enabled(canRedo)

--- a/apps/maker-gjs/src/widgets/scene-editor-view.blp
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.blp
@@ -27,59 +27,16 @@ template $SceneEditorView : Adw.Bin {
 
       [top]
       Adw.HeaderBar {
-        show-end-title-buttons: true;
+        // Central headerbar is intentionally empty — all controls
+        // moved into floating OSD widgets (FloatingHistory on the
+        // left, ContextChip on the right). The bar stays in the
+        // template as a Gtk.WindowHandle-providing drag region so
+        // the user can still grab the canvas-top to move the window.
+        // Window controls (X close) live on the right inspector's
+        // own flat header (see `right-inspector.blp`).
+        show-end-title-buttons: false;
         show-title: false;
-        styles ["flat", "header-osd"]
-
-        // Left cluster: library toggle + back-to-atlas, grouped into
-        // one OSD pill so they read as a single floating widget
-        // alongside the canvas's other OSD overlays (tool rail,
-        // history, zoom). Single `Gtk.Box [start]` rather than two
-        // separate `[start]` slots — the wrapping pill IS the OSD
-        // container, the inner buttons stay borderless `flat`.
-        [start]
-        Gtk.Box {
-          spacing: 2;
-          styles ["toolbar", "osd"]
-
-          Gtk.ToggleButton sidebar_toggle {
-            icon-name: "sidebar-show-symbolic";
-            tooltip-text: _("Toggle library");
-            active: bind template.show-library bidirectional;
-            styles ["flat"]
-          }
-
-          Gtk.Button back_button {
-            action-name: "win.back-to-atlas";
-            tooltip-text: _("Back to atlas");
-            styles ["flat"]
-
-            child: Gtk.Box {
-              spacing: 4;
-
-              Gtk.Image {
-                icon-name: "go-previous-symbolic";
-              }
-
-              Gtk.Label {
-                label: _("Atlas");
-              }
-            };
-          }
-        }
-
-        [end]
-        Gtk.Box {
-          spacing: 2;
-          styles ["toolbar", "osd"]
-
-          Gtk.ToggleButton inspector_toggle {
-            icon-name: "sidebar-show-right-symbolic";
-            tooltip-text: _("Toggle inspector");
-            active: bind template.show-inspector bidirectional;
-            styles ["flat"]
-          }
-        }
+        styles ["flat"]
       }
 
       content: Adw.OverlaySplitView inner_split {

--- a/packages/gjs/src/widgets/editor/context-chip.blp
+++ b/packages/gjs/src/widgets/editor/context-chip.blp
@@ -4,16 +4,33 @@ using Adw 1;
 template $PixelRpgContextChip : Adw.Bin {
   halign: end;
   valign: start;
-  // Clear the transparent floating headerbar (see floating-history).
-  // Symmetrical 60 px so the chip aligns horizontally with the
-  // history pill on the opposite side.
-  margin-top: 60;
+  // Symmetrical 12 px with FloatingHistory so both top pills sit on
+  // the same row over the canvas. Previously sat at 60 to clear the
+  // central headerbar's `[end]` cluster; that cluster moves into this
+  // chip now (inspector_toggle below) so the chip can rise to 12.
+  margin-top: 12;
   margin-end: 12;
 
   Gtk.Box {
     orientation: horizontal;
     spacing: 2;
     styles ["toolbar", "osd"]
+
+    // Library-mirror on the right edge — toggles the right inspector.
+    // Lives here (in the canvas's OSD cluster, not the inspector's
+    // own header) so the user can re-open the inspector after
+    // hiding it; if the toggle lived inside the inspector itself
+    // it would vanish along with everything else when hidden.
+    Gtk.ToggleButton inspector_toggle {
+      icon-name: "sidebar-show-right-symbolic";
+      action-name: "win.toggle-inspector";
+      tooltip-text: _("Toggle inspector");
+      styles ["flat"]
+    }
+
+    Gtk.Separator {
+      orientation: vertical;
+    }
 
     Gtk.MenuButton tile_button {
       tooltip-text: _("Active tile");

--- a/packages/gjs/src/widgets/editor/context-chip.ts
+++ b/packages/gjs/src/widgets/editor/context-chip.ts
@@ -15,6 +15,7 @@ import Template from './context-chip.blp'
  * scene editor) controls their contents.
  */
 export class ContextChip extends Adw.Bin {
+  declare _inspector_toggle: Gtk.ToggleButton
   declare _tile_button: Gtk.MenuButton
   declare _layer_button: Gtk.MenuButton
   declare _tile_name: Gtk.Label
@@ -30,7 +31,7 @@ export class ContextChip extends Adw.Bin {
       {
         GTypeName: 'PixelRpgContextChip',
         Template,
-        InternalChildren: ['tile_button', 'layer_button', 'tile_name', 'layer_name', 'tile_swatch'],
+        InternalChildren: ['inspector_toggle', 'tile_button', 'layer_button', 'tile_name', 'layer_name', 'tile_swatch'],
         Properties: {
           'tile-name': GObject.ParamSpec.string(
             'tile-name',

--- a/packages/gjs/src/widgets/editor/floating-history.blp
+++ b/packages/gjs/src/widgets/editor/floating-history.blp
@@ -4,17 +4,49 @@ using Adw 1;
 template $PixelRpgFloatingHistory : Adw.Bin {
   halign: start;
   valign: start;
-  // Clear the transparent floating headerbar which sits on top of
-  // the canvas now (see `Adw.ToolbarView.extend-content-to-top-edge`
-  // in `scene-editor-view.blp`). 60 px = header height + a 12 px
-  // breathing gap below it.
-  margin-top: 60;
+  margin-top: 12;
   margin-start: 12;
 
+  // Single top-left OSD cluster covering all navigation + history
+  // controls. Previously navigation (library toggle + back-to-atlas)
+  // lived in the central headerbar's [start] OSD pill and history
+  // (undo / redo / grid) lived here — two stacked pills at the
+  // top-left that didn't visually align. Consolidated so only one
+  // pill renders, matching the Gradia "controls float over canvas"
+  // pattern.
   Gtk.Box {
     orientation: horizontal;
     spacing: 2;
     styles ["toolbar", "osd"]
+
+    Gtk.ToggleButton library_toggle {
+      icon-name: "sidebar-show-symbolic";
+      action-name: "win.toggle-library";
+      tooltip-text: _("Toggle library");
+      styles ["flat"]
+    }
+
+    Gtk.Button back_button {
+      action-name: "win.back-to-atlas";
+      tooltip-text: _("Back to atlas");
+      styles ["flat"]
+
+      child: Gtk.Box {
+        spacing: 4;
+
+        Gtk.Image {
+          icon-name: "go-previous-symbolic";
+        }
+
+        Gtk.Label {
+          label: _("Atlas");
+        }
+      };
+    }
+
+    Gtk.Separator {
+      orientation: vertical;
+    }
 
     Gtk.Button undo_button {
       icon-name: "edit-undo-symbolic";

--- a/packages/gjs/src/widgets/editor/floating-history.ts
+++ b/packages/gjs/src/widgets/editor/floating-history.ts
@@ -16,6 +16,8 @@ import Template from './floating-history.blp'
  * actions and decides what they do.
  */
 export class FloatingHistory extends Adw.Bin {
+  declare _library_toggle: Gtk.ToggleButton
+  declare _back_button: Gtk.Button
   declare _undo_button: Gtk.Button
   declare _redo_button: Gtk.Button
   declare _grid_button: Gtk.ToggleButton
@@ -25,7 +27,7 @@ export class FloatingHistory extends Adw.Bin {
       {
         GTypeName: 'PixelRpgFloatingHistory',
         Template,
-        InternalChildren: ['undo_button', 'redo_button', 'grid_button'],
+        InternalChildren: ['library_toggle', 'back_button', 'undo_button', 'redo_button', 'grid_button'],
       },
       FloatingHistory,
     )

--- a/packages/gjs/src/widgets/editor/mode-rail.blp
+++ b/packages/gjs/src/widgets/editor/mode-rail.blp
@@ -8,24 +8,32 @@ template $PixelRpgModeRail : Adw.Bin {
     orientation: vertical;
     hexpand: true;
 
-    Gtk.Box hero_header {
-      orientation: horizontal;
-      margin-top: 12;
-      margin-start: 12;
-      margin-end: 12;
-      spacing: 4;
+    // Drag handle for the whole window — Gtk.WindowHandle treats any
+    // empty space inside as click-and-drag-to-move. The hamburger
+    // sits in the row but a stretching Box next to it leaves enough
+    // empty area to grab. Visually identical to the rest of the
+    // sidebar — no chrome / no separator, just the menu button
+    // floating against the sidebar background.
+    Gtk.WindowHandle {
+      child: Gtk.Box hero_header {
+        orientation: horizontal;
+        margin-top: 12;
+        margin-start: 12;
+        margin-end: 12;
+        spacing: 4;
 
-      Gtk.Box {
-        hexpand: true;
-      }
+        Gtk.Box {
+          hexpand: true;
+        }
 
-      Gtk.MenuButton menu_button {
-        icon-name: "open-menu-symbolic";
-        menu-model: primary_menu;
-        tooltip-text: _("Main Menu");
-        valign: start;
-        styles ["flat"]
-      }
+        Gtk.MenuButton menu_button {
+          icon-name: "open-menu-symbolic";
+          menu-model: primary_menu;
+          tooltip-text: _("Main Menu");
+          valign: start;
+          styles ["flat"]
+        }
+      };
     }
 
     Gtk.Box hero {

--- a/packages/gjs/src/widgets/editor/right-inspector.blp
+++ b/packages/gjs/src/widgets/editor/right-inspector.blp
@@ -5,6 +5,22 @@ template $PixelRpgRightInspector : Adw.Bin {
   styles ["right-inspector"]
 
   Adw.ToolbarView {
+    top-bar-style: flat;
+
+    // Thin flat header just to host the window-close X button +
+    // act as a drag region. Without it, the central canvas's
+    // headerbar reaches across the whole window width (its X
+    // ends up overlapping the inspector's first row — search
+    // field + Switch button get hidden). Moving the X here keeps
+    // it on the inspector's edge where it belongs.
+    [top]
+    Adw.HeaderBar {
+      show-title: false;
+      show-start-title-buttons: false;
+      show-end-title-buttons: true;
+      styles ["flat"]
+    }
+
     content: Gtk.ScrolledWindow {
       hexpand: true;
       vexpand: true;


### PR DESCRIPTION
Three iterations on the Gradia-pattern canvas chrome (feedback round after PR #48):

1. **Left sidebar drag region** — wrap ModeRail's hero_header in `Gtk.WindowHandle` so the sidebar top is a window-drag grip. Hamburger stays where it is, visually identical to the rest of the sidebar.
2. **Right sidebar flat header** — `RightInspector` now wraps its content in an `Adw.ToolbarView` with a thin flat `Adw.HeaderBar` carrying the window-close X (`show-end-title-buttons: true`). The central scene-editor headerbar drops the X to avoid double-buttons. Fixes the close button overlapping the inspector's search field + Switch button row.
3. **Consolidate OSD pills** — `FloatingHistory` grows `library_toggle` + `back_button` at the front; `ContextChip` grows `inspector_toggle` at the start. Central headerbar's two OSD clusters disappear. Toggles use new `Gio.PropertyAction`s (`win.toggle-library` / `win.toggle-inspector`) that wrap `SceneEditorView`'s boolean properties so the cross-package action binding stays in sync with the split-view state. Both floating widgets reset margin-top from 60 → 12.

66 tests pass; check + build clean.