### PR TITLE
feat(welcome): templates + CTA reflow via FlowBox, subtitle drops min char-width

### DIFF
--- a/apps/maker-gjs/src/widgets/welcome-view.blp
+++ b/apps/maker-gjs/src/widgets/welcome-view.blp
@@ -198,16 +198,31 @@ template $WelcomeView : Adw.Bin {
               label: _("Draw maps from tilesets, place a hero and NPCs, hook scenes together with teleports, and script events.");
               halign: center;
               wrap: true;
+              wrap-mode: word_char;
               justify: center;
-              max-width-chars: 48;
+              // No `max-width-chars` here — at narrow widths it
+              // would clamp the label's min to ~48 characters,
+              // forcing the whole hero column wider than the
+              // mobile breakpoint can accommodate. With just
+              // `wrap: true` the label flows to whatever
+              // allocation it gets.
               margin-bottom: 24;
               styles ["dim-label"]
             }
 
-            Gtk.Box cta_box {
+            // FlowBox (not Box) so the two CTA pills stack
+            // vertically once the available width drops below
+            // their combined natural width — mobile-friendly
+            // without a JS-driven orientation switch.
+            Gtk.FlowBox cta_box {
               orientation: horizontal;
               halign: center;
-              spacing: 8;
+              selection-mode: none;
+              min-children-per-line: 1;
+              max-children-per-line: 2;
+              column-spacing: 8;
+              row-spacing: 8;
+              homogeneous: false;
               margin-bottom: 36;
 
               Gtk.Button create_button {
@@ -228,11 +243,21 @@ template $WelcomeView : Adw.Bin {
               styles ["caption-heading", "dim-label"]
             }
 
-            Gtk.Grid templates_grid {
-              row-spacing: 10;
+            // FlowBox replaces the previous fixed 3-column Grid so
+            // template cards reflow per available width:
+            // ~3 cards / row at the desktop clamp maximum (720),
+            // 2 cards mid-width, 1 card at narrow mobile widths.
+            // `homogeneous: true` keeps every visible card the
+            // same size; the JS side just appends children, no
+            // row/col math.
+            Gtk.FlowBox templates_grid {
+              halign: fill;
+              selection-mode: none;
+              min-children-per-line: 1;
+              max-children-per-line: 3;
               column-spacing: 10;
-              column-homogeneous: true;
-              halign: center;
+              row-spacing: 10;
+              homogeneous: true;
               margin-bottom: 12;
             }
           };

--- a/apps/maker-gjs/src/widgets/welcome-view.ts
+++ b/apps/maker-gjs/src/widgets/welcome-view.ts
@@ -31,7 +31,7 @@ export class WelcomeView extends Adw.Bin {
   declare _open_button: Gtk.Button
   declare _browse_button: Gtk.Button
   declare _tour_button: Gtk.Button
-  declare _templates_grid: Gtk.Grid
+  declare _templates_grid: Gtk.FlowBox
   declare _recents_list: Gtk.ListBox
   declare _empty_recents_row: Adw.ActionRow
 
@@ -156,14 +156,15 @@ export class WelcomeView extends Adw.Bin {
   }
 
   private _buildTemplateGrid(): void {
-    // Five templates ship today; three columns keep the grid to two rows
-    // and the cards small enough that the toast overlay isn't forced
-    // outside the window's vertical allocation.
-    const cols = 3
-    STARTER_TEMPLATES.forEach((template, index) => {
+    // FlowBox handles the row/col math itself — cards reflow per
+    // allocated width thanks to the `max-children-per-line: 3` cap
+    // (see welcome-view.blp). `append` puts each card at the next
+    // flow position; no manual index → (row, col) translation
+    // needed.
+    for (const template of STARTER_TEMPLATES) {
       const button = this._buildTemplateCard(template)
-      this._templates_grid.attach(button, index % cols, Math.floor(index / cols), 1, 1)
-    })
+      this._templates_grid.append(button)
+    }
   }
 
   private _buildTemplateCard(template: { id: string; name: string; caption: string; projectPath: string; accentColor: string }): Gtk.Button {


### PR DESCRIPTION
PR #60 made the welcome view's chrome responsive — this PR makes the *content* inside responsive too. Templates Grid → FlowBox (1-3 cards per line based on width); CTA Box → FlowBox (pills stack vertically on narrow); subtitle drops `max-width-chars: 48` so it wraps to any allocation. Welcome now renders cleanly across desktop / tablet / mobile.

Known follow-up: `PixelRpgFloatingZoom` snapshot-without-allocation warning during resize transients — non-blocking, investigating separately.

66 tests pass; check + build clean.