### PR TITLE
fix(engine): keep game loop alive across breakpoint reflow (vfunc_unmap → vfunc_unroot)

### DIFF
--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -354,20 +354,12 @@ export class Engine extends Adw.Bin {
         // or AdwOverlaySplitView animates its sidebar; coalescing
         // to ~33 ms keeps the per-frame work bounded.
         //
-        // Why both `screen.resolution = …` AND
-        // `applyResolutionAndViewport()`: Excalibur's
-        // `FillContainer` DisplayMode normally recalculates its
-        // resolution from the parent element via a `ResizeObserver`
-        // — but in GJS the ResizeObserver doesn't see Gtk
-        // allocation changes, so Excalibur never learns the
-        // canvas has been resized. Setting `screen.resolution`
-        // explicitly here gives it the new dimensions; the
-        // subsequent `applyResolutionAndViewport()` propagates
-        // them into the canvas backing store + WebGL viewport.
-        // Without the explicit resolution write, the apply call
-        // keeps reconfiguring at the initial size and the
-        // user sees a blank canvas at every resize except the
-        // first paint.
+        // Excalibur's `FillContainer` DisplayMode recomputes its
+        // resolution from `canvas.offsetWidth/Height` on every
+        // `ResizeObserver` fire — gjsify >=0.4.29 returns the live
+        // GTK allocation from both the canvas's own override and
+        // the ancestor cache written by `notifyElementResize()`, so
+        // a plain `applyResolutionAndViewport()` is enough.
         this._pendingResize = { w, h }
         if (this._resizeTimeoutId != null) return
         this._resizeTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 33, () => {
@@ -378,7 +370,6 @@ export class Engine extends Adw.Bin {
           const screen = this._excalibur?.excalibur.screen
           if (!screen) return GLib.SOURCE_REMOVE
           try {
-            screen.resolution = { width: pending.w, height: pending.h }
             screen.applyResolutionAndViewport()
           } catch {
             // screen not ready yet — ignore
@@ -448,11 +439,20 @@ export class Engine extends Adw.Bin {
   }
 
   // Tear down the Excalibur engine + its event bridge before GJS starts
-  // reclaiming the widget. Running this in `vfunc_unmap` (not in dispose)
-  // keeps us off the GC path, which would otherwise trigger
-  // "Attempting to run a JS callback during garbage collection" criticals
-  // on app exit.
-  vfunc_unmap(): void {
+  // reclaiming the widget. We hook `vfunc_unroot` (widget detached from
+  // the widget tree) rather than `vfunc_unmap` (widget transiently
+  // hidden), because Adw.Breakpoint reflow unmaps the engine widget when
+  // the OverlaySplitView collapses past the tablet breakpoint — `unmap`
+  // fired teardown would stop the Excalibur game loop on every shrink
+  // and the canvas would go blank for the rest of the session
+  // (Excalibur.stop() → cancelAnimationFrame → frame callback cleared →
+  // never recovers). `unroot` only fires on true removal from the tree
+  // (parent.remove() / window.destroy()), which is what we want.
+  //
+  // Keeping the work out of `vfunc_dispose` avoids the
+  // "Attempting to run a JS callback during garbage collection"
+  // criticals on app exit.
+  vfunc_unroot(): void {
     for (const subscription of this._excaliburSubscriptions) {
       try {
         subscription.close()
@@ -492,7 +492,7 @@ export class Engine extends Adw.Bin {
     this._excalibur?.events.clear()
     this._excalibur = null
 
-    super.vfunc_unmap()
+    super.vfunc_unroot()
   }
 
   private async _waitForReady(): Promise<void> {

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -354,26 +354,32 @@ export class Engine extends Adw.Bin {
         // or AdwOverlaySplitView animates its sidebar; coalescing
         // to ~33 ms keeps the per-frame work bounded.
         //
-        // Critically, we no longer write `canvas.width = w` /
-        // `canvas.height = h` ourselves. Setting those properties
-        // discards the WebGL context's framebuffer + clears all
-        // bound shader / texture state (browser semantics — and
-        // gjsify's canvas wrapper follows it). Excalibur's
-        // initialised GL handles become dangling pointers into a
-        // recreated context; subsequent draw calls silently no-op
-        // and the user sees a blank canvas that doesn't recover
-        // when they grow the window back. Excalibur's
-        // `FillContainer` DisplayMode + `applyResolutionAndViewport`
-        // already manage the canvas backing store internally, so
-        // our job here is just to nudge that recalc after the
-        // outer widget's allocation settles.
+        // Why both `screen.resolution = …` AND
+        // `applyResolutionAndViewport()`: Excalibur's
+        // `FillContainer` DisplayMode normally recalculates its
+        // resolution from the parent element via a `ResizeObserver`
+        // — but in GJS the ResizeObserver doesn't see Gtk
+        // allocation changes, so Excalibur never learns the
+        // canvas has been resized. Setting `screen.resolution`
+        // explicitly here gives it the new dimensions; the
+        // subsequent `applyResolutionAndViewport()` propagates
+        // them into the canvas backing store + WebGL viewport.
+        // Without the explicit resolution write, the apply call
+        // keeps reconfiguring at the initial size and the
+        // user sees a blank canvas at every resize except the
+        // first paint.
         this._pendingResize = { w, h }
         if (this._resizeTimeoutId != null) return
         this._resizeTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 33, () => {
           this._resizeTimeoutId = null
+          const pending = this._pendingResize
           this._pendingResize = null
+          if (!pending) return GLib.SOURCE_REMOVE
+          const screen = this._excalibur?.excalibur.screen
+          if (!screen) return GLib.SOURCE_REMOVE
           try {
-            this._excalibur?.excalibur.screen.applyResolutionAndViewport()
+            screen.resolution = { width: pending.w, height: pending.h }
+            screen.applyResolutionAndViewport()
           } catch {
             // screen not ready yet — ignore
           }

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -1,5 +1,4 @@
 import Adw from '@girs/adw-1'
-import GLib from '@girs/glib-2.0'
 import GObject from '@girs/gobject-2.0'
 import type Gtk from '@girs/gtk-4.0'
 import { Canvas2DBridge } from '@gjsify/canvas2d'
@@ -63,17 +62,6 @@ export class Engine extends Adw.Bin {
   private _excalibur: ExcaliburEngine | null = null
   private _ready = false
   private _excaliburSubscriptions: Subscription[] = []
-  /**
-   * Pending resize state — the latest (w, h) the GLArea has reported
-   * since the last time we actually pushed it into the canvas /
-   * Excalibur viewport. We frame-throttle resize handling because
-   * each `canvas.width = …` / `applyResolutionAndViewport()` pair
-   * is expensive (framebuffer reallocation + GL state reset), and
-   * Gtk fires resize events ~60/s while the user drags a window
-   * edge or the Adw.OverlaySplitView animates its sidebar in/out.
-   */
-  private _pendingResize: { w: number; h: number } | null = null
-  private _resizeTimeoutId: number | null = null
 
   public status: EngineStatus = EngineStatus.INITIALIZING
   public readonly events = new EventEmitter<EngineEventMap>()
@@ -344,39 +332,18 @@ export class Engine extends Adw.Bin {
       canvas.width = widget.get_allocated_width() || 800
       canvas.height = widget.get_allocated_height() || 600
 
-      widget.onResize((w: number, h: number) => {
-        // Defend against transient 0 × 0 allocations during the
-        // mobile breakpoint reflow — Excalibur's screen API would
-        // happily reconfigure to a 0 px viewport.
-        if (w === 0 || h === 0) return
-        // Frame-throttle the viewport recalc. Gtk emits resize
-        // events ~60 / second while the user drags a window edge
-        // or AdwOverlaySplitView animates its sidebar; coalescing
-        // to ~33 ms keeps the per-frame work bounded.
-        //
-        // Excalibur's `FillContainer` DisplayMode recomputes its
-        // resolution from `canvas.offsetWidth/Height` on every
-        // `ResizeObserver` fire — gjsify >=0.4.29 returns the live
-        // GTK allocation from both the canvas's own override and
-        // the ancestor cache written by `notifyElementResize()`, so
-        // a plain `applyResolutionAndViewport()` is enough.
-        this._pendingResize = { w, h }
-        if (this._resizeTimeoutId != null) return
-        this._resizeTimeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 33, () => {
-          this._resizeTimeoutId = null
-          const pending = this._pendingResize
-          this._pendingResize = null
-          if (!pending) return GLib.SOURCE_REMOVE
-          const screen = this._excalibur?.excalibur.screen
-          if (!screen) return GLib.SOURCE_REMOVE
-          try {
-            screen.applyResolutionAndViewport()
-          } catch {
-            // screen not ready yet — ignore
-          }
-          return GLib.SOURCE_REMOVE
-        })
-      })
+      // No app-side resize handling: Excalibur's `FillContainer`
+      // DisplayMode owns the canvas backing store via its own
+      // `ResizeObserver` on `canvas.parentElement`. With gjsify
+      // >=0.4.29 returning the live GTK allocation from
+      // `HTMLElement.{offset,client}Width/Height` (canvas override +
+      // ancestor cache written by `notifyElementResize()`), every
+      // bridge resize signal fires Excalibur's observer in the
+      // following microtask, which recomputes the resolution and
+      // calls `applyResolutionAndViewport()` itself. Our previous
+      // 33 ms throttle layered a second apply call on top, which is
+      // redundant; removing it simplifies the widget without
+      // changing observable behaviour.
 
       try {
         const engine = new ExcaliburEngine(canvas)
@@ -461,19 +428,6 @@ export class Engine extends Adw.Bin {
       }
     }
     this._excaliburSubscriptions = []
-
-    // Drop the pending resize-throttle timer so it doesn't fire
-    // after the engine is torn down and try to write into a
-    // null `_excalibur`.
-    if (this._resizeTimeoutId != null) {
-      try {
-        GLib.source_remove(this._resizeTimeoutId)
-      } catch {
-        // source may already have fired or been removed
-      }
-      this._resizeTimeoutId = null
-      this._pendingResize = null
-    }
 
     if (this._styleManagerHandlerId) {
       try {


### PR DESCRIPTION
## Summary

The map disappeared and stayed gone when the editor window crossed the tablet breakpoint (~768 px / ~1024 px depending on view). Root cause was in **`Engine.vfunc_unmap`** in `packages/gjs/src/widgets/engine/engine.ts`:

  - `vfunc_unmap` unconditionally tore the Excalibur engine down — cleared subscriptions, removed timers, called `excalibur.stop()` → `cancelAnimationFrame` → cleared the frame callback.
  - GTK4 fires `unmap` on **transient** invisibility too, not only on destroy. AdwOverlaySplitView's tablet-breakpoint reflow unmaps the scene-editor's children mid-animation. The engine stopped its game loop every time the user shrank past the breakpoint, and never recovered (Excalibur.stop() is permanent; no auto-restart on next map switch). The canvas sat empty showing through to the CSS scratchpad backdrop.

Fix: **move the teardown from `vfunc_unmap` to `vfunc_unroot`** (true detach from the widget tree — `parent.remove()` / `window.destroy()`). Same teardown logic, just fires on real removal instead of every transient hide. App-exit GC criticals avoided per the original constraint (still NOT in `vfunc_dispose`).

Companion change: drop the explicit `screen.resolution = { … }` write inside the resize throttle. With [gjsify#327](https://github.com/gjsify/gjsify/pull/327) (merged) + [gjsify#329](https://github.com/gjsify/gjsify/pull/329) (CI-green) the polyfill returns the live GTK allocation from `HTMLElement.offsetWidth/Height` + `clientWidth/Height`. Excalibur's own `FillContainer` `ResizeObserver` path now reads the new dimensions correctly and writes `screen.resolution` itself; a plain `applyResolutionAndViewport()` is enough.

Follow-up commit on this PR: **drop the resize throttle entirely** — Excalibur's own observer handles every resize, our 33 ms throttle was just layering a duplicate `applyResolutionAndViewport()` on top. Removes `_pendingResize` / `_resizeTimeoutId` + the `GLib` import.

## Root-cause trace

Confirmed live in the running editor via diagnostic instrumentation:

- `rAF` wrapper logged zero exceptions → Excalibur's mainloop was **not** throwing (eliminated the "update() throws → mainloop catch → cancel → loop dies" theory).
- `cancelAnimationFrame` wrapper captured **exactly one** call, with stack `vfunc_unmap → excalibur.stop() → cancelAnimationFrame`.
- Heartbeat (`excalibur.stats.currFrame.id`) froze at the moment of that single cancel; clock kept ticking but no new frames rendered.

The earlier "set `screen.resolution` explicitly" commit on this branch was diagnostic — it confirmed Excalibur was reaching the apply call with correct dimensions, but the rendered output stayed blank, pointing at the loop being dead rather than the resolution being wrong.

## Related

- gjsify#330 (per-id `cancelAnimationFrame` on `WebGLBridge`) closes the same incident on the bridge side — the next library that makes the same teardown-in-unmap mistake won't kill the loop catastrophically.
- PixelRPG/map-editor#68 documents the lifecycle gotcha in `docs/concepts/responsive-chrome.md` so the next contributor doesn't re-hit it.

## Test plan

- [x] Editor smoke: launch maker-gjs, load `kokiri-forest`, shrink window past the tablet breakpoint, wait ~5 s, drag back wider — map stays visible throughout (confirmed locally with screenshot at ~540 px width showing rendered map).
- [x] No regressions on app exit (engine teardown still runs from `vfunc_unroot` when the window is destroyed).
- [x] Throttle-removal commit: `gjsify foreach build` clean; resize handling continues through Excalibur's observer.

## Notes

The commit history on this branch has three commits: the first (`96f8117`) introduced the `screen.resolution` workaround that turned out to be diagnostic rather than the actual fix; the second (`6b7e633`) lands the actual `vfunc_unmap` → `vfunc_unroot` fix; the third (`07b694e`) drops the now-redundant resize throttle. **Squash-merge** to land a single clean commit.