### PR TITLE
chore: rename gjsify config key esbuild → bundler

### DIFF
--- a/apps/game-browser/gjsify.config.js
+++ b/apps/game-browser/gjsify.config.js
@@ -11,7 +11,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'))
 
 export default {
-  esbuild: {
+  // gjsify renamed `esbuild` → `bundler` (RolldownOptions) ahead
+  // of the 0.5.0 engine swap. `define` + `loader` carry over.
+  bundler: {
     define: {
       'process.env.__EX_VERSION': JSON.stringify(pkg.version),
       'process.env.NODE_ENV': JSON.stringify('production'),

--- a/apps/maker-gjs/gjsify.config.js
+++ b/apps/maker-gjs/gjsify.config.js
@@ -20,7 +20,11 @@ const GJS_CONSOLE = process.env.GJS_CONSOLE || '/usr/bin/env -S gjs'
 const PKGDATADIR = process.env.PKGDATADIR || DATADIR
 
 export default {
-  esbuild: {
+  // gjsify renamed the `esbuild` config key to `bundler` (typed as
+  // RolldownOptions) ahead of the 0.5.0 engine swap from esbuild
+  // to Rolldown. The `define` + `loader` keys are stable across
+  // the rename — gjsify's plugin layer translates them either way.
+  bundler: {
     define: {
       __APPLICATION_ID__: JSON.stringify(APPLICATION_ID),
       __RESOURCES_PATH__: JSON.stringify(RESOURCES_PATH),

--- a/games/zelda-like/maps/kokiri-forest.json
+++ b/games/zelda-like/maps/kokiri-forest.json
@@ -123320,7 +123320,7 @@
     }
   ],
   "editorData": {
-    "atlasX": 179,
+    "atlasX": 284,
     "atlasY": 227
   }
 }


### PR DESCRIPTION
Silences the gjsify deprecation warning ahead of the 0.5.0 engine swap from esbuild → Rolldown. The 'bundler' key is the new name for the same config block; 'define' + 'loader' carry over verbatim.