### PR TITLE
fix(maker): revert esbuild→bundler rename — broke runtime define substitution

### DIFF
--- a/apps/game-browser/gjsify.config.js
+++ b/apps/game-browser/gjsify.config.js
@@ -11,9 +11,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'))
 
 export default {
-  // gjsify renamed `esbuild` → `bundler` (RolldownOptions) ahead
-  // of the 0.5.0 engine swap. `define` + `loader` carry over.
-  bundler: {
+  // Sticking with `esbuild` legacy key — see the corresponding
+  // comment in `apps/maker-gjs/gjsify.config.js`. Naive rename to
+  // `bundler` breaks `define` substitution (lives under
+  // `transform.define` in RolldownOptions) and drops `loader`
+  // entries. Migrate when gjsify 0.5.0 lands with concrete
+  // migration notes.
+  esbuild: {
     define: {
       'process.env.__EX_VERSION': JSON.stringify(pkg.version),
       'process.env.NODE_ENV': JSON.stringify('production'),

--- a/apps/maker-gjs/gjsify.config.js
+++ b/apps/maker-gjs/gjsify.config.js
@@ -20,11 +20,17 @@ const GJS_CONSOLE = process.env.GJS_CONSOLE || '/usr/bin/env -S gjs'
 const PKGDATADIR = process.env.PKGDATADIR || DATADIR
 
 export default {
-  // gjsify renamed the `esbuild` config key to `bundler` (typed as
-  // RolldownOptions) ahead of the 0.5.0 engine swap from esbuild
-  // to Rolldown. The `define` + `loader` keys are stable across
-  // the rename — gjsify's plugin layer translates them either way.
-  bundler: {
+  // Sticking with the legacy `esbuild` config key on purpose —
+  // gjsify will rename it to `bundler` (RolldownOptions) in 0.5.0,
+  // but the new schema nests `define` under `transform.define` and
+  // silently discards `loader` (Rolldown infers module types from
+  // extensions). A naive flat rename breaks `__APPLICATION_ID__`
+  // resolution at runtime + drops the .glsl/.png loader hints
+  // Excalibur needs. We accept the deprecation warning until
+  // gjsify 0.5.0 ships with documented migration notes for both
+  // pieces. See `refs/gjsify/packages/infra/cli/src/utils/
+  // normalize-bundler-options.ts` for the current mapping.
+  esbuild: {
     define: {
       __APPLICATION_ID__: JSON.stringify(APPLICATION_ID),
       __RESOURCES_PATH__: JSON.stringify(RESOURCES_PATH),


### PR DESCRIPTION
PR #56's flat rename broke `__APPLICATION_ID__` resolution at runtime — `bundler` (RolldownOptions) nests `define` under `transform.define` and silently discards `loader`. Reverted to `esbuild:` with a comment explaining the trap. The deprecation warning is purely informational until 0.5.0 lands with migration notes.