### PR TITLE
feat(atlas): mirror scene editor layout — SceneInspector at outer split level

### DIFF
--- a/apps/maker-gjs/src/widgets/atlas-view.blp
+++ b/apps/maker-gjs/src/widgets/atlas-view.blp
@@ -2,6 +2,18 @@ using Gtk 4.0;
 using Adw 1;
 
 template $AtlasView : Adw.Bin {
+  // Outer split (ModeRail left) wraps another split (SceneInspector
+  // right) so both sidebars span the full window height. The central
+  // headerbar lives inside the innermost ToolbarView and only spans
+  // the canvas area between the two sidebars — title centers
+  // properly, X close stays on the inspector's own flat header.
+  //
+  // Pre-refactor SceneInspector lived inside the central
+  // ToolbarView's content (under the headerbar). User feedback:
+  // it should mirror the scene editor's layout (RightInspector at
+  // the outermost layer), which makes the title in the headerbar
+  // also centre between the sidebars instead of between the left
+  // sidebar and the window edge.
   Adw.OverlaySplitView outer_split {
     sidebar-position: start;
     min-sidebar-width: 220;
@@ -15,43 +27,53 @@ template $AtlasView : Adw.Bin {
       project-tagline: _("Atlas view");
     };
 
-    content: Adw.ToolbarView {
-      [top]
-      Adw.HeaderBar {
-        show-end-title-buttons: true;
+    content: Adw.OverlaySplitView inner_split {
+      sidebar-position: end;
+      min-sidebar-width: 280;
+      max-sidebar-width: 320;
+      collapsed: bind template.collapsed;
+      show-sidebar: bind template.show-inspector bidirectional;
 
-        [start]
-        Gtk.ToggleButton sidebar_toggle {
-          icon-name: "sidebar-show-symbolic";
-          tooltip-text: _("Toggle library");
-          active: bind template.show-library bidirectional;
+      sidebar: $PixelRpgSceneInspector inspector {};
+
+      content: Adw.ToolbarView {
+        [top]
+        Adw.HeaderBar {
+          // X close moves to the inspector's own flat header
+          // (see scene-inspector.blp). That keeps the central
+          // headerbar's right edge clean for the inspector toggle
+          // + New Scene primary action.
+          show-end-title-buttons: false;
+
+          [start]
+          Gtk.ToggleButton sidebar_toggle {
+            icon-name: "sidebar-show-symbolic";
+            tooltip-text: _("Toggle library");
+            active: bind template.show-library bidirectional;
+          }
+
+          title-widget: Adw.WindowTitle {
+            title: bind template.project-name;
+            subtitle: _("World");
+          };
+
+          [end]
+          Gtk.ToggleButton inspector_toggle {
+            icon-name: "sidebar-show-right-symbolic";
+            tooltip-text: _("Toggle inspector");
+            active: bind template.show-inspector bidirectional;
+          }
+
+          [end]
+          Gtk.Button new_scene_button {
+            label: _("New Scene");
+            action-name: "win.new-scene";
+            styles ["suggested-action", "pill"]
+          }
         }
-
-        title-widget: Adw.WindowTitle {
-          title: bind template.project-name;
-          subtitle: _("World");
-        };
-
-        [end]
-        Gtk.Button new_scene_button {
-          label: _("New Scene");
-          action-name: "win.new-scene";
-          styles ["suggested-action", "pill"]
-        }
-      }
-
-      content: Adw.OverlaySplitView inner_split {
-        sidebar-position: end;
-        min-sidebar-width: 280;
-        max-sidebar-width: 320;
-        collapsed: bind template.collapsed;
-        show-sidebar: bind template.show-inspector bidirectional;
 
         content: $PixelRpgAtlasCanvas atlas {};
-
-        sidebar: $PixelRpgSceneInspector inspector {};
       };
     };
   }
 }
-

--- a/packages/gjs/src/widgets/editor/scene-inspector.blp
+++ b/packages/gjs/src/widgets/editor/scene-inspector.blp
@@ -5,11 +5,27 @@ template $PixelRpgSceneInspector : Adw.Bin {
   styles ["scene-inspector"]
   width-request: 300;
 
-  Gtk.ScrolledWindow {
-    hscrollbar-policy: never;
-    vscrollbar-policy: automatic;
+  Adw.ToolbarView {
+    top-bar-style: flat;
 
-    child: Gtk.Box body {
+    // Thin flat header — provides the window-close X + window drag
+    // region at the inspector's top. Mirrors the pattern set up
+    // for `RightInspector` in PR #49: the atlas-view's central
+    // headerbar now stops at the inspector's left edge, so the
+    // close button lives on the inspector itself.
+    [top]
+    Adw.HeaderBar {
+      show-title: false;
+      show-start-title-buttons: false;
+      show-end-title-buttons: true;
+      styles ["flat"]
+    }
+
+    content: Gtk.ScrolledWindow {
+      hscrollbar-policy: never;
+      vscrollbar-policy: automatic;
+
+      child: Gtk.Box body {
       orientation: vertical;
       spacing: 12;
       margin-top: 16;
@@ -70,6 +86,7 @@ template $PixelRpgSceneInspector : Adw.Bin {
         title: _("No scene selected");
         description: _("Pick a scene from the atlas to inspect it.");
       }
+      };
     };
   }
 }


### PR DESCRIPTION
Atlas view brought in line with the scene editor's chrome hierarchy (PR #49 + PR #50).

- **Layout**: double-nested `Adw.OverlaySplitView` so the right SceneInspector lives at the outermost layer alongside ModeRail. Both sidebars span the full window height; the central headerbar only stretches between them, centring its title widget over the canvas.
- **SceneInspector** gets its own flat `Adw.HeaderBar` with `show-end-title-buttons: true` (drag region + X close), mirroring the RightInspector change from PR #49.
- **Central atlas headerbar** drops the X (moved to inspector) and gains an `inspector_toggle` ToggleButton in `[end]` next to the existing "New Scene" pill. User can collapse the inspector from the headerbar.

66 tests pass; check + build clean.