### PR TITLE
feat(editor): responsive breakpoints (mobile / tablet / desktop) + full sidebar drag

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.blp
+++ b/apps/maker-gjs/src/widgets/application-window.blp
@@ -8,12 +8,34 @@ template $ApplicationWindow : Adw.ApplicationWindow {
   width-request: 360;
   height-request: 480;
 
+  // Mobile (<768sp): both sidebars collapse into overlay drawers.
+  // User opens them via the floating library / inspector toggle
+  // pills (which sit on the canvas in both views).
   Adw.Breakpoint {
     condition ("max-width: 768sp")
 
     setters {
-      atlas_view.collapsed: true;
-      scene_editor_view.collapsed: true;
+      atlas_view.library-collapsed: true;
+      atlas_view.inspector-collapsed: true;
+      scene_editor_view.library-collapsed: true;
+      scene_editor_view.inspector-collapsed: true;
+    }
+  }
+
+  // Tablet (768sp ≤ width < 1024sp): only the left library
+  // collapses (it's the larger sidebar). The right inspector
+  // stays persistent because that's where the user reads scene
+  // metadata + edits properties — making it a drawer would hide
+  // their current context every time they tap outside.
+  //
+  // Desktop (≥1024sp) uses the template defaults — both sidebars
+  // persistent — so no third breakpoint needed.
+  Adw.Breakpoint {
+    condition ("min-width: 768sp and max-width: 1023sp")
+
+    setters {
+      atlas_view.library-collapsed: true;
+      scene_editor_view.library-collapsed: true;
     }
   }
 

--- a/apps/maker-gjs/src/widgets/atlas-view.blp
+++ b/apps/maker-gjs/src/widgets/atlas-view.blp
@@ -14,7 +14,7 @@ template $AtlasView : Adw.Bin {
     min-sidebar-width: 220;
     max-sidebar-width: 260;
     sidebar-width-fraction: 0.7;
-    collapsed: bind template.collapsed;
+    collapsed: bind template.library-collapsed;
     show-sidebar: bind template.show-library bidirectional;
 
     sidebar: $PixelRpgModeRail mode_rail {
@@ -26,7 +26,7 @@ template $AtlasView : Adw.Bin {
       sidebar-position: end;
       min-sidebar-width: 280;
       max-sidebar-width: 320;
-      collapsed: bind template.collapsed;
+      collapsed: bind template.inspector-collapsed;
       show-sidebar: bind template.show-inspector bidirectional;
 
       sidebar: $PixelRpgSceneInspector inspector {};

--- a/apps/maker-gjs/src/widgets/atlas-view.ts
+++ b/apps/maker-gjs/src/widgets/atlas-view.ts
@@ -40,9 +40,10 @@ export class AtlasView extends Adw.Bin {
   private _scenes: SampleScene[] = SAMPLE_SCENES
   private _teleports: SampleTeleport[] = SAMPLE_TELEPORTS
   private _projectName = SAMPLE_SCENES.length ? "Aria's Quest" : 'New Project'
-  private _collapsed = false
-  private _showLibrary = true
-  private _showInspector = true
+  private _libraryCollapsed = false
+  private _inspectorCollapsed = false
+  private _showLibrary = false
+  private _showInspector = false
   private _projectResource: GameProjectResource | null = null
 
   static {
@@ -59,10 +60,20 @@ export class AtlasView extends Adw.Bin {
             GObject.ParamFlags.READWRITE,
             'New Project',
           ),
-          collapsed: GObject.ParamSpec.boolean(
-            'collapsed',
-            'Collapsed',
-            'Whether both split views collapse to overlays (driven by the window breakpoint)',
+          // Per-sidebar collapse flags so the window breakpoint
+          // can independently switch each into drawer mode. See
+          // `scene-editor-view.ts` for the rationale.
+          'library-collapsed': GObject.ParamSpec.boolean(
+            'library-collapsed',
+            'Library Collapsed',
+            'Whether the left library sidebar collapses to an overlay (set by the window breakpoint)',
+            GObject.ParamFlags.READWRITE,
+            false,
+          ),
+          'inspector-collapsed': GObject.ParamSpec.boolean(
+            'inspector-collapsed',
+            'Inspector Collapsed',
+            'Whether the right scene-inspector sidebar collapses to an overlay (set by the window breakpoint)',
             GObject.ParamFlags.READWRITE,
             false,
           ),
@@ -71,14 +82,14 @@ export class AtlasView extends Adw.Bin {
             'Show library',
             'Whether the library mode rail is visible',
             GObject.ParamFlags.READWRITE,
-            true,
+            false,
           ),
           'show-inspector': GObject.ParamSpec.boolean(
             'show-inspector',
             'Show inspector',
             'Whether the right-side scene inspector is visible',
             GObject.ParamFlags.READWRITE,
-            true,
+            false,
           ),
         },
         Signals: {
@@ -113,18 +124,28 @@ export class AtlasView extends Adw.Bin {
     this.notify('project-name')
   }
 
-  get collapsed(): boolean {
-    return this._collapsed ?? false
+  get libraryCollapsed(): boolean {
+    return this._libraryCollapsed ?? false
   }
 
-  set collapsed(value: boolean) {
-    if (this._collapsed === value) return
-    this._collapsed = value
-    this.notify('collapsed')
+  set libraryCollapsed(value: boolean) {
+    if (this._libraryCollapsed === value) return
+    this._libraryCollapsed = value
+    this.notify('library-collapsed')
+  }
+
+  get inspectorCollapsed(): boolean {
+    return this._inspectorCollapsed ?? false
+  }
+
+  set inspectorCollapsed(value: boolean) {
+    if (this._inspectorCollapsed === value) return
+    this._inspectorCollapsed = value
+    this.notify('inspector-collapsed')
   }
 
   get showLibrary(): boolean {
-    return this._showLibrary ?? true
+    return this._showLibrary ?? false
   }
 
   set showLibrary(value: boolean) {
@@ -134,7 +155,7 @@ export class AtlasView extends Adw.Bin {
   }
 
   get showInspector(): boolean {
-    return this._showInspector ?? true
+    return this._showInspector ?? false
   }
 
   set showInspector(value: boolean) {
@@ -165,6 +186,11 @@ export class AtlasView extends Adw.Bin {
     this.signals.connect(this._atlas, 'scene-selected', (_a: AtlasCanvas, id: string) => {
       const scene = this._scenes.find((s) => s.id === id) ?? null
       this._inspector.setScene(scene, this._scenes, this._teleports, this._projectResource)
+      // Auto-show the inspector on selection — user-attention event.
+      // Atlas sidebars default to closed; tapping a scene card
+      // reveals its metadata without a manual toggle. Idempotent
+      // on a re-tap (property change is a no-op when already true).
+      this.showInspector = true
       this.emit('scene-selected', id)
     })
     this.signals.connect(this._atlas, 'scene-opened', (_a: AtlasCanvas, id: string) => {

--- a/apps/maker-gjs/src/widgets/scene-editor-view.blp
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.blp
@@ -7,7 +7,7 @@ template $SceneEditorView : Adw.Bin {
     min-sidebar-width: 220;
     max-sidebar-width: 260;
     sidebar-width-fraction: 0.7;
-    collapsed: bind template.collapsed;
+    collapsed: bind template.library-collapsed;
     show-sidebar: bind template.show-library bidirectional;
 
     sidebar: $PixelRpgModeRail mode_rail {
@@ -35,7 +35,7 @@ template $SceneEditorView : Adw.Bin {
       sidebar-position: end;
       min-sidebar-width: 280;
       max-sidebar-width: 320;
-      collapsed: bind template.collapsed;
+      collapsed: bind template.inspector-collapsed;
       show-sidebar: bind template.show-inspector bidirectional;
 
       content: $PixelRpgSceneEditor editor {};

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -51,7 +51,8 @@ export class SceneEditorView extends Adw.Bin {
   private signals = new SignalScope()
   private _projectName = "Aria's Quest"
   private _sceneName = ''
-  private _collapsed = false
+  private _libraryCollapsed = false
+  private _inspectorCollapsed = false
   private _showLibrary = true
   private _showInspector = true
   private _engine: Engine | null = null
@@ -88,26 +89,43 @@ export class SceneEditorView extends Adw.Bin {
             GObject.ParamFlags.READWRITE,
             '',
           ),
-          collapsed: GObject.ParamSpec.boolean(
-            'collapsed',
-            'Collapsed',
-            'Whether both split views collapse to overlays (driven by the window breakpoint)',
+          // Per-sidebar collapse flags so the window breakpoint can
+          // independently switch each into overlay-drawer mode. The
+          // tablet preset wants the library overlay + inspector
+          // persistent — impossible to express with a single shared
+          // `collapsed` property.
+          'library-collapsed': GObject.ParamSpec.boolean(
+            'library-collapsed',
+            'Library Collapsed',
+            'Whether the left library sidebar collapses to an overlay (set by the window breakpoint)',
             GObject.ParamFlags.READWRITE,
             false,
           ),
+          'inspector-collapsed': GObject.ParamSpec.boolean(
+            'inspector-collapsed',
+            'Inspector Collapsed',
+            'Whether the right inspector sidebar collapses to an overlay (set by the window breakpoint)',
+            GObject.ParamFlags.READWRITE,
+            false,
+          ),
+          // Both sidebars default to *closed*. On desktop the user
+          // opens them on demand from the floating toggle pills; on
+          // mobile / tablet the breakpoint-driven `collapsed` makes
+          // them drawer-style, so `show-…: false` means the drawer
+          // is hidden at startup.
           'show-library': GObject.ParamSpec.boolean(
             'show-library',
             'Show library',
             'Whether the library mode rail is visible',
             GObject.ParamFlags.READWRITE,
-            true,
+            false,
           ),
           'show-inspector': GObject.ParamSpec.boolean(
             'show-inspector',
             'Show inspector',
             'Whether the right-side inspector is visible',
             GObject.ParamFlags.READWRITE,
-            true,
+            false,
           ),
         },
         Signals: {
@@ -562,18 +580,28 @@ export class SceneEditorView extends Adw.Bin {
     this.notify('scene-name')
   }
 
-  get collapsed(): boolean {
-    return this._collapsed ?? false
+  get libraryCollapsed(): boolean {
+    return this._libraryCollapsed ?? false
   }
 
-  set collapsed(value: boolean) {
-    if (this._collapsed === value) return
-    this._collapsed = value
-    this.notify('collapsed')
+  set libraryCollapsed(value: boolean) {
+    if (this._libraryCollapsed === value) return
+    this._libraryCollapsed = value
+    this.notify('library-collapsed')
+  }
+
+  get inspectorCollapsed(): boolean {
+    return this._inspectorCollapsed ?? false
+  }
+
+  set inspectorCollapsed(value: boolean) {
+    if (this._inspectorCollapsed === value) return
+    this._inspectorCollapsed = value
+    this.notify('inspector-collapsed')
   }
 
   get showLibrary(): boolean {
-    return this._showLibrary ?? true
+    return this._showLibrary ?? false
   }
 
   set showLibrary(value: boolean) {
@@ -583,7 +611,7 @@ export class SceneEditorView extends Adw.Bin {
   }
 
   get showInspector(): boolean {
-    return this._showInspector ?? true
+    return this._showInspector ?? false
   }
 
   set showInspector(value: boolean) {

--- a/games/zelda-like/maps/kokiri-forest.json
+++ b/games/zelda-like/maps/kokiri-forest.json
@@ -123318,5 +123318,9 @@
         "name": "Camera Boundaries"
       }
     }
-  ]
+  ],
+  "editorData": {
+    "atlasX": 179,
+    "atlasY": 227
+  }
 }

--- a/packages/gjs/src/widgets/editor/mode-rail.blp
+++ b/packages/gjs/src/widgets/editor/mode-rail.blp
@@ -4,18 +4,18 @@ using Adw 1;
 template $PixelRpgModeRail : Adw.Bin {
   styles ["mode-rail"]
 
-  Gtk.Box {
-    orientation: vertical;
-    hexpand: true;
+  // The whole sidebar is a drag handle for the window — Gtk.WindowHandle
+  // passes clicks on real widgets (the menu button, the mode action
+  // rows, the footer buttons) straight to them, and treats every
+  // empty pixel between them as click-and-drag-to-move. Pre-refactor
+  // only the hero_header row carried a WindowHandle, so most of the
+  // sidebar was a dead zone for window movement.
+  Gtk.WindowHandle {
+    child: Gtk.Box {
+      orientation: vertical;
+      hexpand: true;
 
-    // Drag handle for the whole window — Gtk.WindowHandle treats any
-    // empty space inside as click-and-drag-to-move. The hamburger
-    // sits in the row but a stretching Box next to it leaves enough
-    // empty area to grab. Visually identical to the rest of the
-    // sidebar — no chrome / no separator, just the menu button
-    // floating against the sidebar background.
-    Gtk.WindowHandle {
-      child: Gtk.Box hero_header {
+      Gtk.Box hero_header {
         orientation: horizontal;
         margin-top: 12;
         margin-start: 12;
@@ -33,10 +33,9 @@ template $PixelRpgModeRail : Adw.Bin {
           valign: start;
           styles ["flat"]
         }
-      };
-    }
+      }
 
-    Gtk.Box hero {
+      Gtk.Box hero {
       orientation: vertical;
       halign: fill;
       margin-top: 4;
@@ -209,6 +208,7 @@ template $PixelRpgModeRail : Adw.Bin {
         };
       }
     }
+    };
   }
 }
 

--- a/packages/gjs/src/widgets/editor/right-inspector.blp
+++ b/packages/gjs/src/widgets/editor/right-inspector.blp
@@ -21,12 +21,18 @@ template $PixelRpgRightInspector : Adw.Bin {
       styles ["flat"]
     }
 
-    content: Gtk.ScrolledWindow {
-      hexpand: true;
-      vexpand: true;
-      hscrollbar-policy: never;
+    // Whole inspector body acts as a drag region for the window —
+    // empty space between rows / below the active tab's content
+    // grabs the window-drag; interactive widgets (list rows, the
+    // search entry, scrollbars) consume their clicks normally and
+    // bypass the WindowHandle.
+    content: Gtk.WindowHandle {
+      child: Gtk.ScrolledWindow {
+        hexpand: true;
+        vexpand: true;
+        hscrollbar-policy: never;
 
-      child: Adw.ViewStack stack {
+        child: Adw.ViewStack stack {
         vexpand: true;
 
         Adw.ViewStackPage {
@@ -60,6 +66,7 @@ template $PixelRpgRightInspector : Adw.Bin {
 
           child: $PixelRpgPropsTab props_tab {};
         }
+        };
       };
     };
 

--- a/packages/gjs/src/widgets/editor/scene-inspector.blp
+++ b/packages/gjs/src/widgets/editor/scene-inspector.blp
@@ -21,11 +21,15 @@ template $PixelRpgSceneInspector : Adw.Bin {
       styles ["flat"]
     }
 
-    content: Gtk.ScrolledWindow {
-      hscrollbar-policy: never;
-      vscrollbar-policy: automatic;
+    // Drag region — empty space inside the inspector body moves
+    // the window. Interactive widgets (Open Scene pill, teleport
+    // rows) intercept clicks normally.
+    content: Gtk.WindowHandle {
+      child: Gtk.ScrolledWindow {
+        hscrollbar-policy: never;
+        vscrollbar-policy: automatic;
 
-      child: Gtk.Box body {
+        child: Gtk.Box body {
       orientation: vertical;
       spacing: 12;
       margin-top: 16;
@@ -86,6 +90,7 @@ template $PixelRpgSceneInspector : Adw.Bin {
         title: _("No scene selected");
         description: _("Pick a scene from the atlas to inspect it.");
       }
+      };
       };
     };
   }


### PR DESCRIPTION
Four interlocking changes — the responsive groundwork the editor was missing:

1. **Sidebar drag from anywhere** — ModeRail / RightInspector / SceneInspector wrap their whole body in `Gtk.WindowHandle`. Empty space anywhere in a sidebar moves the window; interactive widgets bypass the handle.
2. **Split `collapsed` → `library-collapsed` + `inspector-collapsed`** on AtlasView + SceneEditorView so the tablet breakpoint can collapse only one side independently.
3. **Both sidebars default-closed**. On desktop the user opens them via floating toggle pills; atlas auto-shows the inspector on scene-card selection (user-attention event).
4. **Three breakpoints on ApplicationWindow**: mobile (<768sp, both collapsed), tablet (768-1023sp, library collapsed only), desktop (≥1024sp, defaults — both persistent).

Out of scope: toolbar overflow at narrow widths + inspector auto-open on tile-pick in scene editor.

66 tests pass; check + build clean.