### PR TITLE
docs: replace yarn cmd refs with gjsify equivalents

### DIFF
--- a/apps/game-browser/README.md
+++ b/apps/game-browser/README.md
@@ -7,8 +7,8 @@ This app is the **seed for multi-platform game export**: the long-term plan is f
 ## Run
 
 ```bash
-yarn workspace @pixelrpg/game-browser build
-yarn workspace @pixelrpg/game-browser start
+gjsify workspace @pixelrpg/game-browser build
+gjsify workspace @pixelrpg/game-browser start
 ```
 
 - `build` runs `gjsify build --app browser` for `src/main.ts` into `dist/main.js`, then copies `public/index.html` into `dist/`.

--- a/apps/maker-gjs/README.md
+++ b/apps/maker-gjs/README.md
@@ -7,11 +7,11 @@ Single-process: the [`@pixelrpg/engine`](../../packages/engine) (Excalibur.js) r
 ## Run
 
 ```bash
-yarn workspace @pixelrpg/maker-gjs build
-yarn workspace @pixelrpg/maker-gjs start
+gjsify workspace @pixelrpg/maker-gjs build
+gjsify workspace @pixelrpg/maker-gjs start
 
 # With GTK Inspector for debugging
-yarn workspace @pixelrpg/maker-gjs start:debug
+gjsify workspace @pixelrpg/maker-gjs start:debug
 ```
 
 Application ID: `org.pixelrpg.maker`. Resources are bundled into a GResource file (`org.pixelrpg.maker.data.gresource`) at build time.
@@ -43,7 +43,7 @@ UI is defined declaratively in Blueprint (`.blp`) files; widget classes wire sig
 
 ## Build pipeline
 
-`yarn build` runs three steps:
+`gjsify run build` runs three steps:
 
 1. `build:resources` — `gjsify gresource` packs Blueprint UI + CSS + assets into the `.gresource` file
 2. `build:barrels` — `barrelsby` regenerates `index.ts` barrel exports

--- a/apps/storybook-gjs/README.md
+++ b/apps/storybook-gjs/README.md
@@ -28,23 +28,23 @@ This application provides an interactive environment for developing and testing 
 
 ```bash
 # Install dependencies
-yarn install
+gjsify install
 ```
 
 ### Development Commands
 
 ```bash
 # Build the application
-yarn build
+gjsify run build
 
 # Start the application
-yarn start
+gjsify run start
 
 # Start with GTK debugging enabled
-yarn start:debug
+gjsify run start:debug
 
 # Type checking
-yarn check
+gjsify run check
 ```
 
 ## Project Structure
@@ -78,7 +78,7 @@ For interactive debugging:
 
 ```bash
 # Start with GTK debugging enabled
-yarn start:debug
+gjsify run start:debug
 ```
 
 This will open the GTK Inspector alongside the application, allowing you to:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,13 +42,13 @@ git clone https://github.com/your-username/pixelrpg-map-editor.git
 cd pixelrpg-map-editor
 
 # Install dependencies
-yarn install
+gjsify install
 
 # Build all packages
-yarn build
+gjsify run build
 
 # Verify everything works
-yarn check
+gjsify run check
 ```
 
 ## 🔄 Development Workflow
@@ -83,24 +83,24 @@ git checkout -b docs/update-readme
 
 ```bash
 # Run the editor
-yarn workspace @pixelrpg/maker-gjs start
+gjsify workspace @pixelrpg/maker-gjs start
 
 # Run the storybook
-yarn workspace @pixelrpg/storybook-gjs start
+gjsify workspace @pixelrpg/storybook-gjs start
 
 # Type-check a single package
-yarn workspace @pixelrpg/<pkg> run check
+gjsify workspace @pixelrpg/<pkg> check
 
 # Type-check + build everything
-yarn workspaces foreach -A run check
-yarn build
+gjsify foreach check
+gjsify run build
 
 # Run the engine unit tests
-yarn workspace @pixelrpg/engine run test
+gjsify workspace @pixelrpg/engine test
 
 # Auto-format and lint via Biome
-yarn format     # rewrites files in place (applies safe + unsafe fixes)
-yarn lint       # check-only; fails on lint errors
+gjsify format   # rewrites files in place (applies safe + unsafe fixes)
+gjsify lint     # check-only; fails on lint errors
 ```
 
 ## 🏗️ Architecture Guidelines
@@ -205,29 +205,29 @@ function calculateDistance(point1: Point, point2: Point): number {
 `packages/engine` runs Vitest. Unit tests live next to the source they cover (`foo.ts` + `foo.test.ts`).
 
 ```bash
