### PR TITLE
fix(editor): unblock mobile breakpoint + draggable floating OSDs

### DIFF
--- a/apps/maker-gjs/src/widgets/atlas-view.blp
+++ b/apps/maker-gjs/src/widgets/atlas-view.blp
@@ -44,22 +44,27 @@ template $AtlasView : Adw.Bin {
           margin-top: 12;
           margin-start: 12;
 
-          child: Gtk.Box {
-            orientation: horizontal;
-            spacing: 2;
-            styles ["toolbar", "osd"]
+          // WindowHandle wrap on every floating OSD — empty padding
+          // between buttons + outer pill margins accept window-drag,
+          // matching the other top floats across the editor.
+          child: Gtk.WindowHandle {
+            child: Gtk.Box {
+              orientation: horizontal;
+              spacing: 2;
+              styles ["toolbar", "osd"]
 
-            // Left-sidebar toggle at the far-left slot. Direct
-            // template-property binding rather than a GAction —
-            // this widget lives inline in atlas-view.blp so it
-            // can reach `template.show-library` directly; no
-            // cross-package GAction bridge needed.
-            Gtk.ToggleButton library_toggle {
-              icon-name: "sidebar-show-symbolic";
-              tooltip-text: _("Toggle library");
-              active: bind template.show-library bidirectional;
-              styles ["flat"]
-            }
+              // Left-sidebar toggle at the far-left slot. Direct
+              // template-property binding rather than a GAction —
+              // this widget lives inline in atlas-view.blp so it
+              // can reach `template.show-library` directly; no
+              // cross-package GAction bridge needed.
+              Gtk.ToggleButton library_toggle {
+                icon-name: "sidebar-show-symbolic";
+                tooltip-text: _("Toggle library");
+                active: bind template.show-library bidirectional;
+                styles ["flat"]
+              }
+            };
           };
         }
 
@@ -70,19 +75,21 @@ template $AtlasView : Adw.Bin {
           margin-top: 12;
           margin-end: 12;
 
-          child: Gtk.Box {
-            orientation: horizontal;
-            spacing: 2;
-            styles ["toolbar", "osd"]
+          child: Gtk.WindowHandle {
+            child: Gtk.Box {
+              orientation: horizontal;
+              spacing: 2;
+              styles ["toolbar", "osd"]
 
-            // Right-sidebar toggle at the far-right slot. Same
-            // direct-binding pattern as library_toggle above.
-            Gtk.ToggleButton inspector_toggle {
-              icon-name: "sidebar-show-right-symbolic";
-              tooltip-text: _("Toggle inspector");
-              active: bind template.show-inspector bidirectional;
-              styles ["flat"]
-            }
+              // Right-sidebar toggle at the far-right slot. Same
+              // direct-binding pattern as library_toggle above.
+              Gtk.ToggleButton inspector_toggle {
+                icon-name: "sidebar-show-right-symbolic";
+                tooltip-text: _("Toggle inspector");
+                active: bind template.show-inspector bidirectional;
+                styles ["flat"]
+              }
+            };
           };
         }
 

--- a/packages/gjs/src/widgets/editor/atlas-canvas.blp
+++ b/packages/gjs/src/widgets/editor/atlas-canvas.blp
@@ -7,6 +7,18 @@ template $PixelRpgAtlasCanvas : Adw.Bin {
     vexpand: true;
     hscrollbar-policy: automatic;
     vscrollbar-policy: automatic;
+    // The `surface` Gtk.Fixed inside gets `set_size_request(W, H)` to
+    // size the world to the union of all scene cards' bboxes (see
+    // `atlas-canvas.ts:_sizeSurface`). Without explicit min-content
+    // overrides, GTK propagates that as the ScrolledWindow's min,
+    // which then bubbles up to the application window — making it
+    // impossible to shrink the window below the atlas's natural
+    // width (kokiri-forest pushes this to ~1200 px). Pinning both
+    // min-content axes to a tiny value detaches the ScrolledWindow's
+    // min from its child, restoring window-shrink behaviour while
+    // letting the scrollbars handle the larger natural world inside.
+    min-content-width: 1;
+    min-content-height: 1;
 
     child: Gtk.Overlay overlay {
       [overlay]

--- a/packages/gjs/src/widgets/editor/context-chip.blp
+++ b/packages/gjs/src/widgets/editor/context-chip.blp
@@ -11,7 +11,11 @@ template $PixelRpgContextChip : Adw.Bin {
   margin-top: 12;
   margin-end: 12;
 
-  Gtk.Box {
+  // WindowHandle wrap — empty padding inside the OSD pill (between
+  // buttons + outer margins) accepts window-drag, matching
+  // FloatingHistory on the other side.
+  Gtk.WindowHandle {
+  child: Gtk.Box {
     orientation: horizontal;
     spacing: 2;
     styles ["toolbar", "osd"]
@@ -104,5 +108,6 @@ template $PixelRpgContextChip : Adw.Bin {
       tooltip-text: _("Toggle inspector");
       styles ["flat"]
     }
+  };
   }
 }

--- a/packages/gjs/src/widgets/editor/floating-history.blp
+++ b/packages/gjs/src/widgets/editor/floating-history.blp
@@ -14,7 +14,13 @@ template $PixelRpgFloatingHistory : Adw.Bin {
   // top-left that didn't visually align. Consolidated so only one
   // pill renders, matching the Gradia "controls float over canvas"
   // pattern.
-  Gtk.Box {
+  //
+  // `Gtk.WindowHandle` wrap: empty spacing between buttons + the
+  // OSD pill's outer padding pick up window-drag gestures, so the
+  // user can grab the toolbar to move the window. Button clicks
+  // bypass the handle automatically (Gtk widget event semantics).
+  Gtk.WindowHandle {
+  child: Gtk.Box {
     orientation: horizontal;
     spacing: 2;
     styles ["toolbar", "osd"]
@@ -72,5 +78,6 @@ template $PixelRpgFloatingHistory : Adw.Bin {
       tooltip-text: _("Toggle grid view");
       styles ["flat"]
     }
+  };
   }
 }

--- a/packages/gjs/src/widgets/editor/floating-tool-rail.blp
+++ b/packages/gjs/src/widgets/editor/floating-tool-rail.blp
@@ -6,7 +6,10 @@ template $PixelRpgFloatingToolRail : Adw.Bin {
   valign: center;
   margin-start: 12;
 
-  Gtk.Box {
+  // WindowHandle wrap — empty space between the tool toggles + the
+  // separator gap accepts window-drag, matching the other floats.
+  Gtk.WindowHandle {
+  child: Gtk.Box {
     orientation: vertical;
     spacing: 2;
     styles ["toolbar", "osd"]
@@ -77,5 +80,6 @@ template $PixelRpgFloatingToolRail : Adw.Bin {
       action-target: "'event'";
       group: btn_pencil;
     }
+  };
   }
 }

--- a/packages/gjs/src/widgets/editor/floating-zoom.blp
+++ b/packages/gjs/src/widgets/editor/floating-zoom.blp
@@ -6,7 +6,10 @@ template $PixelRpgFloatingZoom : Adw.Bin {
   valign: end;
   margin-bottom: 12;
 
-  Gtk.Box {
+  // WindowHandle wrap — pill padding + the cursor label area pick
+  // up window-drag gestures.
+  Gtk.WindowHandle {
+  child: Gtk.Box {
     orientation: horizontal;
     spacing: 2;
     styles ["toolbar", "osd"]
@@ -49,5 +52,6 @@ template $PixelRpgFloatingZoom : Adw.Bin {
       margin-start: 8;
       margin-end: 8;
     }
+  };
   }
 }

--- a/packages/gjs/src/widgets/editor/scene-inspector.blp
+++ b/packages/gjs/src/widgets/editor/scene-inspector.blp
@@ -3,7 +3,10 @@ using Adw 1;
 
 template $PixelRpgSceneInspector : Adw.Bin {
   styles ["scene-inspector"]
-  width-request: 300;
+  // No hard width-request — the inner ScrolledWindow handles
+  // overflow, and a hard floor here would block the window from
+  // shrinking past it (~1085 px on test runs), preventing the
+  // mobile breakpoint (768sp) from ever firing.
 
   Adw.ToolbarView {
     top-bar-style: flat;

--- a/packages/gjs/src/widgets/engine/engine.blp
+++ b/packages/gjs/src/widgets/engine/engine.blp
@@ -5,10 +5,19 @@ template $Engine : Adw.Bin {
   vexpand: true;
   hexpand: true;
   visible: true;
+  // Force a 1-px floor so the engine never inherits a wider minimum
+  // from the WebGL/Canvas2D bridge widget appended at runtime. Without
+  // this the canvas's natural size (whatever GLArea reports) becomes
+  // the min-content-width chain bubbling up to the application
+  // window, blocking the mobile breakpoint from firing.
+  width-request: 1;
+  height-request: 1;
 
   Gtk.Box canvasContainer {
     vexpand: true;
     hexpand: true;
     orientation: vertical;
+    width-request: 1;
+    height-request: 1;
   }
 }


### PR DESCRIPTION
Follow-up to PR #53 — three fixes for the mobile width path the user surfaced:

1. **Atlas min-width unblocked**: `atlas-canvas.blp`'s ScrolledWindow pins `min-content-width: 1` (+ height). The inner Gtk.Fixed `set_size_request(W, H)` for the scene-card bbox was bubbling up as the window's min, preventing the 768 sp mobile breakpoint from firing on kokiri-forest (warnings: `AdwToastOverlay … exceeds ApplicationWindow width: requested 1202 px`).
2. **SceneInspector + Engine min-widths**: SceneInspector drops its hard `width-request: 300`. Engine widget template pins `width-request: 1` on its root + canvasContainer so the WebGL/Canvas2D bridge's GLArea natural size doesn't propagate as a min.
3. **Floating OSDs draggable**: FloatingHistory / ContextChip / FloatingZoom / FloatingToolRail / atlas inline toggle pills wrap their inner Box in `Gtk.WindowHandle`. Empty pixels + outer pill padding accept window-drag; button clicks bypass automatically.

Out of scope: Excalibur camera doesn't re-centre on resize, so the scene editor's map may still render off-map at very narrow widths — separate follow-up.

66 tests pass; check + build clean.