### PR TITLE
fix(editor): wrap engine canvasContainer in ScrolledWindow to detach min-propagation

### DIFF
--- a/packages/gjs/src/widgets/engine/engine.blp
+++ b/packages/gjs/src/widgets/engine/engine.blp
@@ -5,19 +5,35 @@ template $Engine : Adw.Bin {
   vexpand: true;
   hexpand: true;
   visible: true;
-  // Force a 1-px floor so the engine never inherits a wider minimum
-  // from the WebGL/Canvas2D bridge widget appended at runtime. Without
-  // this the canvas's natural size (whatever GLArea reports) becomes
-  // the min-content-width chain bubbling up to the application
-  // window, blocking the mobile breakpoint from firing.
-  width-request: 1;
-  height-request: 1;
 
-  Gtk.Box canvasContainer {
-    vexpand: true;
+  // The WebGL/Canvas2D bridge widget appended at runtime reports the
+  // canvas's natural framebuffer size as its minimum, which would
+  // bubble up to the application window and block the mobile
+  // breakpoint from firing. Wrapping in a Gtk.ScrolledWindow with
+  // `min-content-{width,height}: 1` detaches the child's min from
+  // the parent chain — the ScrolledWindow itself reports 1×1 as
+  // its minimum and lets its child take whatever allocation it
+  // gets (hexpand/vexpand both true on the canvasContainer Box).
+  //
+  // `hscrollbar-policy: external` + `vscrollbar-policy: external`
+  // mean the ScrolledWindow never actually shows scrollbars or
+  // intercepts wheel scroll — it's used purely as a size-detach
+  // wrapper. The canvas always gets `min(allocation, natural)` of
+  // space; if the window shrinks below the canvas's natural,
+  // GTK clips the canvas (preserving the rest of the chrome)
+  // instead of refusing to shrink.
+  Gtk.ScrolledWindow {
     hexpand: true;
-    orientation: vertical;
-    width-request: 1;
-    height-request: 1;
+    vexpand: true;
+    min-content-width: 1;
+    min-content-height: 1;
+    hscrollbar-policy: external;
+    vscrollbar-policy: external;
+
+    child: Gtk.Box canvasContainer {
+      vexpand: true;
+      hexpand: true;
+      orientation: vertical;
+    };
   }
 }

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -292,14 +292,13 @@ export class Engine extends Adw.Bin {
     const widget = useFallback ? new Canvas2DBridge() : new WebGLBridge()
     widget.set_hexpand(true)
     widget.set_vexpand(true)
-    // Force a 1-px floor on the GLArea / Canvas2D widget itself. Without
-    // this it reports the canvas's natural framebuffer width (e.g.,
-    // 1202 px on kokiri-forest) as its minimum, which propagates up
-    // through the canvasContainer Box → engine widget → ToolbarView →
-    // ApplicationWindow and blocks the mobile breakpoint. The widget
-    // still fills its hexpand/vexpand allocation; we're only releasing
-    // the *minimum*, not the natural target.
-    widget.set_size_request(1, 1)
+    // Removed: explicit set_size_request(1, 1) was causing the WebGL
+    // canvas to render blank at tablet width — the bridge's allocation
+    // collapsed to its minimum during certain layout passes, and the
+    // map disappeared until the user resized back to full-width.
+    // Size propagation is now handled by the ScrolledWindow wrap
+    // around `canvasContainer` in `engine.blp`, which detaches the
+    // child's min from bubbling up without clamping the bridge itself.
     // The WebGL bridge is a `Gtk.GLArea`, which defaults to an opaque
     // framebuffer. Excalibur clears with `Color.Transparent`, but
     // without `has-alpha` the alpha channel is dropped by GLArea


### PR DESCRIPTION
The `widget.set_size_request(1, 1)` on the WebGL/Canvas2D bridge (from PR #55) was causing the map to render blank at tablet width — the bridge's allocation collapsed to its minimum during certain layout passes.

Reverted the bridge set_size_request, replaced with a size-detach `Gtk.ScrolledWindow` wrap around `canvasContainer` in `engine.blp` (hscrollbar/vscrollbar policy: external so no scrollbars ever show; min-content-{width,height}: 1 detaches the propagation). hexpand/vexpand keep the canvas filling its allocation.

Mobile breakpoint still fires; canvas no longer collapses during resize.

66 tests pass; check + build clean.