### PR TITLE
chore(deps): bump @gjsify/* from ^0.4.21 to ^0.4.29 + close resize flash

### DIFF
--- a/apps/game-browser/package.json
+++ b/apps/game-browser/package.json
@@ -17,7 +17,7 @@
     "excalibur": "^0.32.0"
   },
   "devDependencies": {
-    "@gjsify/cli": "^0.4.21",
+    "@gjsify/cli": "^0.4.29",
     "http-server": "^14.1.1",
     "typescript": "^6.0.3"
   }

--- a/apps/maker-gjs/package.json
+++ b/apps/maker-gjs/package.json
@@ -28,7 +28,7 @@
   "author": "Pascal Garber <pascal@artandcode.studio>",
   "license": "GPL-3.0",
   "devDependencies": {
-    "@gjsify/cli": "^0.4.21",
+    "@gjsify/cli": "^0.4.29",
     "typescript": "^6.0.3"
   },
   "dependencies": {
@@ -40,11 +40,11 @@
     "@girs/glib-2.0": "^2.88.0-4.0.0-rc.15",
     "@girs/gobject-2.0": "^2.88.0-4.0.0-rc.15",
     "@girs/gtk-4.0": "^4.23.0-4.0.0-rc.15",
-    "@gjsify/canvas2d": "^0.4.21",
-    "@gjsify/dom-elements": "^0.4.21",
-    "@gjsify/event-bridge": "^0.4.21",
-    "@gjsify/webgl": "^0.4.21",
-    "@gjsify/xmlhttprequest": "^0.4.21",
+    "@gjsify/canvas2d": "^0.4.29",
+    "@gjsify/dom-elements": "^0.4.29",
+    "@gjsify/event-bridge": "^0.4.29",
+    "@gjsify/webgl": "^0.4.29",
+    "@gjsify/xmlhttprequest": "^0.4.29",
     "@pixelrpg/engine": "workspace:^",
     "@pixelrpg/gjs": "workspace:^",
     "excalibur": "^0.32.0"

--- a/apps/storybook-gjs/package.json
+++ b/apps/storybook-gjs/package.json
@@ -23,13 +23,13 @@
     "@girs/glib-2.0": "^2.88.0-4.0.0-rc.15",
     "@girs/gobject-2.0": "^2.88.0-4.0.0-rc.15",
     "@girs/gtk-4.0": "^4.23.0-4.0.0-rc.15",
-    "@gjsify/dom-elements": "^0.4.21",
+    "@gjsify/dom-elements": "^0.4.29",
     "@pixelrpg/games-zelda-like": "workspace:^",
     "@pixelrpg/gjs": "workspace:^",
     "@pixelrpg/story-gjs": "workspace:^"
   },
   "devDependencies": {
-    "@gjsify/cli": "^0.4.21",
+    "@gjsify/cli": "^0.4.29",
     "typescript": "^6.0.3"
   }
 }

--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -4,7 +4,7 @@
     "@biomejs/biome@^2.4.13",
     "typescript@^6.0.3",
     "excalibur@^0.32.0",
-    "@gjsify/cli@^0.4.21",
+    "@gjsify/cli@^0.4.29",
     "http-server@^14.1.1",
     "@girs/adw-1@^1.10.0-4.0.0-rc.15",
     "@girs/gdk-4.0@^4.0.0-4.0.0-rc.15",
@@ -14,11 +14,11 @@
     "@girs/glib-2.0@^2.88.0-4.0.0-rc.15",
     "@girs/gobject-2.0@^2.88.0-4.0.0-rc.15",
     "@girs/gtk-4.0@^4.23.0-4.0.0-rc.15",
-    "@gjsify/canvas2d@^0.4.21",
-    "@gjsify/dom-elements@^0.4.21",
-    "@gjsify/event-bridge@^0.4.21",
-    "@gjsify/webgl@^0.4.21",
-    "@gjsify/xmlhttprequest@^0.4.21",
+    "@gjsify/canvas2d@^0.4.29",
+    "@gjsify/dom-elements@^0.4.29",
+    "@gjsify/event-bridge@^0.4.29",
+    "@gjsify/webgl@^0.4.29",
+    "@gjsify/xmlhttprequest@^0.4.29",
     "serve@^14.2.6",
     "vitest@^4.1.5",
     "@girs/graphene-1.0@^1.0.0-4.0.0-rc.15",
@@ -28,67 +28,67 @@
   ],
   "packages": {
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.15.tgz",
-      "integrity": "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==",
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.16.tgz",
+      "integrity": "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==",
       "bin": {
         "biome": "bin/biome"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.15.tgz",
-      "integrity": "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg=="
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.16.tgz",
+      "integrity": "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.15.tgz",
-      "integrity": "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ=="
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.16.tgz",
+      "integrity": "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.15.tgz",
-      "integrity": "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug=="
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.16.tgz",
+      "integrity": "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.15.tgz",
-      "integrity": "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ=="
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.16.tgz",
+      "integrity": "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.15.tgz",
-      "integrity": "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g=="
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.16.tgz",
+      "integrity": "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.15.tgz",
-      "integrity": "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w=="
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.16.tgz",
+      "integrity": "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.15.tgz",
-      "integrity": "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w=="
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.16.tgz",
+      "integrity": "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.4.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.15.tgz",
-      "integrity": "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="
+      "version": "2.4.16",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.16.tgz",
+      "integrity": "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="
     },
     "node_modules/@deepkit/type-compiler": {
       "version": "1.0.19",
@@ -145,20 +145,31 @@
       "integrity": "sha512-jNdTKVjdNFMiV7JPimdPudsvkbByeCPkQtiYIemiSwvJ5LQfB48rEf7pYYGBrAtUSBjSUjayWVynGOESNsQ7Bg==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/gtk-4.0": "4.23.0-4.0.0-rc.17",
-        "@girs/gsk-4.0": "4.0.0-4.0.0-rc.17",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/gdk-4.0": "4.0.0-4.0.0-rc.17",
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/gsk-4.0": "4.0.0-4.0.0-rc.17",
+        "@girs/gtk-4.0": "4.23.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/pango-1.0": "1.57.1-4.0.0-rc.17",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.17",
         "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/adw-1/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.17"
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/cairo-1.0": {
@@ -167,8 +178,19 @@
       "integrity": "sha512-CAR/TbYfxWq+pJl7H7s4dG6zH3KN1LUYy+YAFFmaopFJEaLheMN9j84gX+VsF23UwZvKVZH+PX5qk6LSrBdWjg==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17"
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/cairo-1.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/freetype2-2.0": {
@@ -180,77 +202,88 @@
         "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
-    "node_modules/@girs/gda-6.0": {
-      "version": "6.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gda-6.0/-/gda-6.0-6.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-B/XvID2/S5p1VgQVaKjS45eC+PvWSDQ+cXjSHSLRZXySY7Y04l3poy67Z9KN81eq01DzTyOrZ3dAnI5VDpuvqQ==",
+    "node_modules/@girs/freetype2-2.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/libxml2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/gda-6.0": {
+      "version": "6.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gda-6.0/-/gda-6.0-6.0.0-4.0.1.tgz",
+      "integrity": "sha512-7I7edX34M124BiElbI/BHK5yBByWYTkQ8WMTltTGoAFUPg0EC6xiP3KyvzS2DxUFdgTwC+8xicOUQay07QsNxQ==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/libxml2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@girs/gda-6.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/gda-6.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/gda-6.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/gda-6.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/gda-6.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/gda-6.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/gdk-4.0": {
@@ -259,16 +292,27 @@
       "integrity": "sha512-1UPtr5LfLn558R3tXADVJV9vDWc3rQRwSvC0C8gr2/NesRbTb/O7r95ikgxKGDD6MwV8fW+zrMSGBJwtvwifHg==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/pango-1.0": "1.57.1-4.0.0-rc.17",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.17",
         "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/gdk-4.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.17"
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/gdkpixbuf-2.0": {
@@ -278,9 +322,20 @@
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
         "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17"
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/gio-2.0": {
@@ -289,92 +344,152 @@
       "integrity": "sha512-OkyK3LvTjgaRIiySxZdDdOM07BFRzy7SRPj1J4YbMSZpqmkpWRhmeq7uZoZCLqQxAQk4MUdAOp17XiUGZFpibg==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17"
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
-    "node_modules/@girs/giounix-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/giounix-2.0/-/giounix-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-dVNSeHOYegXEoj1vhS6lGX61JIa79l1spmmxwCNek25U3hmDI8IfoSE7+Xf8Pbl6nsXrWAu+cnsv9cKOh+csIQ==",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
-      }
-    },
-    "node_modules/@girs/giounix-2.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
-      }
-    },
-    "node_modules/@girs/giounix-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
-      }
-    },
-    "node_modules/@girs/giounix-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
-      }
-    },
-    "node_modules/@girs/giounix-2.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
-      }
-    },
-    "node_modules/@girs/giounix-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
-      }
-    },
-    "node_modules/@girs/giounix-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
-      }
-    },
-    "node_modules/@girs/gjs": {
+    "node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
       "version": "4.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
       "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
       "dependencies": {
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17"
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/giounix-2.0": {
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/giounix-2.0/-/giounix-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-KpSps+1q4mImr+lVLmRDpiRNj+SMQ2OA5Y9KGeN/lkylgDfmOqn8E5tfn5BdAasvWJPuAZ8O3/CE4ro5NEwfpw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/giounix-2.0/node_modules/@girs/gio-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/giounix-2.0/node_modules/@girs/gjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/giounix-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/giounix-2.0/node_modules/@girs/glib-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/giounix-2.0/node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/giounix-2.0/node_modules/@girs/gobject-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gjs": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.4.tgz",
+      "integrity": "sha512-Tgp5Jt3wenLcevB5n+DdH/jWmrRAgnL9ERvqRpiz3hup+NHdHDLp4HrlhyUqoEr37qknA3+El210bQdxbm5FuA==",
+      "dependencies": {
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4"
+      }
+    },
+    "node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
+      "dependencies": {
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
+      }
+    },
+    "node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
+      }
+    },
+    "node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
+      "dependencies": {
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
+      }
+    },
+    "node_modules/@girs/gjs/node_modules/@girs/glib-2.0": {
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
+      "dependencies": {
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
+      }
+    },
+    "node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
+      "dependencies": {
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/glib-2.0": {
@@ -383,6 +498,17 @@
       "integrity": "sha512-nTZBcDY++60wLo2OfrOWAYe7Lw9BRVIEIwiQ+7CieDAzgBgpMs1QE2xY3xwfUHEBIyzsDSZMd2DW4afHXtkz3g==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
@@ -396,6 +522,17 @@
         "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
+    "node_modules/@girs/gmodule-2.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
+      }
+    },
     "node_modules/@girs/gobject-2.0": {
       "version": "2.88.0-4.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.17.tgz",
@@ -405,14 +542,36 @@
         "@girs/glib-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
+    "node_modules/@girs/gobject-2.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
+      }
+    },
     "node_modules/@girs/graphene-1.0": {
       "version": "1.0.0-4.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-rc.17.tgz",
       "integrity": "sha512-9+b0ApjMsG8Pq2bLyug3mE4lO3cFNqoEvtQIl3z50cXz/4alpPI+GdBL9C/SeiqMiEK+x3RbPsFXm7r/epkGDg==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17"
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/graphene-1.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/gsk-4.0": {
@@ -421,18 +580,29 @@
       "integrity": "sha512-NztZASK0Lahi2whus75NeVOOl/RcJRjswVY9HDCZjO38KoFWIO8rt1aT0z5Dw8YXscnNhkkbQcMh+myWq0yHuw==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/gdk-4.0": "4.0.0-4.0.0-rc.17",
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/pango-1.0": "1.57.1-4.0.0-rc.17",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.17",
         "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/gsk-4.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.17"
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/gtk-4.0": {
@@ -441,19 +611,30 @@
       "integrity": "sha512-tbX3nR68/n6BhhePMJHjIp9gSHfM+noyUjpx+4Pd1VImbEWjfZKqn92+X9zQZWyD6rgmaRu0CRGbD3z5ecNMcA==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/gsk-4.0": "4.0.0-4.0.0-rc.17",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/gdk-4.0": "4.0.0-4.0.0-rc.17",
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/gsk-4.0": "4.0.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/pango-1.0": "1.57.1-4.0.0-rc.17",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.17",
         "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/gtk-4.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.17"
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/gtksource-5": {
@@ -462,20 +643,31 @@
       "integrity": "sha512-hkhqqUCmBZhF+eZP42JDo3+bNmRF0WHUpc0+hhDhwOju1XeAnLh89qcL3qjc4bZt5NaJRgQ5tI5U9FehMWEurw==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/gtk-4.0": "4.23.0-4.0.0-rc.17",
-        "@girs/gsk-4.0": "4.0.0-4.0.0-rc.17",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/gdk-4.0": "4.0.0-4.0.0-rc.17",
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/gsk-4.0": "4.0.0-4.0.0-rc.17",
+        "@girs/gtk-4.0": "4.23.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/pango-1.0": "1.57.1-4.0.0-rc.17",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.17",
         "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/gtksource-5/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.17"
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/gwebgl-0.1": {
@@ -554,87 +746,98 @@
       "integrity": "sha512-sefFHkbo++qj7Fbt9l6VmAhHtGFvVoQEyIsfQtsWLCURj2A4YCcBMvFhD2IZRSEBE6ZxyIvxszyzauintFcVlg==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17"
+        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/harfbuzz-0.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/libxml2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/libxml2-2.0/-/libxml2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-vcllLH05b5euXQfQXCwKbE+Gg6cFyzeKXG65KTFFUeafmUJ9rYEhcMU/f7RF9zksKS81kGqePwUtA+Qg/EzJkw==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/libxml2-2.0/-/libxml2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-4OOeKPeIMuoS9JF1EwX6Fyca5+fz18Xy2yTacZlbDmZyb4G2WAx1B+Wng2qRMzKZS6rcgCoteWKD1pE0jEqR/w==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/libxml2-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/libxml2-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/libxml2-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/libxml2-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/libxml2-2.0/node_modules/@girs/gjs/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/libxml2-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/libxml2-2.0/node_modules/@girs/gobject-2.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/pango-1.0": {
@@ -643,13 +846,24 @@
       "integrity": "sha512-bsYFe06tlIAcqcKK8ALOBOzIs04sgTIturR0tGyeC1bxwPPU+2VTeHDarRMbG7tCq9U1B6hCSHzPaT1Z94onHg==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.17",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17",
         "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17"
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.17",
+        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/pango-1.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/pangocairo-1.0": {
@@ -658,962 +872,973 @@
       "integrity": "sha512-f6NfgDiNJVnRCa4QVBa4hvkGs0cVVfTqy1chvxfN95YjLLeO9rmlYlpqPoonN39ttM+HuEG0X4IuQoY1yG3zxw==",
       "dependencies": {
         "@girs/gjs": "4.0.0-rc.17",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.17",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.17",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17",
         "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17"
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/pango-1.0": "1.57.1-4.0.0-rc.17",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.17",
+        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/pangocairo-1.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.17.tgz",
+      "integrity": "sha512-8UzowTxia0CzmyW7NRLnWNeEx+ImFxi4hyuZZppSfJBHQj4/sbaQSKf672CIbtOzsbVdeKQyQ8WWzlvA8rTxzQ==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
       }
     },
     "node_modules/@girs/soup-3.0": {
-      "version": "3.6.6-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/soup-3.0/-/soup-3.0-3.6.6-4.0.0-rc.15.tgz",
-      "integrity": "sha512-z4gsn9YuFx/I74xwnfZHW74zjZBlhsiwqCVBJzNRab/oxLtnoT+7j65X2GeqHlD9XGIBB6/jN+PB0UVrfd4v4g==",
+      "version": "3.6.6-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/soup-3.0/-/soup-3.0-3.6.6-4.0.1.tgz",
+      "integrity": "sha512-6UbEMuyluSCq2kwyZMLfpoDplSEzWYgZEvN83CAV1fvCWVz+VD2BD/eabiaOCozu+7QsHdud9DhJglC86zH6dQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/soup-3.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/soup-3.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/soup-3.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/soup-3.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/soup-3.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/soup-3.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/abort-controller": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.4.21.tgz",
-      "integrity": "sha512-y6kYJfvnkZyKqN8uXbR7s6cjHkFO4Z6pnU7BARlTp3/llg/kcEc1rHUyF0ZGGAlNVNY+lRjMfCAG6VwZcJ+uqA==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.4.29.tgz",
+      "integrity": "sha512-WKBNfInyr18S6dws3npqrLex7rNGmN/4EGyD7FKvRDIGwwZutAATgRaRuuwGYjYkEx3Anl5Wm20b5NNR5t+yoQ==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.21"
+        "@gjsify/dom-events": "^0.4.29"
       }
     },
     "node_modules/@gjsify/assert": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.4.21.tgz",
-      "integrity": "sha512-UaZK5fM6c2hfW7i6FgQ75zZaDuKAa0IrrLR+IVGtOb7XvikAcv3Hr8y6Brm0+KnE/D7O4FtBIJTKBprUzLGh+Q=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.4.29.tgz",
+      "integrity": "sha512-6FWFvqdhmqTrNcqm7XoLMjZ+z1ritIWAzhPnfApQWuIbvsRtEe+n4iLj2L2XkBHawFHQTn1urdQXvBngSm7QTg=="
     },
     "node_modules/@gjsify/async_hooks": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.4.21.tgz",
-      "integrity": "sha512-unRKiSTdMIjnIkxQ/q1QVXurv6bFgZuZoysRBDczjBtn3NQaNU369SV5LGI2vC3qzMoQpke34JrVKa8q/tdmuQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.4.29.tgz",
+      "integrity": "sha512-1Q4b+eMKUlY8rIPqcSAK6anS8PC2GVqMt66YXDcYhJVWFdOFFLQwUZ+OTlP1EngXfQ6NIbNmvidxIeJU56TIiw==",
       "dependencies": {
-        "@gjsify/events": "^0.4.21"
+        "@gjsify/events": "^0.4.29"
       }
     },
     "node_modules/@gjsify/buffer": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.4.21.tgz",
-      "integrity": "sha512-+y28qeHRSJ5VFmpQEeWjDFYK9n7Gi2HVE2PAZ+SZNlzz1mW+YmMTK1q3GcusFkjT9rGCgNHZNMQHcC03U9zz5A==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.4.29.tgz",
+      "integrity": "sha512-ajMmfaNp0zDp+HAJS+FI9p+lucOAiWMu1c5NlFbEMgoYrvqQFD+HjecoGaNAzJaOeUQBUjUe+q8tUXqyHdIs+w==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.21"
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/canvas2d": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d/-/canvas2d-0.4.21.tgz",
-      "integrity": "sha512-7R2mr6f1E97s0qYx/pBX8RzJDUtVJvSD5nF+wrld6gau0eua2UjPKJfPELOy0c6EFyausN1SmsixBvmo972RTw==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d/-/canvas2d-0.4.29.tgz",
+      "integrity": "sha512-Oi3UgnFg7TeqY1ehXVKcawcxVOPszD7IxzfWhUy1/gKTOHZ6MwNhG18jmd6i3hZhUueOPHQVNyrkrPuD3tJ5OQ==",
       "dependencies": {
-        "@girs/gdk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gtk-4.0": "4.23.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@gjsify/canvas2d-core": "^0.4.21",
-        "@gjsify/dom-elements": "^0.4.21",
-        "@gjsify/dom-events": "^0.4.21",
-        "@gjsify/event-bridge": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gdk-4.0": "4.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/gtk-4.0": "4.23.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1",
+        "@gjsify/canvas2d-core": "^0.4.29",
+        "@gjsify/dom-elements": "^0.4.29",
+        "@gjsify/dom-events": "^0.4.29",
+        "@gjsify/event-bridge": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/canvas2d-core": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d-core/-/canvas2d-core-0.4.21.tgz",
-      "integrity": "sha512-ncjJVHOiIepScCIP8gwdG1jleI+9+Ro3tEOFM5DU4ze+aKMtH1jefX2pFitQ9IJDnXSdZJs1yasjIWg2qJVrog==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d-core/-/canvas2d-core-0.4.29.tgz",
+      "integrity": "sha512-PAoI3SY5M+F5U7BspF/o+naDMv/dqmte0+Co4A2XrpH1Y98SCY0HYi6Sc4mJ/ENaGih7y2ffygvzNL/TwA3OSQ==",
       "dependencies": {
-        "@girs/gdk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gdk-4.0": "4.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-NFWG8T3WCNT6JV/p1g8VVBUdQQdW7SfQJk0De1PATLo+gpbay0M5eHCb1+oQoPPOozyFviAXtFm0o0XjIki2xA==",
+      "version": "4.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.1.tgz",
+      "integrity": "sha512-zrzRqPBD2PFh0/lqav7TYnL4qVHHIgH7SM6oEj/I7kQZWjk06GyfSj60cyhYOXUlX5O67tViZ0KPPnXO0O6eqA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-9ewd7cwn+2YjjhRW2WUTn38U2D98gEAWM85zBcYti+81yvG/5iRH93o1Ki32bwFWzSI1JWi/+F90YkbV0Hb9QQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-giX1l3cOc0bvdvbdoHAAVskF/xfSYySh5WajX4+Yq7mMYAeWhXzsiY15s6FNjoRiB8BIIWg4lT6uGPqlMREhhw==",
+      "version": "13.2.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
+      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-sC9ANhTdVngxlXGfItkiTeBkhfW+DwyfGo2b7rV8H4r0MQ3//2+L3tu6O3QFqbvGXSSk7K56a0D3fSc1et/aHQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0": {
-      "version": "1.57.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-8a42I+2JQV20enK2zgJq++9AqAgPoXagikhEYH2hnLenG2kdYCImTsBQ2FxVdGmLS89+Qohg92tMR64VtJIo8Q==",
+      "version": "1.57.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.1.tgz",
+      "integrity": "sha512-1GrH9fqEsB/feXy/02pYujF42/taO8IL/fzTwx9syisiRHEEXNQwSV6N3EbCDOKHeUbDzv2KyNJm5b3pVLszRw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-9ewd7cwn+2YjjhRW2WUTn38U2D98gEAWM85zBcYti+81yvG/5iRH93o1Ki32bwFWzSI1JWi/+F90YkbV0Hb9QQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-giX1l3cOc0bvdvbdoHAAVskF/xfSYySh5WajX4+Yq7mMYAeWhXzsiY15s6FNjoRiB8BIIWg4lT6uGPqlMREhhw==",
+      "version": "13.2.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
+      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-tDRLVAV3ZJBzGOER7csNezXkeoYPVlaALKZ+7UiaVQ+VMYIDl2gtpOg7FVHl5dVmWgwPlpdM/RvSbiIXgEmb4Q==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-GRJbgTQap2LGPukqqL0WnrFpCZhR2i0DlLwD9QkSP1dFRCe4owaNizC6kQdbkvojqR+b3GfFbzqyVGlZKzD0Vg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-9ewd7cwn+2YjjhRW2WUTn38U2D98gEAWM85zBcYti+81yvG/5iRH93o1Ki32bwFWzSI1JWi/+F90YkbV0Hb9QQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-giX1l3cOc0bvdvbdoHAAVskF/xfSYySh5WajX4+Yq7mMYAeWhXzsiY15s6FNjoRiB8BIIWg4lT6uGPqlMREhhw==",
+      "version": "13.2.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
+      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-NFWG8T3WCNT6JV/p1g8VVBUdQQdW7SfQJk0De1PATLo+gpbay0M5eHCb1+oQoPPOozyFviAXtFm0o0XjIki2xA==",
+      "version": "4.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.1.tgz",
+      "integrity": "sha512-zrzRqPBD2PFh0/lqav7TYnL4qVHHIgH7SM6oEj/I7kQZWjk06GyfSj60cyhYOXUlX5O67tViZ0KPPnXO0O6eqA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-9ewd7cwn+2YjjhRW2WUTn38U2D98gEAWM85zBcYti+81yvG/5iRH93o1Ki32bwFWzSI1JWi/+F90YkbV0Hb9QQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-giX1l3cOc0bvdvbdoHAAVskF/xfSYySh5WajX4+Yq7mMYAeWhXzsiY15s6FNjoRiB8BIIWg4lT6uGPqlMREhhw==",
+      "version": "13.2.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
+      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-sC9ANhTdVngxlXGfItkiTeBkhfW+DwyfGo2b7rV8H4r0MQ3//2+L3tu6O3QFqbvGXSSk7K56a0D3fSc1et/aHQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0": {
-      "version": "4.23.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-extSsa7YIzglPPUjNYoPyQyJIMflZbA/ORVtecPUXYRLB4mTwy8+CGvnXjD7FsQLnbGP/f1SrpuO14OQvqJ90Q==",
+      "version": "4.23.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.1.tgz",
+      "integrity": "sha512-a5wAjHPHI//ZiMODFM2EEV0R/+5wcoM5BkDBjlaX3eRbapq3+DWxhevsgmZRlwz4SOqLqgvusJRsjnX3nrf+tg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gsk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gdk-4.0": "4.0.0-4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/gsk-4.0": "4.0.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/graphene-1.0": "1.0.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-9ewd7cwn+2YjjhRW2WUTn38U2D98gEAWM85zBcYti+81yvG/5iRH93o1Ki32bwFWzSI1JWi/+F90YkbV0Hb9QQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-Nqdy0NnKRdn61HDqht5JWGbVTS/Oc2VVDrzvnLFHF9AagtULQ9dhvDl7DoOhP/PngsoZFwX2y4OteEOs45ZWCw==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-fXHpp8NJUaUTA2/HU7KbGPUOVWE3N2HLrP7x4HQvxtvlUjo6BbyvQXTgyrnMED2ZlsvEy5RPVSAsk0RJiS81gg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/gsk-4.0": {
-      "version": "4.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-uqw+KCXNSw4RelqywbLI0l5fC1Ff72PqpTVCuS3S7rDXbL2LkClvI5N3DvBHfj29MGORzTYPo8I0VE7+poJ9oQ==",
+      "version": "4.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.1.tgz",
+      "integrity": "sha512-rayS9BQzgCF9ruVXZQ9pOvwoEHxVFaNoRGH9NU2N6XiTG6T3dk6QGSzSBuvnNtmN1af5/vldBPvkJRSvWzhQ6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gdk-4.0": "4.0.0-4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/graphene-1.0": "1.0.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-giX1l3cOc0bvdvbdoHAAVskF/xfSYySh5WajX4+Yq7mMYAeWhXzsiY15s6FNjoRiB8BIIWg4lT6uGPqlMREhhw==",
+      "version": "13.2.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
+      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0": {
-      "version": "1.57.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-8a42I+2JQV20enK2zgJq++9AqAgPoXagikhEYH2hnLenG2kdYCImTsBQ2FxVdGmLS89+Qohg92tMR64VtJIo8Q==",
+      "version": "1.57.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.1.tgz",
+      "integrity": "sha512-1GrH9fqEsB/feXy/02pYujF42/taO8IL/fzTwx9syisiRHEEXNQwSV6N3EbCDOKHeUbDzv2KyNJm5b3pVLszRw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-9ewd7cwn+2YjjhRW2WUTn38U2D98gEAWM85zBcYti+81yvG/5iRH93o1Ki32bwFWzSI1JWi/+F90YkbV0Hb9QQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-giX1l3cOc0bvdvbdoHAAVskF/xfSYySh5WajX4+Yq7mMYAeWhXzsiY15s6FNjoRiB8BIIWg4lT6uGPqlMREhhw==",
+      "version": "13.2.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
+      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-tDRLVAV3ZJBzGOER7csNezXkeoYPVlaALKZ+7UiaVQ+VMYIDl2gtpOg7FVHl5dVmWgwPlpdM/RvSbiIXgEmb4Q==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-GRJbgTQap2LGPukqqL0WnrFpCZhR2i0DlLwD9QkSP1dFRCe4owaNizC6kQdbkvojqR+b3GfFbzqyVGlZKzD0Vg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-9ewd7cwn+2YjjhRW2WUTn38U2D98gEAWM85zBcYti+81yvG/5iRH93o1Ki32bwFWzSI1JWi/+F90YkbV0Hb9QQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-giX1l3cOc0bvdvbdoHAAVskF/xfSYySh5WajX4+Yq7mMYAeWhXzsiY15s6FNjoRiB8BIIWg4lT6uGPqlMREhhw==",
+      "version": "13.2.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
+      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/child_process": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.4.21.tgz",
-      "integrity": "sha512-LXTvQRNHnV9UbCafvxudfTo8q3JLwFA4wjHd/AifRPju+6t3MO1HXMTU9ZTiKScW14GUyPUfhsde3zAABK+u8Q==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.4.29.tgz",
+      "integrity": "sha512-M8fobLeMNKdY+wDmk7l2WEd54RpIJbYQOM3571nLa3iT75/fLC8msfk33AitaSVMieigkGOQmK1NSmRbqnK0jQ==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/buffer": "^0.4.21",
-        "@gjsify/events": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/buffer": "^0.4.29",
+        "@gjsify/events": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/cli": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.4.21.tgz",
-      "integrity": "sha512-cMIBG4nzTyPVwwtRYMwM6PyVvs6xvpEZrYkGs++f4w48l1wee+OSEJuXLajV+UkpMlSFyDIR8yK16P8nRbMfAw==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.4.29.tgz",
+      "integrity": "sha512-pULWhJz0qUayx7XyrvlrFwdNPNLiU3smuleI/swo9Pnbw1Hg2A266WDnVLveL6NHPcWmsrMXFK2+Q5BYzldMVA==",
       "dependencies": {
-        "@gjsify/buffer": "^0.4.21",
-        "@gjsify/create-app": "^0.4.21",
-        "@gjsify/node-globals": "^0.4.21",
-        "@gjsify/node-polyfills": "^0.4.21",
-        "@gjsify/npm-registry": "^0.4.21",
-        "@gjsify/resolve-npm": "^0.4.21",
-        "@gjsify/rolldown-plugin-gjsify": "^0.4.21",
-        "@gjsify/rolldown-plugin-pnp": "^0.4.21",
-        "@gjsify/semver": "^0.4.21",
-        "@gjsify/tar": "^0.4.21",
-        "@gjsify/web-polyfills": "^0.4.21",
-        "@gjsify/workspace": "^0.4.21",
+        "@gjsify/buffer": "^0.4.29",
+        "@gjsify/create-app": "^0.4.29",
+        "@gjsify/node-globals": "^0.4.29",
+        "@gjsify/node-polyfills": "^0.4.29",
+        "@gjsify/npm-registry": "^0.4.29",
+        "@gjsify/resolve-npm": "^0.4.29",
+        "@gjsify/rolldown-plugin-gjsify": "^0.4.29",
+        "@gjsify/rolldown-plugin-pnp": "^0.4.29",
+        "@gjsify/semver": "^0.4.29",
+        "@gjsify/tar": "^0.4.29",
+        "@gjsify/web-polyfills": "^0.4.29",
+        "@gjsify/workspace": "^0.4.29",
         "cosmiconfig": "^9.0.1",
         "get-tsconfig": "^4.14.0",
         "pkg-types": "^2.3.1",
@@ -1625,1918 +1850,1918 @@
       }
     },
     "node_modules/@gjsify/cluster": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.4.21.tgz",
-      "integrity": "sha512-RbIM6NTxJGf+yH/9k1g6dmRdRl0I/l06NgfjmK9+FMarhGORJ0dxp5BT/oFhf9X8hWtN9Sbjcd4Ejt8nkoF/Wg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.4.29.tgz",
+      "integrity": "sha512-FEl/SMkyPOkXm/pA184qVLAmDCcT6GfZeNMYSbj9CNQBY2fSMKsDw36qaKAZd70t4VXLz4fLh2olIsMkA7+4qA==",
       "dependencies": {
-        "@gjsify/events": "^0.4.21"
+        "@gjsify/events": "^0.4.29"
       }
     },
     "node_modules/@gjsify/compression-streams": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.4.21.tgz",
-      "integrity": "sha512-c7Y+GTb3sI9bSOd9DUNL4TqW+aVcZSBpqT27DB6/844sgL/zDs4OCHNNSDoLB8v4xaPszrzjQBUbxSM0cabtlA==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.4.29.tgz",
+      "integrity": "sha512-a7kavr7JathO/8YHLN30OhDlhYNL42bIBJMjBA1DjFImxPWBQFzG/YEnaHFBFpS5GF9WAs3y7kq4BnvnWPL95A==",
       "dependencies": {
-        "@gjsify/web-streams": "^0.4.21"
+        "@gjsify/web-streams": "^0.4.29"
       }
     },
     "node_modules/@gjsify/console": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.4.21.tgz",
-      "integrity": "sha512-xvbX1BzqX7zXh9/eFaSm6k9krYkQZZWYqpaRRPnXc5hRwyBWQDIX2ZUPPYSq0jM4pi9zdo6gAiQKP4B67QWxEQ=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.4.29.tgz",
+      "integrity": "sha512-q1C85VZQzqWSDzfEa6oBel2fU/J4sFIUMQ+YvxmG72N6PfimpAV5oJLDLJnpZ3AAdrcxJqeqCdSk59NXz6S++A=="
     },
     "node_modules/@gjsify/constants": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.4.21.tgz",
-      "integrity": "sha512-QqFlyqPYClOqjeuqIp9J3hdGztrtv8/y/n5IUIulwiL/9CbXClz8KVxKo78WEqH0mvE1p6vvdaCc+THQeapBzA==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.4.29.tgz",
+      "integrity": "sha512-CcKa5GTQC/61gnPSmqUQfLLrXi8gllV9RUiw+1bk2eh6ZyfwTacyHXSKp9NseFzBtEh3N4upR27vWRiHhdtGkQ==",
       "dependencies": {
-        "@gjsify/crypto": "^0.4.21",
-        "@gjsify/fs": "^0.4.21",
-        "@gjsify/os": "^0.4.21"
+        "@gjsify/crypto": "^0.4.29",
+        "@gjsify/fs": "^0.4.29",
+        "@gjsify/os": "^0.4.29"
       }
     },
     "node_modules/@gjsify/create-app": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.4.21.tgz",
-      "integrity": "sha512-PQQqL0iOYq8QUoRUlcOEYkbatw9FN1Lpc4fqvOomz0+oUjSnuzFXXoVDEazq9MtAWlqWFwJCiBIqv39Xsa69tA==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.4.29.tgz",
+      "integrity": "sha512-UW9QKaTutUtlDgA7yf0F7m+Ry59SP40CGQq2WYksOyaDXokhUTJ0yDWKU9WMpINSipogP5WIb22yCJyR+WaPWg==",
       "dependencies": {
         "yargs": "^18.0.0"
       },
       "bin": "./lib/index.js"
     },
     "node_modules/@gjsify/crypto": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.4.21.tgz",
-      "integrity": "sha512-mAlTkqY0D/wWJNhO2K35FBuX4KE/TIwBp/zmeN2azEv20Cit/Qv6oDFMD3U+/waVbETmBJiSx/zj+RBR6rDQIg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.4.29.tgz",
+      "integrity": "sha512-okSahieyHuD43UgfDZbThBoUKIiCZXgpMqdUk+Z2gkLJ0narE/SW0h2YgLAL9Ilex4YoOox1xn3QuaA1LD/T9g==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/buffer": "^0.4.21",
-        "@gjsify/stream": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/buffer": "^0.4.29",
+        "@gjsify/stream": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dgram": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.4.21.tgz",
-      "integrity": "sha512-iuyY7ArHHLt14mTvmcbepSzBskeBjuuzvgCQ5ZkNKAgU1uaQagTCIo4BJAMXOdRxc25eBpnNT3kGgzJXdoI9sA==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.4.29.tgz",
+      "integrity": "sha512-Iegd4deVDUxloKsx/b2tQTvwnyft5QWUgau+QQE0K15OY4vickix+/ibPHEfmFL0/Glgrmdw6fWnW1e9Z/wtJw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/buffer": "^0.4.21",
-        "@gjsify/events": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/buffer": "^0.4.29",
+        "@gjsify/events": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/diagnostics_channel": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.4.21.tgz",
-      "integrity": "sha512-rkvIBuK/pYLdGpwsgtUPJgf4SZgm8QCWWVDGEveppZP2vItc7ACzyq0p+0G8wxlWpjYGMx5EqlBI6T+C+LOVMg=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.4.29.tgz",
+      "integrity": "sha512-L9faFgekgJkncFqX8cX6NrP8jHOtk6+JiJTQKLGv0k45HfpgjeLzHHGZhdRBKyaGjGVI66Qi1YPQJp93inLm+Q=="
     },
     "node_modules/@gjsify/dns": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.4.21.tgz",
-      "integrity": "sha512-T9D2/jPwUbMaAh0Pz9fQ5RLu6KjgKX0ddn8/hqG8jjP+mqSFfKjVPh1KGE4mADbMfbN1wZ2/uK7zh4nGvhmc4A==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.4.29.tgz",
+      "integrity": "sha512-7cys03RodCLQCQa2BwuNZu7F0aPX88khI8x2nPOn7rRtFKa/LHWHMZNYM88692C8bZLb3BdBVnT9BmcLYy9knw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/net": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/net": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-elements/-/dom-elements-0.4.21.tgz",
-      "integrity": "sha512-VwrzXD85p2LW5XeADaV0IDErr9gR7+7uBOCT2ev63bUArA5DDYQf6n84RNKmaEqrxX+vOb9EPkqf5Rc8I/NsNA==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-elements/-/dom-elements-0.4.29.tgz",
+      "integrity": "sha512-avek9+NEIKaGRPjvyzF25QpZjlK068oeJAJSpAXfLByBVjk/+XheKdeV6D2UBhB9UtTvRPxtUpw3bUZmgBOu+w==",
       "dependencies": {
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/abort-controller": "^0.4.21",
-        "@gjsify/canvas2d-core": "^0.4.21",
-        "@gjsify/dom-events": "^0.4.21",
-        "@gjsify/fetch": "^0.4.21"
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/abort-controller": "^0.4.29",
+        "@gjsify/canvas2d-core": "^0.4.29",
+        "@gjsify/dom-events": "^0.4.29",
+        "@gjsify/fetch": "^0.4.29"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-sC9ANhTdVngxlXGfItkiTeBkhfW+DwyfGo2b7rV8H4r0MQ3//2+L3tu6O3QFqbvGXSSk7K56a0D3fSc1et/aHQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/dom-events": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.4.21.tgz",
-      "integrity": "sha512-h6Cbj657jAx4FWyS0w1UWcnVqTLGw5uk9MAu5c7mNHJnU/jf+kgpToh+0LRRwlC8w9iM7uWL/Xp42apl/EUCbA==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.4.29.tgz",
+      "integrity": "sha512-JkEKSK9VG+C2s0dkLFPLOTGbfJ2SCN3WZ3DFsXQ4XoOCP7Y1zdpXGNEJUB82hEPds0DBjA1jXTdGEwkIh8KRYA==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.4.21"
+        "@gjsify/dom-exception": "^0.4.29"
       }
     },
     "node_modules/@gjsify/dom-exception": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.4.21.tgz",
-      "integrity": "sha512-4n4oMAYUfoCng8dH7E7Qnbj0Gyu3ft6Fdd1btHh3TLvY46dj/JTZtoitufmZkhVIw5223v0wVzSN+qk5hRvNkw=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.4.29.tgz",
+      "integrity": "sha512-igyfZJfbQw4k0OkOsMkHb/BTbtniocTIeB5OEJb0uwWlayv9i9ZisgUcs6lB/5LOLY9b232+1JVrg/cqXQF4OA=="
     },
     "node_modules/@gjsify/domain": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.4.21.tgz",
-      "integrity": "sha512-HS5z0mKqaJoSdW6xFTAKa1sw3u2wGYLD/XTR0ZslaYXJpcDIywQxBSL0WTsfPVoSDy11I6WBtLKyABI0lr7hDQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.4.29.tgz",
+      "integrity": "sha512-/jWcW6kKzGO3S3usU3yLA+yqzKRyG/j4ZJK2liwIJfZdZA2le+9s1UUAcstlV9dmiis5+TrBTeYirtq/JnX5wA==",
       "dependencies": {
-        "@gjsify/events": "^0.4.21"
+        "@gjsify/events": "^0.4.29"
       }
     },
     "node_modules/@gjsify/domparser": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.4.21.tgz",
-      "integrity": "sha512-s8Hmp+h+nUDDYoeDhz8jBA4q08Xp5VixfphjtdewfXsDHoQa+EqibysCI2K7EOJChP0g7UD96SOlZ4NpPGt2Sw=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.4.29.tgz",
+      "integrity": "sha512-kZvkLe5VO08MYPHTIzSqL0MJxFA7MhdSLnChosw/EeKk94ojqWy3IqhMCrBBche+cFdqo+DvUb9KxR6kkAnGIg=="
     },
     "node_modules/@gjsify/event-bridge": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/event-bridge/-/event-bridge-0.4.21.tgz",
-      "integrity": "sha512-xmG46R+er+wNBv0G/YknmnMvbjnXFfz2WRsLxUbfRuWFY+lN4H9YqyF2V9w8ZqQom5baCSd7758Mtzlv+/PAFg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/event-bridge/-/event-bridge-0.4.29.tgz",
+      "integrity": "sha512-nVMl2y0exCwLGdRGGnOApDdkQicy6WT526WNOwKqhF7QJCOYjRoAU1ry8eeDhcsMkjL9Ibll7HvF4rpy12yHew==",
       "dependencies": {
-        "@girs/gdk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gtk-4.0": "4.23.0-4.0.0-rc.15",
-        "@gjsify/dom-events": "^0.4.21"
+        "@girs/gdk-4.0": "4.0.0-4.0.1",
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gtk-4.0": "4.23.0-4.0.1",
+        "@gjsify/dom-events": "^0.4.29"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-NFWG8T3WCNT6JV/p1g8VVBUdQQdW7SfQJk0De1PATLo+gpbay0M5eHCb1+oQoPPOozyFviAXtFm0o0XjIki2xA==",
+      "version": "4.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.1.tgz",
+      "integrity": "sha512-zrzRqPBD2PFh0/lqav7TYnL4qVHHIgH7SM6oEj/I7kQZWjk06GyfSj60cyhYOXUlX5O67tViZ0KPPnXO0O6eqA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-9ewd7cwn+2YjjhRW2WUTn38U2D98gEAWM85zBcYti+81yvG/5iRH93o1Ki32bwFWzSI1JWi/+F90YkbV0Hb9QQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-sC9ANhTdVngxlXGfItkiTeBkhfW+DwyfGo2b7rV8H4r0MQ3//2+L3tu6O3QFqbvGXSSk7K56a0D3fSc1et/aHQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-giX1l3cOc0bvdvbdoHAAVskF/xfSYySh5WajX4+Yq7mMYAeWhXzsiY15s6FNjoRiB8BIIWg4lT6uGPqlMREhhw==",
+      "version": "13.2.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
+      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/pango-1.0": {
-      "version": "1.57.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-8a42I+2JQV20enK2zgJq++9AqAgPoXagikhEYH2hnLenG2kdYCImTsBQ2FxVdGmLS89+Qohg92tMR64VtJIo8Q==",
+      "version": "1.57.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.1.tgz",
+      "integrity": "sha512-1GrH9fqEsB/feXy/02pYujF42/taO8IL/fzTwx9syisiRHEEXNQwSV6N3EbCDOKHeUbDzv2KyNJm5b3pVLszRw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-tDRLVAV3ZJBzGOER7csNezXkeoYPVlaALKZ+7UiaVQ+VMYIDl2gtpOg7FVHl5dVmWgwPlpdM/RvSbiIXgEmb4Q==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-GRJbgTQap2LGPukqqL0WnrFpCZhR2i0DlLwD9QkSP1dFRCe4owaNizC6kQdbkvojqR+b3GfFbzqyVGlZKzD0Vg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0": {
-      "version": "4.23.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-extSsa7YIzglPPUjNYoPyQyJIMflZbA/ORVtecPUXYRLB4mTwy8+CGvnXjD7FsQLnbGP/f1SrpuO14OQvqJ90Q==",
+      "version": "4.23.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.1.tgz",
+      "integrity": "sha512-a5wAjHPHI//ZiMODFM2EEV0R/+5wcoM5BkDBjlaX3eRbapq3+DWxhevsgmZRlwz4SOqLqgvusJRsjnX3nrf+tg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gsk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gdk-4.0": "4.0.0-4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/gsk-4.0": "4.0.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/graphene-1.0": "1.0.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-9ewd7cwn+2YjjhRW2WUTn38U2D98gEAWM85zBcYti+81yvG/5iRH93o1Ki32bwFWzSI1JWi/+F90YkbV0Hb9QQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-sC9ANhTdVngxlXGfItkiTeBkhfW+DwyfGo2b7rV8H4r0MQ3//2+L3tu6O3QFqbvGXSSk7K56a0D3fSc1et/aHQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-Nqdy0NnKRdn61HDqht5JWGbVTS/Oc2VVDrzvnLFHF9AagtULQ9dhvDl7DoOhP/PngsoZFwX2y4OteEOs45ZWCw==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-fXHpp8NJUaUTA2/HU7KbGPUOVWE3N2HLrP7x4HQvxtvlUjo6BbyvQXTgyrnMED2ZlsvEy5RPVSAsk0RJiS81gg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/gsk-4.0": {
-      "version": "4.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-uqw+KCXNSw4RelqywbLI0l5fC1Ff72PqpTVCuS3S7rDXbL2LkClvI5N3DvBHfj29MGORzTYPo8I0VE7+poJ9oQ==",
+      "version": "4.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.1.tgz",
+      "integrity": "sha512-rayS9BQzgCF9ruVXZQ9pOvwoEHxVFaNoRGH9NU2N6XiTG6T3dk6QGSzSBuvnNtmN1af5/vldBPvkJRSvWzhQ6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gdk-4.0": "4.0.0-4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/graphene-1.0": "1.0.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-giX1l3cOc0bvdvbdoHAAVskF/xfSYySh5WajX4+Yq7mMYAeWhXzsiY15s6FNjoRiB8BIIWg4lT6uGPqlMREhhw==",
+      "version": "13.2.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
+      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/pango-1.0": {
-      "version": "1.57.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-8a42I+2JQV20enK2zgJq++9AqAgPoXagikhEYH2hnLenG2kdYCImTsBQ2FxVdGmLS89+Qohg92tMR64VtJIo8Q==",
+      "version": "1.57.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.1.tgz",
+      "integrity": "sha512-1GrH9fqEsB/feXy/02pYujF42/taO8IL/fzTwx9syisiRHEEXNQwSV6N3EbCDOKHeUbDzv2KyNJm5b3pVLszRw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-tDRLVAV3ZJBzGOER7csNezXkeoYPVlaALKZ+7UiaVQ+VMYIDl2gtpOg7FVHl5dVmWgwPlpdM/RvSbiIXgEmb4Q==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-GRJbgTQap2LGPukqqL0WnrFpCZhR2i0DlLwD9QkSP1dFRCe4owaNizC6kQdbkvojqR+b3GfFbzqyVGlZKzD0Vg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/events": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.4.21.tgz",
-      "integrity": "sha512-J3p+D98Uyl6Vh2/fMSLL/hi7KZx+EZHdPvkLR3iJUyHgTonlDnERtA5inUiFNorPn/EuStggvetjoKE3ONzoPg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.4.29.tgz",
+      "integrity": "sha512-2L5hkMpMqrNRYFAhHKw5HmoJS+QMvcVZobsPubcIdN2jbKnUwJHwYDHNSYYqmHQpUs9NXuCrRthZgA1xB2NUfQ==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.21"
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/eventsource": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.4.21.tgz",
-      "integrity": "sha512-SVEyJRQF9uk+gxzo8uTyUHbhsjLfjgIauowUy5nZ2ilgs+9ctm5Oqob7Zg+XU1Bl1ag4yBpkjnX8/OT9YZalNQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.4.29.tgz",
+      "integrity": "sha512-f5tL3cz+2pz9vAX/Klce18bSDqv8FYQoa8CjYO4ZirIAL7dEcmPpEpFClbUn41VrnyHpfYYgKfbh7DmYeGfgFA==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.21",
-        "@gjsify/web-streams": "^0.4.21"
+        "@gjsify/dom-events": "^0.4.29",
+        "@gjsify/web-streams": "^0.4.29"
       }
     },
     "node_modules/@gjsify/fetch": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.4.21.tgz",
-      "integrity": "sha512-cPmcRCB2TXsR2GmrgAnKHM1WCye0Vt+Y4LqinYKS19VPHdmVeFLYaRh5cCJ+L88K+JnucS1/C09tSVEClqsiNg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.4.29.tgz",
+      "integrity": "sha512-TRCrJtAWcuTesLks1Hyug9PaqWajgEg2F0DqAKM7WxSSNncyctKUIodmsS7IORJKE1MmDXViWuUPzwDIWT+2dA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/soup-3.0": "3.6.6-4.0.0-rc.15",
-        "@gjsify/formdata": "^0.4.21",
-        "@gjsify/http": "^0.4.21",
-        "@gjsify/url": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/soup-3.0": "3.6.6-4.0.1",
+        "@gjsify/formdata": "^0.4.29",
+        "@gjsify/http": "^0.4.29",
+        "@gjsify/url": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/formdata": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.4.21.tgz",
-      "integrity": "sha512-87XbTOR/AV8TtIDq3ZUCnUey0qB1LgMdADPUdSDL+6jcd5fs6/zJzJZP33o+HgAHVR9JMOkvZZRybBIyUX3OzQ=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.4.29.tgz",
+      "integrity": "sha512-DcaBa9OFfTP7KbXSiUQA+T/3kMAbG+8PYBrdRUTkmLyH/tuaZxJdv3z7UquZn05cNU7rU594VbrlRzUUtk2vxA=="
     },
     "node_modules/@gjsify/fs": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.4.21.tgz",
-      "integrity": "sha512-mFfSYEuMXUPA9BfnSQBgoQVYI7MAZ+5azD+qWfkSSty3xYMBPislJdrS8ZTxd5aqgKoY0b556gBHwG7kgj0Ciw==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.4.29.tgz",
+      "integrity": "sha512-8wjWuk/AUdHUxfVWrHYhIKqKEZQL91KW2lKIEHqsDn8VogAP5VGqM4wuLO+BJdVBzjLaXGdKVBjwOhxLqHWpBQ==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/buffer": "^0.4.21",
-        "@gjsify/events": "^0.4.21",
-        "@gjsify/stream": "^0.4.21",
-        "@gjsify/url": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/buffer": "^0.4.29",
+        "@gjsify/events": "^0.4.29",
+        "@gjsify/stream": "^0.4.29",
+        "@gjsify/url": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/gamepad": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.4.21.tgz",
-      "integrity": "sha512-rgGu3Kn2mr4tEFpnk0StnLYbgitY5hGGgDtNf8AECU6wdopd7VVe4pjdZQP9sdAQhsCI5aBkhfWEIZ6PNXVBSQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.4.29.tgz",
+      "integrity": "sha512-kTfVjCvF6k88J5+BTyENo/a4N2Pinb3jvKvM///06CdP8/UlbfmNTiZq+1NczXv8h3+PzhGK1ud5rMPlIOlU3Q==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.21"
+        "@gjsify/dom-events": "^0.4.29"
       }
     },
     "node_modules/@gjsify/http": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.4.21.tgz",
-      "integrity": "sha512-JuQFv1QX57KchK7ItdDjXnpjB+6SYddwYJ1txixxavfuSXxCImUeT5BvNnZ6R2uISFH4glwAfA2CJaktWyBlcw==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.4.29.tgz",
+      "integrity": "sha512-0xovm37eBxX/bj3/kK0A5qWHXznFNoSmKlLxqI2XGdyaae5+opqz49UzPVJa+BDsKUMuUPCiUrfhhS+mzUUDTA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/soup-3.0": "3.6.6-4.0.0-rc.15",
-        "@gjsify/buffer": "^0.4.21",
-        "@gjsify/events": "^0.4.21",
-        "@gjsify/http-soup-bridge": "^0.4.21",
-        "@gjsify/net": "^0.4.21",
-        "@gjsify/stream": "^0.4.21",
-        "@gjsify/url": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/soup-3.0": "3.6.6-4.0.1",
+        "@gjsify/buffer": "^0.4.29",
+        "@gjsify/events": "^0.4.29",
+        "@gjsify/http-soup-bridge": "^0.4.29",
+        "@gjsify/net": "^0.4.29",
+        "@gjsify/stream": "^0.4.29",
+        "@gjsify/url": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/http-soup-bridge": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.4.21.tgz",
-      "integrity": "sha512-YOOdz7kA3XhmNjCRMc8BCxVWYr7BKXs63b9Y60V1bSAgjN8FIIcAmhK2K20UAF5dzFom0k9EVh2iy4QS3IbWVg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.4.29.tgz",
+      "integrity": "sha512-NvuAQvNT+05uupD8M1gaOnxCYXP6vtXOs05rUWNNI0MZomQbCoTx2cBZ4T8RsRAikBwoGT9RlUfJ6bZfybqWiw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/soup-3.0": "3.6.6-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/soup-3.0": "3.6.6-4.0.1"
       }
     },
     "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.4.21.tgz",
-      "integrity": "sha512-wijL6FsrY8GLpTa9ZwcnlO6mnQ9/4k17q57fVTk+RoeNmfwgleuc8S3KzhgzEDDK8FJsnu77QaJyqzJt/xnGsg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.4.29.tgz",
+      "integrity": "sha512-GbUV9S+Ef7YBWCKAFr+otbKH4Erj7mPxDYkm+ZQPERkNZ0iNjtrYsFTrsANTPXJHEM/WgHzcPFPbbsfCdKN8BA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/soup-3.0": "3.6.6-4.0.0-rc.15",
-        "@gjsify/events": "^0.4.21",
-        "@gjsify/http2-native": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/soup-3.0": "3.6.6-4.0.1",
+        "@gjsify/events": "^0.4.29",
+        "@gjsify/http2-native": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/http2-native": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.4.21.tgz",
-      "integrity": "sha512-fcTsu0M55Rb3+CMa2JBJuDnySV/JRajpr4oHC5ihsuWZs1ZrW8OWEEEhqcKw0ZqLcRK6VgJNnLJaLRNq3TeoWQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.4.29.tgz",
+      "integrity": "sha512-fn9wq5pTE8BBAYicYYBrDFnbk3OIItxjxdGJTzadICbhW7STlTU9tIDdhzbQt1j3oqdLbs71n2f4dNh84jZcMg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2-native/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2-native/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2-native/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2-native/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2-native/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2-native/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/https": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.4.21.tgz",
-      "integrity": "sha512-pYlSvS2U+TD+oPAtcs9UBIr7ylHsbtvOCZMk4J/slns3YZKEqaaR2sH8KNBBf59dn2HIA9O2RW0cO+1EedyvUg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.4.29.tgz",
+      "integrity": "sha512-NOOq5oIMRmBZa8RgP8pMrddeoHjzYneByUlTn0eq/jNl8NxJEwKA/adyx7F0tYflgN41lT6vsSUPRAok2IAJQw==",
       "dependencies": {
-        "@gjsify/http": "^0.4.21",
-        "@gjsify/tls": "^0.4.21"
+        "@gjsify/http": "^0.4.29",
+        "@gjsify/tls": "^0.4.29"
       }
     },
     "node_modules/@gjsify/inspector": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.4.21.tgz",
-      "integrity": "sha512-qLU3t1jdGHATPF/KIHGV4yYnllZFmb4bDNLNRPEhEEpeOa892PENfSZeA6DUPMTw926RaGJqNEL5izZJQl7q0A=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.4.29.tgz",
+      "integrity": "sha512-rbXVL8kwQdxV39mE5g3syBVOS2gR7p6ids5bW9QIccH9r3BnZ+K+oDDHDP9iwSuEuhIwbqkEnZyVOvrRumWyTA=="
     },
     "node_modules/@gjsify/message-channel": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.4.21.tgz",
-      "integrity": "sha512-O3tWlUy2Xr2i/RsPKy/gAksregyZmCh1hq8nUkhydAOxKMU3ZMDzicscpkpOAmZzrH533GMCrEOz2dkTI3xh0A==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.4.29.tgz",
+      "integrity": "sha512-l3n04jneznSQX3KvV+BhyUg87VCsomI8/hY1T1smDsDYynVtxFu6JYxzejbSDU5z74NS8h94ISwFfdUNnZ7qPg==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.21"
+        "@gjsify/dom-events": "^0.4.29"
       }
     },
     "node_modules/@gjsify/module": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.4.21.tgz",
-      "integrity": "sha512-YoJYWkKhPKjnOEo7jPGuoJxIm1LCLororusAN7byr4vrIvnuqfdZOnIoe9Sx6bxYUiyNPTqtPTEzqD2xIgNUHw==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.4.29.tgz",
+      "integrity": "sha512-QGQhnw28Uc6aiq3b2On1xoEY9PnxJa3rppl/a0MOoAkasxi2SB4W7bnSdCJsnW5LMlGyLNiFoDje6AUyeXTNhA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/net": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.4.21.tgz",
-      "integrity": "sha512-mv0DHPOgMfQyVvuHN+GRcVPFdHPS7QmA1cHwXG3B+5P4btbYWwX4wCLH8PrWxVKP/9IONsVS6NPgaHSYvMS05w==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.4.29.tgz",
+      "integrity": "sha512-04h88lYX7BMZIhlwrHN22NLBIU7SPcF3aAlqZudqNcRCuinLyiXCpq2LLhKm/obfuqFY1rc1LSWGuDehqTJ6og==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/buffer": "^0.4.21",
-        "@gjsify/events": "^0.4.21",
-        "@gjsify/stream": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/buffer": "^0.4.29",
+        "@gjsify/events": "^0.4.29",
+        "@gjsify/stream": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/node-globals": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.4.21.tgz",
-      "integrity": "sha512-mURFEDWQRZzV3wxpAZo/ykMTvOUlQ1LToyieszMYqB1gYZIo5NfMnyNr9jlyY4AagUZBOR+W+Cst4tuWNIiv/w==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.4.29.tgz",
+      "integrity": "sha512-Xbx7cco/pEnVb9VqjiCZvKMgZBJGbsvmjmLxG7cjY6LRHw313KOUWPTFjShKnGc0xfwfcd1lNdEM227Xj2Gl4w==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/buffer": "^0.4.21",
-        "@gjsify/process": "^0.4.21",
-        "@gjsify/url": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/buffer": "^0.4.29",
+        "@gjsify/process": "^0.4.29",
+        "@gjsify/url": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/node-polyfills": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.4.21.tgz",
-      "integrity": "sha512-Pm7bUaKKBFiZ75eFzBc/jxtyD+icwMmuQx7XYqty9S40k3rSNKhQDFV8q4XMIyWAI2ERL7ZStKDnMYeBO7gGSg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.4.29.tgz",
+      "integrity": "sha512-DH8eug9vh1i82HTqZfqoAdO9tyKOBalufVXe6vuFYzSc6w/OsII3hdCykJlE9bDjss7Xy2ARGgH0xxUfW2yVKw==",
       "dependencies": {
-        "@gjsify/assert": "^0.4.21",
-        "@gjsify/async_hooks": "^0.4.21",
-        "@gjsify/buffer": "^0.4.21",
-        "@gjsify/child_process": "^0.4.21",
-        "@gjsify/cluster": "^0.4.21",
-        "@gjsify/console": "^0.4.21",
-        "@gjsify/constants": "^0.4.21",
-        "@gjsify/crypto": "^0.4.21",
-        "@gjsify/dgram": "^0.4.21",
-        "@gjsify/diagnostics_channel": "^0.4.21",
-        "@gjsify/dns": "^0.4.21",
-        "@gjsify/domain": "^0.4.21",
-        "@gjsify/events": "^0.4.21",
-        "@gjsify/fs": "^0.4.21",
-        "@gjsify/http": "^0.4.21",
-        "@gjsify/http2": "^0.4.21",
-        "@gjsify/https": "^0.4.21",
-        "@gjsify/inspector": "^0.4.21",
-        "@gjsify/module": "^0.4.21",
-        "@gjsify/net": "^0.4.21",
-        "@gjsify/node-globals": "^0.4.21",
-        "@gjsify/os": "^0.4.21",
-        "@gjsify/path": "^0.4.21",
-        "@gjsify/perf_hooks": "^0.4.21",
-        "@gjsify/process": "^0.4.21",
-        "@gjsify/querystring": "^0.4.21",
-        "@gjsify/readline": "^0.4.21",
-        "@gjsify/sqlite": "^0.4.21",
-        "@gjsify/stream": "^0.4.21",
-        "@gjsify/string_decoder": "^0.4.21",
-        "@gjsify/sys": "^0.4.21",
-        "@gjsify/timers": "^0.4.21",
-        "@gjsify/tls": "^0.4.21",
-        "@gjsify/tty": "^0.4.21",
-        "@gjsify/url": "^0.4.21",
-        "@gjsify/util": "^0.4.21",
-        "@gjsify/v8": "^0.4.21",
-        "@gjsify/vm": "^0.4.21",
-        "@gjsify/worker_threads": "^0.4.21",
-        "@gjsify/zlib": "^0.4.21"
+        "@gjsify/assert": "^0.4.29",
+        "@gjsify/async_hooks": "^0.4.29",
+        "@gjsify/buffer": "^0.4.29",
+        "@gjsify/child_process": "^0.4.29",
+        "@gjsify/cluster": "^0.4.29",
+        "@gjsify/console": "^0.4.29",
+        "@gjsify/constants": "^0.4.29",
+        "@gjsify/crypto": "^0.4.29",
+        "@gjsify/dgram": "^0.4.29",
+        "@gjsify/diagnostics_channel": "^0.4.29",
+        "@gjsify/dns": "^0.4.29",
+        "@gjsify/domain": "^0.4.29",
+        "@gjsify/events": "^0.4.29",
+        "@gjsify/fs": "^0.4.29",
+        "@gjsify/http": "^0.4.29",
+        "@gjsify/http2": "^0.4.29",
+        "@gjsify/https": "^0.4.29",
+        "@gjsify/inspector": "^0.4.29",
+        "@gjsify/module": "^0.4.29",
+        "@gjsify/net": "^0.4.29",
+        "@gjsify/node-globals": "^0.4.29",
+        "@gjsify/os": "^0.4.29",
+        "@gjsify/path": "^0.4.29",
+        "@gjsify/perf_hooks": "^0.4.29",
+        "@gjsify/process": "^0.4.29",
+        "@gjsify/querystring": "^0.4.29",
+        "@gjsify/readline": "^0.4.29",
+        "@gjsify/sqlite": "^0.4.29",
+        "@gjsify/stream": "^0.4.29",
+        "@gjsify/string_decoder": "^0.4.29",
+        "@gjsify/sys": "^0.4.29",
+        "@gjsify/timers": "^0.4.29",
+        "@gjsify/tls": "^0.4.29",
+        "@gjsify/tty": "^0.4.29",
+        "@gjsify/url": "^0.4.29",
+        "@gjsify/util": "^0.4.29",
+        "@gjsify/v8": "^0.4.29",
+        "@gjsify/vm": "^0.4.29",
+        "@gjsify/worker_threads": "^0.4.29",
+        "@gjsify/zlib": "^0.4.29"
       }
     },
     "node_modules/@gjsify/npm-registry": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.4.21.tgz",
-      "integrity": "sha512-P7VwphdTrV/b9RnbLNO0eS9B9X274n+m+CYZCRzIGq8MfYZ2DhVIpZ9EAHy9NxkeXm2Np24Giaw3lMmh+CAQ4A=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.4.29.tgz",
+      "integrity": "sha512-PC1Blb18Mga4rRuN8CCW0+7U6f9san/g9eASvUn2cJB0QR1DJQWA3HeWIygwrEA7Ux7WU28xcgGa9Tez+7RaZg=="
     },
     "node_modules/@gjsify/os": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.4.21.tgz",
-      "integrity": "sha512-zZTMN7WuzfJRM1k0kBTCXOwK4N2fW7CvMbl2OyW0G4tHzTjdRTBy6hB+qdv4S/s7JY2HtW+iT2WqgTph8oHzkw==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.4.29.tgz",
+      "integrity": "sha512-pZmOYvENjOYyNK4ea6PphMHJeBByeVvmcCnO9jaJwaMtE20UT5dVbMux8TzFKn/Lup8eB3DE8dR5aEtkG25NxQ==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/path": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.4.21.tgz",
-      "integrity": "sha512-/i+D07k5V9LOW75C1DwtSd+7xAhU84wfYrGiVQGth72qY1282YyJvfdu4Ddh+PBF6i9vJSssW+yMxtjQlcFBWg=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.4.29.tgz",
+      "integrity": "sha512-zAqrP4r1wBYIIVbFxeQBc9/yVppuW79iD9GQVacQQj4kIOkmAwwUs8MM37zMKYwWFdYyWqpd74RN37oajCGj6Q=="
     },
     "node_modules/@gjsify/perf_hooks": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.4.21.tgz",
-      "integrity": "sha512-zcaQwdZeGgkEra+W8sgKC0FAASDXyve/FZKCQ1NLSOKfyjPst7416MeIXt4ruBkeiCvc0GjWAGaTGwQA4/wgAw=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.4.29.tgz",
+      "integrity": "sha512-4pOP8i8mVrK53N8NyjiOphWDgscuMWLfoiSNWeiT1ziwcIKfaGAe+kpsXSwaTDCRix9EnUFxfLNOPNrtWsX2Jw=="
     },
     "node_modules/@gjsify/process": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.4.21.tgz",
-      "integrity": "sha512-4m6oZoLRXmYyUTsA47W0ExHBRFitjeNEHOh+SGao7vnKyy2oBcen3UFilb6i7psQ+r2TcwMbbUo/ptfCtGe9ow==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.4.29.tgz",
+      "integrity": "sha512-ZhAR6DigW3v2Di7LSsltFrr0+MHDD1vDQnN85KyfeEiE/+jLh9kTK3h70lm4WhgELOzoxK/e37tro3pteP4/yw==",
       "dependencies": {
-        "@gjsify/events": "^0.4.21",
-        "@gjsify/terminal-native": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@gjsify/events": "^0.4.29",
+        "@gjsify/terminal-native": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/querystring": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.4.21.tgz",
-      "integrity": "sha512-2TCEppqELU6N16OwO1D0CbqWUYX2JhBghGQw18FpA8Lyg+APtFI7VYioNL6ZZ5VFIpAxkQU0b1NAWcJtA3baOQ=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.4.29.tgz",
+      "integrity": "sha512-d833whAg9YMmiP0bC0qgZsRBg6AcuU5F99+rGC3wiwnAphBo0oVyEQ+oiOuKrmhL+rm4wjEVxJ0sczvvA3Rn+Q=="
     },
     "node_modules/@gjsify/readline": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.4.21.tgz",
-      "integrity": "sha512-iOYpfwqo4LU1zg09HMH07eEEhKf/gTwk98xjYILntv5UpnmsBSQPGUk84FxhyhqDzp0WDMkqCUsLy/9lagodOw==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.4.29.tgz",
+      "integrity": "sha512-wrVU5WAy8bSTSnnZHWqtDC/BNS95Ba+rrs7yV4MJyd/Jh1j5a1K1gr+2bC2+kLfTvpPE9a30NhKgYStONWnmDA==",
       "dependencies": {
-        "@gjsify/events": "^0.4.21"
+        "@gjsify/events": "^0.4.29"
       }
     },
     "node_modules/@gjsify/resolve-npm": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.4.21.tgz",
-      "integrity": "sha512-CLGsE/QEd2Xo3GBeRu5G0sAvGdzhlpWju8ctaql4l7sfaFyBOhI4t3ht08K0O0OJ3VGQvgRdDcCaI5hT/kwyqw=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.4.29.tgz",
+      "integrity": "sha512-0Pxk5heqEklyAtdwlsQFZwiuVCnEVVOcDvF+o1X2o+/L/pBieyqr4QG2hXqCrfWrlaziz1aUGKURCpBiKAd+cw=="
     },
     "node_modules/@gjsify/rolldown-plugin-deepkit": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.4.21.tgz",
-      "integrity": "sha512-+ZveMJunCiJpA/MFyP6x1DJww+0m81E+ew0mu7qWoJ5N7lxakFslInAD+QV7XdV4t7JVKU33gHENCdLCKtYvmw==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.4.29.tgz",
+      "integrity": "sha512-/jb49ggAk04xDd9P0Fk2RJNr6CweJR6JGLMw1vzE0ZdG038/5rCKH0gzEkJNYGiClWtD6a1/1YfxH96n3/kdUw==",
       "dependencies": {
         "@deepkit/type-compiler": "^1.0.19",
         "typescript": "^6.0.3"
       }
     },
     "node_modules/@gjsify/rolldown-plugin-gjsify": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.4.21.tgz",
-      "integrity": "sha512-F9e53kVupLYbAxOMaJM9fVf3rw5iXoTGQii5GyjTWQHtUErydLi6AtVK69zk5qFs/aGTXNYKKYnkmLXupMbNbg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.4.29.tgz",
+      "integrity": "sha512-F3wKxRvYRzNg3nMap/I1yOQIjb8TNxzR8GtxMrcL1uyrCmzIQY9Qa4FRD6b5Gp0601zGM/nG5POsMIeYUCz8sw==",
       "dependencies": {
-        "@gjsify/console": "^0.4.21",
-        "@gjsify/resolve-npm": "^0.4.21",
-        "@gjsify/rolldown-plugin-deepkit": "^0.4.21",
-        "@gjsify/rolldown-plugin-pnp": "^0.4.21",
-        "@gjsify/vite-plugin-blueprint": "^0.4.21",
+        "@gjsify/console": "^0.4.29",
+        "@gjsify/resolve-npm": "^0.4.29",
+        "@gjsify/rolldown-plugin-deepkit": "^0.4.29",
+        "@gjsify/rolldown-plugin-pnp": "^0.4.29",
+        "@gjsify/vite-plugin-blueprint": "^0.4.29",
         "@rollup/pluginutils": "^5.3.0",
         "acorn": "^8.16.0",
         "acorn-walk": "^8.3.5",
@@ -3545,1478 +3770,1528 @@
       }
     },
     "node_modules/@gjsify/rolldown-plugin-pnp": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.4.21.tgz",
-      "integrity": "sha512-MV3w1XmA1h5FZL5nAK5hLgg5BfEOTYBXDizDm8L50RqDgwOxocULAvrbPuRn90VTWdMh8vNoAjPx7SoXmmezvw=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.4.29.tgz",
+      "integrity": "sha512-VDeSmVpn72oJ6FYhxybF262+fUqwuCJdn9I6N3AWkUgH8OABYZ9I6BgUKDRwSfCzpm6ZNyHASIJXeBiCNPoKUw=="
     },
     "node_modules/@gjsify/sab-native": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.4.21.tgz",
-      "integrity": "sha512-J/NQ74yfW3PUg6q4lhDeOe2XjcoikP7RaI8EkKnyzOpaFSdNsdqWdSGIhbxloBzG3S4DgTFcoj6pI+Zg4aHcIw==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.4.29.tgz",
+      "integrity": "sha512-eMsQtt4gwwewWp9T+FtDGPgAVmdgacVv+k8shWS0VRyErAdMod7BQJVHei0hP2jkw1cBZiH4LzxsxQ6GaVe9sQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sab-native/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sab-native/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sab-native/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sab-native/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sab-native/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sab-native/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/semver": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.4.21.tgz",
-      "integrity": "sha512-5QCD2DKsoCNcv0RH0rCx4se+TzgjuO6oo9bptY9Bqz6WswCZpZBuYBX8wtVxobWSxqWknwzfnauop+xsRPuj8A=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.4.29.tgz",
+      "integrity": "sha512-LqTWo30k2kXSp0LYj5MN9Y1gJraolzUQwZ0dVbmfM3KEd8/ZsURk3a7VkFmdwUzAfUt7HwQLsM7VkZJOjxKrqA=="
     },
     "node_modules/@gjsify/sqlite": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.4.21.tgz",
-      "integrity": "sha512-/HeIJUQ3+bStEuJcIIfJqbrcCfVyUzQrbqbPHA79cyMJ2Nj4B36g/B2CX6O3PmDEi+yyZty5BByEzMtEskiJuA==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.4.29.tgz",
+      "integrity": "sha512-8+Sz57gfZN7j+xf/BRzM3/kAggObPkU9IoJ1um0NuX48Usj/sm6qiVUKex0AlQfbEnKyLhB6d4XCK/mdwg14eg==",
       "dependencies": {
-        "@girs/gda-6.0": "6.0.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gda-6.0": "6.0.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/stream": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.4.21.tgz",
-      "integrity": "sha512-lcf3V0klStcSpceJs1RrpeERs4ZE6SNIKP9y6bHHMjw8GfRY8QEkd3LU0ngqwe+zoJ6VrbD3MTjyGw09li9MMg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.4.29.tgz",
+      "integrity": "sha512-3tQD5437fqmo0X1B0RytP93gDQ8hBHzWGkvRphaEc2efO+iqFYZwiZtBmP6ZcDjP7kHCaIxZ3uNSD6Ck+RRORQ==",
       "dependencies": {
-        "@gjsify/events": "^0.4.21",
-        "@gjsify/utils": "^0.4.21",
-        "@gjsify/web-streams": "^0.4.21"
+        "@gjsify/events": "^0.4.29",
+        "@gjsify/utils": "^0.4.29",
+        "@gjsify/web-streams": "^0.4.29"
       }
     },
     "node_modules/@gjsify/string_decoder": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.4.21.tgz",
-      "integrity": "sha512-8WZucZ4tSNz8x1GXS3ikduTwG2Gx59HCBh6Ly40DMu9QjQSxhrOy+E0V30TjgePBk84JQsIKJC76fMC1JD486w==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.4.29.tgz",
+      "integrity": "sha512-zH2M/XD390qyeIJnYXA0b5sM1yoQjaRy+CJMKQZ7okzS1ruEKknqqNe4OCkkBxuYPZNyhnBt2+Jp2WdvCM/qsQ==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.21"
+        "@gjsify/buffer": "^0.4.29"
       }
     },
     "node_modules/@gjsify/sys": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.4.21.tgz",
-      "integrity": "sha512-AkOshqt4SMw2aeoERUckizt674E4uTd1z9HTymlbBLNL2UFpV+3TTHK58LCi+7wz7ipUEhPFAiDxoAWgeyD2CQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.4.29.tgz",
+      "integrity": "sha512-Vf9c6FACBrx/TrMcs5GqByda1fZGl+rfRG16uy+kMak2PvAUGEgRve4ojeaKeh0o39uL1MukwGg4u191SI9yoQ==",
       "dependencies": {
-        "@gjsify/util": "^0.4.21"
+        "@gjsify/util": "^0.4.29"
       }
     },
     "node_modules/@gjsify/tar": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.4.21.tgz",
-      "integrity": "sha512-wklHa++30vdOrDV95JgR9QRtrleTE0hspblAWq9Kq6ij/cFv7kzXd6Jwjg97jDt5/KDRfY3P84gRm5bhqE6qLA=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.4.29.tgz",
+      "integrity": "sha512-1dZ+T/YCGTH6M1pCFDB+9ivQGjQlWlGEZPQpDXpAvFGjjSuReKpjDOXFHy3mvzeLXHglyeiMtOnmGQaqYO9Jdg=="
     },
     "node_modules/@gjsify/terminal-native": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.4.21.tgz",
-      "integrity": "sha512-qV//7siSqRXZ9gfVd4Eu8jLfJjYO2sECiET+70NZs+0rSScqkxdR/G0O91+tHrLzfEC32lLVlISnttlYSRGaIg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.4.29.tgz",
+      "integrity": "sha512-Ip0dH1aO9XhtN14HAUXpyL+hRPMnkbaP0zlc651rUxvgDPN/X1COfnpTpbuqThVZ7L2al+Zd7QoxK2GYmsVCWQ==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/timers": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.4.21.tgz",
-      "integrity": "sha512-OETMXvQ5fTuiBU9PIrtMHJXbxKA0n140iZ1/2A/6RJBB9JgdaMkQNHRBJbtWz+L1uAs48VCm1DJZ2+Rr/V2Azg=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.4.29.tgz",
+      "integrity": "sha512-rfZd5Sz/U9+L2nTq/5usrv6kWNX/8U5U+xFkMzQWmlrvZfDz+wpP91B9tajQBlTP9HtKejeGfalLII12T6gwTQ=="
     },
     "node_modules/@gjsify/tls": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.4.21.tgz",
-      "integrity": "sha512-Np7TgJKaVvp1nEQgRW9Q/hgJ9FS9kc/kSzZIZzmzRB2jEFhGntxCzrs9pv6pWW6dX0JYPuAXkFi5IycfaEmQ8g==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.4.29.tgz",
+      "integrity": "sha512-jmctrsXvnE/9zsAdkamPvAe11THG/op+G2cmlYIs/AK9YXYuWbTWlImc8WxbhJHMhv2cxNIoJs1vVKlxDgs3xA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/net": "^0.4.21",
-        "@gjsify/utils": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/net": "^0.4.29",
+        "@gjsify/tls-native": "^0.4.29",
+        "@gjsify/utils": "^0.4.29"
+      }
+    },
+    "node_modules/@gjsify/tls-native": {
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.4.29.tgz",
+      "integrity": "sha512-77fvusLDjQxaHzP6jK3kbM2uJY4PXwOAdZIIKGQ9TDLLjMmezZRkSfxA/RU5yirOtRRu/Y+pHkgQG1U9kJZFkA==",
+      "dependencies": {
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/tls-native/node_modules/@girs/glib-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/tls-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/tls-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/tls-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/tls-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/tls-native/node_modules/@girs/gobject-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/tls-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/tls-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/tls-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/tls-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tty": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.4.21.tgz",
-      "integrity": "sha512-33v5Loglo31tIr6696JGOj4H9PKpGmcK9Vgh0+IiKnodwVU5Su6Zt94R3pGtZ+4RmYFS1zqhqqoeDeb3/Huq3A==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.4.29.tgz",
+      "integrity": "sha512-1l5p6P4bjp5GpfRdTYE40nflYT0RzpxKvyTe5TT+ysb3e66va2RIX0CnciZYk7h++qI6nOexPZogc6cRF3hVPg==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/stream": "^0.4.21",
-        "@gjsify/terminal-native": "^0.4.21"
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/stream": "^0.4.29",
+        "@gjsify/terminal-native": "^0.4.29"
       }
     },
     "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/url": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.4.21.tgz",
-      "integrity": "sha512-DRoyeBRrOOGwBDNvYufZrKphkvMXrjTUf8CuucnoAK6clGcx8sUbsf8ztm2Bxj2ZJdSOW67/HMhhfaxH9VyfAg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.4.29.tgz",
+      "integrity": "sha512-LkSCTBBwaqWn5sIZMcLmT7HA7IrY/iZsqoUDPKasW8xylpNwJc0MTaakco6AUT4r3RW2yCnt7SLsgryXaz57Sg==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/url/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/url/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/url/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/url/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/url/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/url/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/util": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.4.21.tgz",
-      "integrity": "sha512-g/GienCwaduO6T1vd9p9zMm7/B1IiwAqirMTcVd7ctWKwi3U/y8p5G2pliVr0ZJbwcV8uTOpgZX5tqfDVN0PaA=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.4.29.tgz",
+      "integrity": "sha512-RuAf78PpeMvhWjmFj6UL8DyqgHE0ev0P0V5saWGnuIi4U51wCyl3jtngecsoIpxu2DZFnS2ywBCqyXuSix+e+A=="
     },
     "node_modules/@gjsify/utils": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.4.21.tgz",
-      "integrity": "sha512-0Bb9W1U87C5tpbOQmVrIJCtdn8yaxrEE7WOW7fxWBqab9OzgMzXnfpy2VFosmD8ch5VkVHRFAQYvK59TZRRWdg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.4.29.tgz",
+      "integrity": "sha512-jaq444UT8U+HTmmvTC8TrlUe6nckpb52H2SWSngGzpjoRPJrkxZvKfyPNgrY1EnvYZOyoKSJpsLfMi7s7VlvjA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/giounix-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/giounix-2.0": "2.0.0-4.0.1",
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/v8": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.4.21.tgz",
-      "integrity": "sha512-nCJpXb641h2zTdm+b1QZb6Aup8vpuCLJEZJeEC3HVkzVHOTogZEDT61xQCnO7xKxtNQreIbYwIXT9BPN2lkt7g=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.4.29.tgz",
+      "integrity": "sha512-mVvEEEIKeGFQY7MbMy9wheKAaPf93CbcU1eQtn90H4A89/JfQp3WmvKPjZdCE/SNNrmGlEqSFCekwhWkFNeoQA=="
     },
     "node_modules/@gjsify/vite-plugin-blueprint": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.4.21.tgz",
-      "integrity": "sha512-RicnxAoPK/UXVAL5Ys66ppJMTzu8akYVubNVIzXq+cg2TPJO1aUcs0hdrMIrlkrWDek7adMyxnsvP/kIt2Af+A==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.4.29.tgz",
+      "integrity": "sha512-L0GazK/pVv1sQiLvJjP38aH2V0yNA3+rBAXUoieN4QDO9Mwv6Kj6sVCwNkT1ogxJUIH+gHrowSL5D0gNQwTYtQ==",
       "dependencies": {
         "execa": "^9.6.1",
         "minify-xml": "^4.5.2"
       }
     },
-    "node_modules/@gjsify/vite-plugin-blueprint/node_modules/execa": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.1",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.2.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.1.1"
-      }
-    },
-    "node_modules/@gjsify/vite-plugin-blueprint/node_modules/execa/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      }
-    },
-    "node_modules/@gjsify/vite-plugin-blueprint/node_modules/execa/node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="
-    },
-    "node_modules/@gjsify/vite-plugin-blueprint/node_modules/execa/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
-    },
-    "node_modules/@gjsify/vite-plugin-blueprint/node_modules/execa/node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      }
-    },
-    "node_modules/@gjsify/vite-plugin-blueprint/node_modules/execa/node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
-    },
-    "node_modules/@gjsify/vite-plugin-blueprint/node_modules/execa/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-    },
-    "node_modules/@gjsify/vite-plugin-blueprint/node_modules/execa/node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
-    },
     "node_modules/@gjsify/vm": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.4.21.tgz",
-      "integrity": "sha512-CPRhDdNfWWwk6+VBKwipHAUd/D2fIZMpt5KmBHx5mWnHTa7TyKYR/KTKM1emJJPG0j08bWOG6g7dgBmNtV+82Q=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.4.29.tgz",
+      "integrity": "sha512-xU3Pr7dxd72VohyxFXBgnFuhBTvmdnRKP1/Wzr1dCGrxXPlLSCSqU5wvZPpVoIhsM94oWpwImVQTMSyOamc0kw=="
     },
     "node_modules/@gjsify/web-globals": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.4.21.tgz",
-      "integrity": "sha512-LPqYk0KMUL4XlQYOpgbOKjLNnNnUxrcoxrgCo0rd6jo7pJ+99VUjrGRTrZLcxTChtZ9fBsDHq1wthQuocjPB2w==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.4.29.tgz",
+      "integrity": "sha512-VAackkGVxKRXuOTu3jqWEKE7ZG7Ho058ZnBI/mEPtT9Y61sdWnKO7zAMKLJBN0P4v2X9FZXtkZIjwTQsJkq5nw==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.4.21",
-        "@gjsify/buffer": "^0.4.21",
-        "@gjsify/compression-streams": "^0.4.21",
-        "@gjsify/dom-events": "^0.4.21",
-        "@gjsify/dom-exception": "^0.4.21",
-        "@gjsify/eventsource": "^0.4.21",
-        "@gjsify/formdata": "^0.4.21",
-        "@gjsify/gamepad": "^0.4.21",
-        "@gjsify/perf_hooks": "^0.4.21",
-        "@gjsify/url": "^0.4.21",
-        "@gjsify/web-streams": "^0.4.21",
-        "@gjsify/webaudio": "^0.4.21",
-        "@gjsify/webcrypto": "^0.4.21"
+        "@gjsify/abort-controller": "^0.4.29",
+        "@gjsify/buffer": "^0.4.29",
+        "@gjsify/compression-streams": "^0.4.29",
+        "@gjsify/dom-events": "^0.4.29",
+        "@gjsify/dom-exception": "^0.4.29",
+        "@gjsify/eventsource": "^0.4.29",
+        "@gjsify/formdata": "^0.4.29",
+        "@gjsify/gamepad": "^0.4.29",
+        "@gjsify/perf_hooks": "^0.4.29",
+        "@gjsify/url": "^0.4.29",
+        "@gjsify/web-streams": "^0.4.29",
+        "@gjsify/webaudio": "^0.4.29",
+        "@gjsify/webcrypto": "^0.4.29"
       }
     },
     "node_modules/@gjsify/web-polyfills": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.4.21.tgz",
-      "integrity": "sha512-x/CKg/em7BZn3PNOrlFqpNz0t1g4/3LB3/t/mJ7+3kXw0oQKjkkpiPn0a6Vi3rXYIGGe0rRMVdz8O9OSgSiuvQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.4.29.tgz",
+      "integrity": "sha512-dx2Xp1LrFKKbuTHatWwdsjwumoWZz/3+KuAeBULe3D/AtbLoKZUVK4drAZceAEk2Aefn4LL1einu2J4Ck6jzAQ==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.4.21",
-        "@gjsify/compression-streams": "^0.4.21",
-        "@gjsify/dom-events": "^0.4.21",
-        "@gjsify/dom-exception": "^0.4.21",
-        "@gjsify/domparser": "^0.4.21",
-        "@gjsify/eventsource": "^0.4.21",
-        "@gjsify/fetch": "^0.4.21",
-        "@gjsify/formdata": "^0.4.21",
-        "@gjsify/gamepad": "^0.4.21",
-        "@gjsify/message-channel": "^0.4.21",
-        "@gjsify/web-globals": "^0.4.21",
-        "@gjsify/web-streams": "^0.4.21",
-        "@gjsify/webassembly": "^0.4.21",
-        "@gjsify/webaudio": "^0.4.21",
-        "@gjsify/webcrypto": "^0.4.21",
-        "@gjsify/websocket": "^0.4.21",
-        "@gjsify/webstorage": "^0.4.21",
-        "@gjsify/xmlhttprequest": "^0.4.21"
+        "@gjsify/abort-controller": "^0.4.29",
+        "@gjsify/compression-streams": "^0.4.29",
+        "@gjsify/dom-events": "^0.4.29",
+        "@gjsify/dom-exception": "^0.4.29",
+        "@gjsify/domparser": "^0.4.29",
+        "@gjsify/eventsource": "^0.4.29",
+        "@gjsify/fetch": "^0.4.29",
+        "@gjsify/formdata": "^0.4.29",
+        "@gjsify/gamepad": "^0.4.29",
+        "@gjsify/message-channel": "^0.4.29",
+        "@gjsify/web-globals": "^0.4.29",
+        "@gjsify/web-streams": "^0.4.29",
+        "@gjsify/webassembly": "^0.4.29",
+        "@gjsify/webaudio": "^0.4.29",
+        "@gjsify/webcrypto": "^0.4.29",
+        "@gjsify/websocket": "^0.4.29",
+        "@gjsify/webstorage": "^0.4.29",
+        "@gjsify/xmlhttprequest": "^0.4.29"
       }
     },
     "node_modules/@gjsify/web-streams": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.4.21.tgz",
-      "integrity": "sha512-7t91w4kqX0pwwsHg3rFw/lOEcwv6Fr8lAp6ObpmOKXb5qgDIrs3L2rtd5UfbtsWY+mbmVht+MwhrW8VLgBwUFQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.4.29.tgz",
+      "integrity": "sha512-Rat0swQrlzVXEfayGcwwzgegNyZqZhK/rKFZaIvqOjbInAK22TUyPLCkvnQxBjx2qx/JyTpWUTxLdxnm4c1L9Q==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.21"
+        "@gjsify/utils": "^0.4.29"
       }
     },
     "node_modules/@gjsify/webassembly": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.4.21.tgz",
-      "integrity": "sha512-n4XnOaANvN+52fPppzygohj9v0/iRgT6UVXGMhPyzItQnk2fHrfY8QutBjTy95QM54XhB7q1u4MhY3mTaenFkQ=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.4.29.tgz",
+      "integrity": "sha512-bYcUljt0+BUjGQjPBH8Yz97FI08JQz4pPyP7AeTzKRr/gyIa0usqi20tBftPIiuWeFkEoNFn5H0R+YLvGjnl+g=="
     },
     "node_modules/@gjsify/webaudio": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.4.21.tgz",
-      "integrity": "sha512-ipFRGfQTMzcc+6mligXnHsCQ8FULIy4iGYDnDLjcLx3p04Ku1rm1A6/zu1f1Q1UuI7L8C2+9tz//JNKPCWZANQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.4.29.tgz",
+      "integrity": "sha512-UPFQ4X8OR9mL4qO+pBbRw0FI6t3HkJTaQoYrNvLXsDl2dDQ+Yo0qurH04/CYfqEqlfOm5EhofXsStPzE5Hzj5Q==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.21"
+        "@gjsify/dom-events": "^0.4.29"
       }
     },
     "node_modules/@gjsify/webcrypto": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.4.21.tgz",
-      "integrity": "sha512-TCDPe7w84wVAV7Ingz6GN9to8GxfBBgj5uh+B0KUJSSjegBUXNOCtn9xvgWnrzxjyINIHJ2MENi5N3eFiRekaQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.4.29.tgz",
+      "integrity": "sha512-uQjPmTkhotIXbmF8v2duEtQ82tUfwLlRR+80748kHn1/WRowbKJHJOzt6En7UYBjTpwoPy2yXvBinzgOU3KwWA==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.4.21"
+        "@gjsify/dom-exception": "^0.4.29"
       }
     },
     "node_modules/@gjsify/webgl": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/webgl/-/webgl-0.4.21.tgz",
-      "integrity": "sha512-Ix0ajVtSG+JxjqqTNNGFAI3mSN1rEvjeRxq34q1eLJQ441rSRgKiPW4oDLJoLdXp3lwt09WwFqM4hN2vH+ksYg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/webgl/-/webgl-0.4.29.tgz",
+      "integrity": "sha512-3LWQhTqXs1N847hcElsSgW9WeiySdi5czfCacprToHhe52ZvqexT3+B4sdo9NWyuHxlq4uN2VvKekjdZ6MwAlw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gtk-4.0": "4.23.0-4.0.0-rc.15",
+        "@girs/gjs": "4.0.1",
+        "@girs/gtk-4.0": "4.23.0-4.0.1",
         "@girs/gwebgl-0.1": "0.1.0-4.0.0-rc.5",
-        "@gjsify/dom-elements": "^0.4.21",
-        "@gjsify/dom-events": "^0.4.21",
-        "@gjsify/event-bridge": "^0.4.21",
-        "@gjsify/utils": "^0.4.21",
+        "@gjsify/dom-elements": "^0.4.29",
+        "@gjsify/dom-events": "^0.4.29",
+        "@gjsify/event-bridge": "^0.4.29",
+        "@gjsify/utils": "^0.4.29",
         "bit-twiddle": "^1.0.2",
         "glsl-tokenizer": "^2.1.5"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gjs/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0": {
-      "version": "4.23.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-extSsa7YIzglPPUjNYoPyQyJIMflZbA/ORVtecPUXYRLB4mTwy8+CGvnXjD7FsQLnbGP/f1SrpuO14OQvqJ90Q==",
+      "version": "4.23.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.1.tgz",
+      "integrity": "sha512-a5wAjHPHI//ZiMODFM2EEV0R/+5wcoM5BkDBjlaX3eRbapq3+DWxhevsgmZRlwz4SOqLqgvusJRsjnX3nrf+tg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gsk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gdk-4.0": "4.0.0-4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/gsk-4.0": "4.0.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/graphene-1.0": "1.0.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-9ewd7cwn+2YjjhRW2WUTn38U2D98gEAWM85zBcYti+81yvG/5iRH93o1Ki32bwFWzSI1JWi/+F90YkbV0Hb9QQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-NFWG8T3WCNT6JV/p1g8VVBUdQQdW7SfQJk0De1PATLo+gpbay0M5eHCb1+oQoPPOozyFviAXtFm0o0XjIki2xA==",
+      "version": "4.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.1.tgz",
+      "integrity": "sha512-zrzRqPBD2PFh0/lqav7TYnL4qVHHIgH7SM6oEj/I7kQZWjk06GyfSj60cyhYOXUlX5O67tViZ0KPPnXO0O6eqA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-sC9ANhTdVngxlXGfItkiTeBkhfW+DwyfGo2b7rV8H4r0MQ3//2+L3tu6O3QFqbvGXSSk7K56a0D3fSc1et/aHQ==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-Nqdy0NnKRdn61HDqht5JWGbVTS/Oc2VVDrzvnLFHF9AagtULQ9dhvDl7DoOhP/PngsoZFwX2y4OteEOs45ZWCw==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-fXHpp8NJUaUTA2/HU7KbGPUOVWE3N2HLrP7x4HQvxtvlUjo6BbyvQXTgyrnMED2ZlsvEy5RPVSAsk0RJiS81gg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gsk-4.0": {
-      "version": "4.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-uqw+KCXNSw4RelqywbLI0l5fC1Ff72PqpTVCuS3S7rDXbL2LkClvI5N3DvBHfj29MGORzTYPo8I0VE7+poJ9oQ==",
+      "version": "4.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.1.tgz",
+      "integrity": "sha512-rayS9BQzgCF9ruVXZQ9pOvwoEHxVFaNoRGH9NU2N6XiTG6T3dk6QGSzSBuvnNtmN1af5/vldBPvkJRSvWzhQ6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gdk-4.0": "4.0.0-4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/graphene-1.0": "1.0.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-giX1l3cOc0bvdvbdoHAAVskF/xfSYySh5WajX4+Yq7mMYAeWhXzsiY15s6FNjoRiB8BIIWg4lT6uGPqlMREhhw==",
+      "version": "13.2.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
+      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/pango-1.0": {
-      "version": "1.57.1-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.0-rc.15.tgz",
-      "integrity": "sha512-8a42I+2JQV20enK2zgJq++9AqAgPoXagikhEYH2hnLenG2kdYCImTsBQ2FxVdGmLS89+Qohg92tMR64VtJIo8Q==",
+      "version": "1.57.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.1.tgz",
+      "integrity": "sha512-1GrH9fqEsB/feXy/02pYujF42/taO8IL/fzTwx9syisiRHEEXNQwSV6N3EbCDOKHeUbDzv2KyNJm5b3pVLszRw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-tDRLVAV3ZJBzGOER7csNezXkeoYPVlaALKZ+7UiaVQ+VMYIDl2gtpOg7FVHl5dVmWgwPlpdM/RvSbiIXgEmb4Q==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-GRJbgTQap2LGPukqqL0WnrFpCZhR2i0DlLwD9QkSP1dFRCe4owaNizC6kQdbkvojqR+b3GfFbzqyVGlZKzD0Vg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/pango-1.0": "1.57.1-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.0-rc.15",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/pango-1.0": "1.57.1-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
+        "@girs/freetype2-2.0": "2.0.0-4.0.1"
       }
     },
     "node_modules/@gjsify/websocket": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.4.21.tgz",
-      "integrity": "sha512-LGiffVLzPyBBnm+l780Tx/e4KiHRe4nvYK5Bxq3gIoLd/LphGAgPHfmc9PJibEsxHQL07VnzIu60DUO1+AMNYg==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.4.29.tgz",
+      "integrity": "sha512-ZJaA4E1jRia9dHSV29fG1HVV8waIy+C7h7SBuakKz21zq5u+5vyylhIy28KHzDkgVI5cSf7WxpZaDzCVQGTseA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/soup-3.0": "3.6.6-4.0.0-rc.15",
-        "@gjsify/dom-events": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/soup-3.0": "3.6.6-4.0.1",
+        "@gjsify/dom-events": "^0.4.29"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/webstorage": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.4.21.tgz",
-      "integrity": "sha512-wq/2NaqtHPUnpPNHykDyu/puMG9U/9ujgjZSO6sv/3xLqfGGZAS47kYVYj2/XjW+YtdMQwi2Ubs9USpV/U2tmA=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.4.29.tgz",
+      "integrity": "sha512-x2mJyvv1t7CMQlIh79j7DmAPqzBL3FrIWnhGgv3hNXtIb4Gb8J+/uyj05teORxYfH/yPHTD+6otCyiewUX7LJw=="
     },
     "node_modules/@gjsify/worker_threads": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.4.21.tgz",
-      "integrity": "sha512-SU5IZ/yvL45sCsYqenz46dhkGBnrtei4sw6/RvS4ucldQnDC3upK7RcVqwNCkBjESShqsl4WzqBzfUGT3KwYaA==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.4.29.tgz",
+      "integrity": "sha512-a8uKGx/jSIbhmLKqMTs7QY9Q3FmPfDNovuHr/qu5Z+0E+eHG0WEKIdL21SfYtjAqy++F2Doy21y+GKq5+systg==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/events": "^0.4.21",
-        "@gjsify/message-channel": "^0.4.21",
-        "@gjsify/sab-native": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/events": "^0.4.29",
+        "@gjsify/message-channel": "^0.4.29",
+        "@gjsify/sab-native": "^0.4.29"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/workspace": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.4.21.tgz",
-      "integrity": "sha512-0kNCzTSAUuZGg67P/x8U0fkBoINvdlJ5flKDTdgc5cYMDO4Ruz62ZHZtoROXV/njE9GO6d6L090+cfQ29Eo1PQ=="
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.4.29.tgz",
+      "integrity": "sha512-HL62CJ3B8BKdYwRcWQW0quN3k9Eot0nBEQGd97k6YFsAzImYrNsylcHJKNIshyRm7t1P/BqB/QPH5Orlup/n3Q=="
     },
     "node_modules/@gjsify/xmlhttprequest": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.4.21.tgz",
-      "integrity": "sha512-mYBgZ6zMAhC19rvZ+4pKwh+sRua3a4W0WHTeUQ0A0fPNb9n9YW64wlJK2qfIShsjg9DDwYrqbfKA5VMdtyrGig==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.4.29.tgz",
+      "integrity": "sha512-5bCVW0vUqS5XxWUvjm1TyqYK59Rmvo3rpNMpDQ6WWbbqMvWaiKUoKu1ZyZEH7lTFUv0TpT2TmQhK1M+yHFLZyA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@gjsify/fetch": "^0.4.21"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@gjsify/fetch": "^0.4.29"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/zlib": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.4.21.tgz",
-      "integrity": "sha512-7j1fCne+Q7nu/dvTdZ//BDkQkY8Xxi1x9Hq9tZHha5NmY3pDAozcYSCondd21pse25Kio1jrj6HEFO9IMb4JBQ==",
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.4.29.tgz",
+      "integrity": "sha512-R3HdIP2A2YLZaBAr773B02EseEqScUGm9pDsGFuYTX5rcOih4R6d78fZAHuhVgUNKlQ4EifI7OtiGRIigfiqlw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-ccnwhll0WgK6u4cCN7lwD8frRWnygRHdXi6mAZXpZaYi8vcPxWz59kQLVE8Zr2wwGhWaHygeuQd4FyY9FOil4A==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-QCiFhcK04FbS83zuOcNpyD06D9VL5VMzWgLwbD3guipT3YTrpyiiioBDvMEnsPRBXE1fQTulfnLzaBQz480Hag==",
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-7XTGnWFPXSYMdMJVFgMsbNvXpQM48ZTPU3zMOKBGlWabjW2mX73xoGK7/D8ISpddqteC5QU5adohZXhuWI5qcA==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.15.tgz",
-      "integrity": "sha512-rATaKfEcIFnwgTBcAzu/khOmkHG2sAOxKFq7L8hN3/j7RrF3ehlMYczKXSM3SPN3tYj8XANJF8OBZ/eKkh8Olg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-GkH1Zp/E049gntiU1enoR7sg4rqEC2uOtRJ28hl1sWkJteyGtUkDK6dQP3WE90JVyEN7eIZK4kmkXgGULqLUWA==",
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15",
-        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.15.tgz",
-      "integrity": "sha512-VxseRg9u+YRanhCSpgHTm3NFlSDbD1CbG8Ah5VRZmgqIhGGj6SAgcGglqnahav5e8/NJmUrDN801ClFo69E5Kg==",
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
       "dependencies": {
-        "@girs/gjs": "4.0.0-rc.15",
-        "@girs/glib-2.0": "2.88.0-4.0.0-rc.15"
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -5064,74 +5339,74 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "dependencies": {
         "@napi-rs/wasm-runtime": "^1.1.4",
         "@emnapi/core": "1.10.0",
@@ -5139,14 +5414,14 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
@@ -5454,12 +5729,12 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dependencies": {
-        "concat-map": "0.0.1",
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -5786,9 +6061,9 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dependencies": {
         "es-errors": "^1.3.0"
       }
@@ -5822,19 +6097,22 @@
       "integrity": "sha512-anCvsZK2Dh3BTlw/ERHr3fvfqF2vdJHw88soCs3r6EIwxbhibNRILMZw3Ae6GMTY8FkzRfkGLyk7DlEZVesUaw=="
     },
     "node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "dependencies": {
-        "onetime": "^5.1.2",
-        "is-stream": "^2.0.0",
-        "get-stream": "^6.0.0",
-        "cross-spawn": "^7.0.3",
-        "signal-exit": "^3.0.3",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "human-signals": "^2.1.0",
-        "strip-final-newline": "^2.0.0"
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
       }
     },
     "node_modules/expect-type": {
@@ -5958,9 +6236,13 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      }
     },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
@@ -6064,9 +6346,9 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -6142,9 +6424,9 @@
       "integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig=="
     },
     "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
     },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
@@ -6289,11 +6571,6 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="
     },
-    "node_modules/merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6338,11 +6615,6 @@
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
       "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-    },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "node_modules/minify-xml": {
       "version": "4.5.2",
@@ -6389,12 +6661,18 @@
       "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="
     },
     "node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "dependencies": {
-        "path-key": "^3.0.0"
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
       }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6422,14 +6700,6 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
       }
     },
     "node_modules/opener": {
@@ -6683,11 +6953,11 @@
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -6825,9 +7095,9 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -6873,9 +7143,9 @@
       }
     },
     "node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -6905,9 +7175,9 @@
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="
     },
     "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g=="
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -7001,6 +7271,103 @@
       "bin": {
         "vite": "bin/vite.js"
       }
+    },
+    "node_modules/vite/node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "./bin/cli.mjs"
+      }
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      }
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A=="
+    },
+    "node_modules/vite/node_modules/rolldown/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ=="
     },
     "node_modules/vitest": {
       "version": "4.1.7",

--- a/packages/gjs/package.json
+++ b/packages/gjs/package.json
@@ -16,10 +16,10 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@gjsify/canvas2d": "^0.4.21",
-    "@gjsify/dom-elements": "^0.4.21",
-    "@gjsify/event-bridge": "^0.4.21",
-    "@gjsify/webgl": "^0.4.21",
+    "@gjsify/canvas2d": "^0.4.29",
+    "@gjsify/dom-elements": "^0.4.29",
+    "@gjsify/event-bridge": "^0.4.29",
+    "@gjsify/webgl": "^0.4.29",
     "@pixelrpg/engine": "workspace:*",
     "@pixelrpg/story-gjs": "workspace:^",
     "excalibur": "^0.32.0"

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -332,18 +332,31 @@ export class Engine extends Adw.Bin {
       canvas.width = widget.get_allocated_width() || 800
       canvas.height = widget.get_allocated_height() || 600
 
-      // No app-side resize handling: Excalibur's `FillContainer`
-      // DisplayMode owns the canvas backing store via its own
-      // `ResizeObserver` on `canvas.parentElement`. With gjsify
-      // >=0.4.29 returning the live GTK allocation from
-      // `HTMLElement.{offset,client}Width/Height` (canvas override +
-      // ancestor cache written by `notifyElementResize()`), every
-      // bridge resize signal fires Excalibur's observer in the
-      // following microtask, which recomputes the resolution and
-      // calls `applyResolutionAndViewport()` itself. Our previous
-      // 33 ms throttle layered a second apply call on top, which is
-      // redundant; removing it simplifies the widget without
-      // changing observable behaviour.
+      widget.onResize((w: number, h: number) => {
+        // Sync the Excalibur viewport with the new GTK allocation
+        // IMMEDIATELY — before the next GLArea render. Excalibur's
+        // own `FillContainer` ResizeObserver also fires on every
+        // notifyElementResize, but it dispatches via a microtask
+        // (W3C spec — ResizeObserver batches entries through the
+        // "deliver resize loop notifications" cycle). If GTK's next
+        // render signal fires before that microtask flushes, the
+        // freshly-allocated edge pixels show their initial GL state
+        // (pure blue / uninitialized memory) for one frame — visible
+        // as a bright flash during fast drags. Pushing the
+        // resolution write synchronously here closes the gap: the
+        // next render clears the entire new area with Excalibur's
+        // backgroundColor (the scratchpad dark from
+        // `_applyScratchpadBackground()`), not the GL default.
+        if (w === 0 || h === 0) return
+        const screen = this._excalibur?.excalibur.screen
+        if (!screen) return
+        try {
+          screen.resolution = { width: w, height: h }
+          screen.applyResolutionAndViewport()
+        } catch {
+          // screen not ready yet — ignore; observer microtask will catch up
+        }
+      })
 
       try {
         const engine = new ExcaliburEngine(canvas)


### PR DESCRIPTION
## Summary

Bumps every `@gjsify/*` dependency from `^0.4.21` to `^0.4.29` (13 spec sites across 4 `package.json` files + lockfile refresh) and re-adds one synchronous resize-handler line to close a small visual regression that surfaced once the polyfill fixes landed natively.

### What v0.4.29 brings us

- **gjsify#327 + gjsify#329** — `HTMLElement.{client,offset,scroll}Width/Height` now return the live GTK allocation. Excalibur 0.32's `FillContainer` `ResizeObserver` path works natively; no app-side `notifyElementResize` plumbing required. (The hot-patched `node_modules` copy this PR replaces is now redundant — `gjsify install` brings the official version.)
- **gjsify#330** — `WebGLBridge.cancelAnimationFrame(id)` is now per-id (was a no-op-with-side-effect that nuked the loop on any cancel). PR #66's `vfunc_unmap → vfunc_unroot` fix is the load-bearing one for OUR app, but having both layers means a future regression on either side won't catastrophically blank the canvas.

### Companion engine.ts change — synchronous resize sync

Excalibur's own `FillContainer` observer fires on every `notifyElementResize`, but delivers via a microtask (W3C `ResizeObserver` semantics — entries batch through the "deliver resize loop notifications" cycle). When GTK's next render signal fires before that microtask flushes, the freshly-allocated edge pixels show their initial GL state — a bright blue flash from uninitialized framebuffer memory — for one frame during fast window drags ([screenshot in conversation #35](#)).

`widget.onResize` now does a synchronous `screen.resolution = { w, h }` + `applyResolutionAndViewport()` to close that gap: the next render clears the entire new area with Excalibur's `backgroundColor` (the scratchpad dark from `_applyScratchpadBackground()`) instead of the GL default.

## Test plan

- [x] `gjsify install` clean.
- [x] `gjsify foreach build -t` clean.
- [x] Editor smoke: launch maker-gjs, load kokiri-forest, shrink below tablet breakpoint and back, drag window edge fast across the desktop/tablet boundary — map stays visible, no blue flash.
- [x] App exit clean (the `Gjs-CRITICAL` on `unroot` during GC is blocked by GJS and was present in the previous `vfunc_unmap`-based path too — not a regression).

## Notes

- During this work `gjsify install` deleted 219 source files from the working tree (`games/zelda-like/**`, `packages/engine/**`, `packages/gjs/**` — anything under workspace package source dirs that the installer apparently treats as "extra"). `git restore` recovered everything. Filed as a follow-up against gjsify; not in scope for this PR.
- The `gjsify-lock.json` diff dominates the changeset (~3.5k lines moved) because v0.4.29 also pulled in transitive updates from the same release. The actual semantic delta is the 13 version-bump spec sites + 25 lines in `engine.ts`.