-yarn workspace @pixelrpg/engine run test          # one-shot
-yarn workspace @pixelrpg/engine run test:watch    # watch mode
+gjsify workspace @pixelrpg/engine test            # one-shot
+gjsify workspace @pixelrpg/engine test:watch      # watch mode
 ```
 
 The other workspaces (`packages/gjs`, `apps/*`) are GTK-bound and currently lack a test harness — extend the engine's pure-function coverage first; widget tests come later.
 
 ### Manual verification
 
-- **Type-check**: `yarn workspaces foreach -A run check`
-- **Build**: `yarn build` — must succeed for all packages
-- **Smoke-test the editor**: `yarn workspace @pixelrpg/maker-gjs start` — open a map, try the brush/eraser tools
-- **Smoke-test the storybook**: `yarn workspace @pixelrpg/storybook-gjs start` — render widget stories
+- **Type-check**: `gjsify foreach check`
+- **Build**: `gjsify run build` — must succeed for all packages
+- **Smoke-test the editor**: `gjsify workspace @pixelrpg/maker-gjs start` — open a map, try the brush/eraser tools
+- **Smoke-test the storybook**: `gjsify workspace @pixelrpg/storybook-gjs start` — render widget stories
 
 ### Linting & formatting
 
 Biome handles both linting and formatting (Prettier and ESLint are not used).
 
 ```bash
-yarn lint     # report lint issues
-yarn format   # auto-fix and reformat in place
+gjsify lint   # report lint issues
+gjsify format # auto-fix and reformat in place
 ```
 
-A `husky` pre-commit hook runs `yarn format` before each commit. VS Code is configured (`.vscode/settings.json`) to format on save with `biomejs.biome`.
+A `husky` pre-commit hook runs `gjsify format` before each commit. VS Code is configured (`.vscode/settings.json`) to format on save with `biomejs.biome`.
 
 ## 📚 Documentation
 
@@ -319,10 +319,10 @@ Add screenshots of UI changes.
 ### Automated Checks
 
 All PRs must pass:
-- TypeScript compilation (`yarn workspaces foreach -A run check`)
-- Build process (`yarn build`)
-- Lint (`yarn lint` — Biome)
-- Engine unit tests (`yarn workspace @pixelrpg/engine run test`)
+- TypeScript compilation (`gjsify foreach check`)
+- Build process (`gjsify run build`)
+- Lint (`gjsify lint` — Biome)
+- Engine unit tests (`gjsify workspace @pixelrpg/engine test`)
 
 Widget-level tests for the GJS packages and apps are not yet in place; see the [Testing](#-testing) section.
 
@@ -338,7 +338,7 @@ Widget-level tests for the GJS packages and apps are not yet in place; see the [
 
 - [Project README](../README.md) — overview, architecture, workspace layout
 - [AGENTS.md](../AGENTS.md) — coding conventions, ECS patterns, Blueprint, GTK4 lifecycle
-- Storybook: `yarn workspace @pixelrpg/storybook-gjs start`
+- Storybook: `gjsify workspace @pixelrpg/storybook-gjs start`
 
 ## 🎉 Recognition
 

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -34,6 +34,6 @@ In GJS, the canvas comes from the GTK Engine widget in [`@pixelrpg/gjs`](../gjs)
 ## Build
 
 ```bash
-yarn workspace @pixelrpg/engine run build
-yarn workspace @pixelrpg/engine run check
+gjsify workspace @pixelrpg/engine build
+gjsify workspace @pixelrpg/engine check
 ```

--- a/packages/gjs/README.md
+++ b/packages/gjs/README.md
@@ -28,8 +28,8 @@ CSS: import `@pixelrpg/gjs/index.css` from your application's stylesheet. Loweri
 ## Build
 
 ```bash
-yarn workspace @pixelrpg/gjs run build
-yarn workspace @pixelrpg/gjs run check
+gjsify workspace @pixelrpg/gjs build
+gjsify workspace @pixelrpg/gjs check
 ```
 
 ## Related

--- a/packages/story-gjs/README.md
+++ b/packages/story-gjs/README.md
@@ -43,6 +43,6 @@ The host application collects modules via `registry` and renders them. See [`app
 ## Build
 
 ```bash
-yarn workspace @pixelrpg/story-gjs run build
-yarn workspace @pixelrpg/story-gjs run check
+gjsify workspace @pixelrpg/story-gjs build
+gjsify workspace @pixelrpg/story-gjs check
 ```


### PR DESCRIPTION
## Summary

- Workspace scripts already run on `gjsify foreach` / `gjsify workspace` (see root `package.json`), but the README + `docs/CONTRIBUTING.md` walkthroughs still pointed new contributors at `yarn install` / `yarn workspace … run …`. Sync the docs with the actual tooling.
- One-to-one substitutions; no behavior change. `AGENTS.md` line 5 already documents the migration (`gjsify install (replaces yarn)`) — left untouched.

Substitutions used:

| before | after |
|---|---|
| `yarn install` | `gjsify install` |
| `yarn build` | `gjsify run build` |
| `yarn check` | `gjsify run check` |
| `yarn lint` / `yarn format` | `gjsify lint` / `gjsify format` |
| `yarn workspaces foreach -A run check` | `gjsify foreach check` |
| `yarn workspace <pkg> run <script>` | `gjsify workspace <pkg> <script>` |
| `yarn workspace <pkg> start[:debug]` | `gjsify workspace <pkg> start[:debug]` |

## Test plan

- [x] `grep -rn "yarn install\|yarn workspace\|yarn run\|yarn build\|yarn check\|yarn test\|yarn lint\|yarn format\|yarn start" .` returns only the explanatory line in `AGENTS.md`.
- [ ] Reader spot-check: walk a fresh contributor through `docs/CONTRIBUTING.md` — every command should run.