### PR TITLE
fix(engine): skip 0×0 canvas resize to keep WebGL framebuffer alive

### DIFF
--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -333,6 +333,20 @@ export class Engine extends Adw.Bin {
       canvas.height = widget.get_allocated_height() || 600
 
       widget.onResize((w: number, h: number) => {
+        // Defend against transient 0 × 0 allocations during the
+        // mobile breakpoint reflow. When the OverlaySplitView
+        // switches its sidebar from persistent → overlay-drawer mode,
+        // the canvas widget's allocation briefly passes through 0 in
+        // one axis before settling on the new layout. Assigning
+        // `canvas.width = 0` resets the WebGL framebuffer to a 0-px
+        // viewport — Excalibur's render passes silently no-op against
+        // that, and the framebuffer doesn't recover when a subsequent
+        // positive allocation arrives (the GL context's draw state
+        // ends up stale). User-visible: map disappears entirely on
+        // resize to mobile, only the scratchpad backdrop remains.
+        // Skipping the 0-allocation lets the canvas keep its last
+        // valid size until the layout settles.
+        if (w === 0 || h === 0) return
         canvas.width = w
         canvas.height = h
         try {


### PR DESCRIPTION
Root cause for the 'map disappears at mobile width' bug. When the breakpoint flips the OverlaySplitView's sidebar to overlay-drawer mode, the canvas widget's allocation briefly passes through 0 in one axis. Our resize handler wrote `canvas.width = 0` / `canvas.height = 0` for that transient, which reset the WebGL framebuffer to a 0-pixel viewport — Excalibur's draw state didn't recover on subsequent positive allocations. Map vanished, only scratchpad remained.

Fix: early-return from onResize when w or h is 0. Canvas keeps its last valid framebuffer through the layout transient.

66 tests pass; check + build clean.