### PR TITLE
fix(editor): AdwViewStack non-homogeneous + force engine widget min:1

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.blp
+++ b/apps/maker-gjs/src/widgets/application-window.blp
@@ -43,6 +43,15 @@ template $ApplicationWindow : Adw.ApplicationWindow {
     child: Adw.ViewStack stack {
       vexpand: true;
       hexpand: true;
+      // Default is `true`, which measures every page and uses the
+      // max as the stack's size. With the scene editor's WebGL
+      // canvas reporting a large natural width (~1200 px), that
+      // bubbled up as the application window's minimum even while
+      // the atlas view was shown — blocking the mobile breakpoint
+      // from firing at <768 sp. Setting both to false makes the
+      // stack track only the visible page's measurement.
+      hhomogeneous: false;
+      vhomogeneous: false;
 
       Adw.ViewStackPage {
         name: "welcome";

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -292,6 +292,14 @@ export class Engine extends Adw.Bin {
     const widget = useFallback ? new Canvas2DBridge() : new WebGLBridge()
     widget.set_hexpand(true)
     widget.set_vexpand(true)
+    // Force a 1-px floor on the GLArea / Canvas2D widget itself. Without
+    // this it reports the canvas's natural framebuffer width (e.g.,
+    // 1202 px on kokiri-forest) as its minimum, which propagates up
+    // through the canvasContainer Box → engine widget → ToolbarView →
+    // ApplicationWindow and blocks the mobile breakpoint. The widget
+    // still fills its hexpand/vexpand allocation; we're only releasing
+    // the *minimum*, not the natural target.
+    widget.set_size_request(1, 1)
     // The WebGL bridge is a `Gtk.GLArea`, which defaults to an opaque
     // framebuffer. Excalibur clears with `Color.Transparent`, but
     // without `has-alpha` the alpha channel is dropped by GLArea


### PR DESCRIPTION
Follow-up to PR #54 — the mobile-width warnings persisted because earlier fixes only addressed the visible view's chain.

**Root cause**: `AdwViewStack` defaults to `hhomogeneous: true`, which measures every page and uses the max width as the stack's size. The scene editor's WebGL canvas (~1200 px natural framebuffer) was leaking into the atlas view's layout request, blocking the mobile breakpoint from firing.

**Fixes**:
1. Set `hhomogeneous: false` + `vhomogeneous: false` on the ViewStack so only the visible page's measurement counts.
2. `engine.ts` forces `widget.set_size_request(1, 1)` on the WebGL/Canvas2D bridge so it doesn't propagate its framebuffer's natural width as a min.

Window now shrinks freely to the app's own 360 px floor; the 768 sp mobile breakpoint fires correctly.

66 tests pass; check + build clean.