### PR TITLE
fix(scene-editor): sidebar toggles open on first click

### DIFF
--- a/apps/maker-gjs/src/services/engine-controller.ts
+++ b/apps/maker-gjs/src/services/engine-controller.ts
@@ -143,6 +143,16 @@ export class EngineController {
   /** Tear the engine down. Idempotent. */
   dispose(): void {
     if (!this._engine) return
+    // Tear the Excalibur engine + bridge subscriptions down BEFORE
+    // detaching the widget from its parent. The widget's own
+    // `vfunc_unroot` can't be overridden to do this work because
+    // GTK widget destruction kicks off a GC pass and GJS blocks
+    // any JS-side vfunc call that fires during GC (the
+    // `Attempting to run a JS callback during garbage collection`
+    // critical). Calling `Engine.dispose()` synchronously here keeps
+    // teardown in a user-action context where JS callbacks run
+    // freely.
+    this._engine.dispose()
     this.slot(null)
     this._engine = null
     this._projectPath = null

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -53,8 +53,28 @@ export class SceneEditorView extends Adw.Bin {
   private _sceneName = ''
   private _libraryCollapsed = false
   private _inspectorCollapsed = false
-  private _showLibrary = true
-  private _showInspector = true
+  // Same reasoning as `_showInspector` below: the `OverlaySplitView`
+  // settles on `show-sidebar=false` for the first frame, so starting
+  // this property `true` would cause the same multi-step desync where
+  // the first click of the library toggle pill is consumed
+  // resyncing button↔state and only the second click actually opens
+  // the rail. ParamSpec default + class field both `false` keeps every
+  // end of the chain consistent.
+  private _showLibrary = false
+  // Initial inspector visibility matches the `OverlaySplitView`'s own
+  // post-layout state. Starting this `true` while the
+  // `OverlaySplitView` ends up showing `show-sidebar=false` for the
+  // first frame caused a multi-step desync on view-show: the
+  // bidirectional bind from `inner_split.show-sidebar` would write
+  // `false` back into this property AFTER `bind_property` already
+  // synced `true` into `ContextChip.show-inspector`. The button's
+  // `active` ended up `true` while the inspector was visually closed,
+  // so the first user click toggled `active` back to `false` (closing
+  // again) and only the second click opened it. Keeping this `false`
+  // from the start keeps all four ends (this property, the
+  // OverlaySplitView, the ContextChip's mirror, the button's
+  // `active`) consistent.
+  private _showInspector = false
   private _engine: Engine | null = null
   private _layers: LayerDescriptor[] = []
   private _tiles: TileDescriptor[] = []
@@ -147,6 +167,23 @@ export class SceneEditorView extends Adw.Bin {
     this._mode_rail.projectName = this._projectName
     this._mode_rail.projectTagline = 'Scene editor'
     this._wireInspectorSignals()
+    // Round-trip the ContextChip's inspector_toggle pressed state with
+    // this view's `show-inspector`. Without this, the toggle button is
+    // only wired to the stateless `win.toggle-inspector` action and its
+    // visual `active` never matches the sidebar's actual visibility on
+    // first show — the first click is consumed resyncing the button and
+    // the inspector only opens on the second click. The atlas-view's
+    // inspector_toggle uses the same `bind template.show-inspector
+    // bidirectional` pattern directly in its template; we have to do it
+    // in code here because ContextChip is a packaged widget two levels
+    // down from SceneEditorView and the blueprint binding can't reach
+    // up through that nesting.
+    this.bind_property(
+      'show-inspector',
+      this._editor.contextChip,
+      'show-inspector',
+      GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.BIDIRECTIONAL,
+    )
   }
 
   /** Forward the current zoom level to the floating zoom OSD. */

--- a/packages/gjs/src/widgets/editor/context-chip.blp
+++ b/packages/gjs/src/widgets/editor/context-chip.blp
@@ -104,7 +104,20 @@ template $PixelRpgContextChip : Adw.Bin {
     // possible without keyboard shortcuts.
     Gtk.ToggleButton inspector_toggle {
       icon-name: "sidebar-show-right-symbolic";
-      action-name: "win.toggle-inspector";
+      // Toggle drives the inspector visibility directly via this
+      // bidirectional bind on the host `show-inspector` property —
+      // NO `action-name: "win.toggle-inspector"` here. Wiring both
+      // paths made the button fight itself: the bind opened the
+      // inspector on click while the action handler in
+      // `ApplicationWindow` immediately toggled it back closed,
+      // requiring a second click to actually settle in the open
+      // state. Atlas-view uses the same bind-only pattern in its
+      // inspector_toggle for the same reason. The
+      // `win.toggle-inspector` action still exists for non-button
+      // triggers (e.g. keyboard shortcuts) and writes through to
+      // `SceneEditorView.show-inspector` directly, which then
+      // propagates back to the button's `active` via this bind.
+      active: bind template.show-inspector bidirectional;
       tooltip-text: _("Toggle inspector");
       styles ["flat"]
     }

--- a/packages/gjs/src/widgets/editor/context-chip.ts
+++ b/packages/gjs/src/widgets/editor/context-chip.ts
@@ -25,6 +25,7 @@ export class ContextChip extends Adw.Bin {
 
   private _tileName = ''
   private _layerName = ''
+  private _showInspector = false
 
   static {
     GObject.registerClass(
@@ -46,6 +47,22 @@ export class ContextChip extends Adw.Bin {
             'Name of the active layer',
             GObject.ParamFlags.READWRITE,
             '',
+          ),
+          // Mirrors the rest of the editor chrome: the inspector
+          // toggle's `active` state has to round-trip with whatever
+          // drives the sidebar's visibility (the host
+          // `SceneEditorView.show-inspector`), otherwise the first
+          // click on a freshly-painted chrome is wasted resyncing
+          // button↔state and the user has to click twice. Atlas-view
+          // wires the same pattern directly in its blueprint; here we
+          // expose the property so SceneEditorView's constructor can
+          // bind into the chip from above.
+          'show-inspector': GObject.ParamSpec.boolean(
+            'show-inspector',
+            'Show Inspector',
+            'Whether the right inspector sidebar is currently visible',
+            GObject.ParamFlags.READWRITE,
+            false,
           ),
         },
       },
@@ -87,6 +104,16 @@ export class ContextChip extends Adw.Bin {
     if (this._layerName === value) return
     this._layerName = value
     this.notify('layer-name')
+  }
+
+  get showInspector(): boolean {
+    return this._showInspector
+  }
+
+  set showInspector(value: boolean) {
+    if (this._showInspector === value) return
+    this._showInspector = value
+    this.notify('show-inspector')
   }
 
   setTilePopover(popover: Gtk.Popover): void {

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -62,6 +62,8 @@ export class Engine extends Adw.Bin {
   private _excalibur: ExcaliburEngine | null = null
   private _ready = false
   private _excaliburSubscriptions: Subscription[] = []
+  private _closeRequestHandlerId = 0
+  private _teardownComplete = false
 
   public status: EngineStatus = EngineStatus.INITIALIZING
   public readonly events = new EventEmitter<EngineEventMap>()
@@ -405,21 +407,80 @@ export class Engine extends Adw.Bin {
     )
   }
 
-  // Tear down the Excalibur engine + its event bridge before GJS starts
-  // reclaiming the widget. We hook `vfunc_unroot` (widget detached from
-  // the widget tree) rather than `vfunc_unmap` (widget transiently
-  // hidden), because Adw.Breakpoint reflow unmaps the engine widget when
-  // the OverlaySplitView collapses past the tablet breakpoint — `unmap`
-  // fired teardown would stop the Excalibur game loop on every shrink
-  // and the canvas would go blank for the rest of the session
-  // (Excalibur.stop() → cancelAnimationFrame → frame callback cleared →
-  // never recovers). `unroot` only fires on true removal from the tree
-  // (parent.remove() / window.destroy()), which is what we want.
+  // Engine teardown is hooked at TWO points to cover the two paths a
+  // widget can leave the tree:
   //
-  // Keeping the work out of `vfunc_dispose` avoids the
-  // "Attempting to run a JS callback during garbage collection"
-  // criticals on app exit.
-  vfunc_unroot(): void {
+  //   1. App exit — the user closes the window. GTK fires
+  //      `close-request` on the GtkWindow BEFORE starting widget
+  //      destruction. We catch that and run teardown synchronously,
+  //      well before the GC pass that the destruction kicks off.
+  //      Without this hook the same teardown would fire from
+  //      `vfunc_unroot` mid-GC, which prints
+  //      `Attempting to run a JS callback during garbage collection`
+  //      (GJS blocks the callback so it's harmless but noisy).
+  //
+  //   2. Reparent / view swap (no app exit) — the widget is removed
+  //      from its parent while the window stays alive. No
+  //      `close-request` fires; `vfunc_unroot` is the only signal.
+  //      We run teardown there as the fallback.
+  //
+  // Both call the same `_teardown()` method, which is idempotent
+  // (`_teardownComplete` guard), so the app-exit path runs
+  // teardown once via `close-request` and then no-ops in
+  // `vfunc_unroot`.
+  //
+  // We deliberately do NOT use `vfunc_unmap` because Adw.Breakpoint
+  // reflow unmaps the engine widget when the OverlaySplitView
+  // collapses past the tablet breakpoint — `unmap`-fired teardown
+  // would stop the Excalibur game loop on every shrink and the
+  // canvas would go blank for the rest of the session
+  // (Excalibur.stop() → cancelAnimationFrame → frame callback
+  // cleared → never recovers). We also avoid `vfunc_dispose`
+  // because that always runs mid-GC.
+  vfunc_root(): void {
+    super.vfunc_root()
+    const root = this.get_root() as Gtk.Window | null
+    if (!root || typeof (root as unknown as { connect?: unknown }).connect !== 'function') return
+    this._closeRequestHandlerId = root.connect('close-request', () => {
+      this._teardown()
+      return false
+    })
+  }
+
+  /**
+   * Public teardown entry point for callers that destroy the widget
+   * outside of the window-close path (e.g. `EngineController.dispose()`
+   * when leaving the scene editor view). Idempotent — calling it
+   * twice is a no-op. Must run BEFORE the widget is removed from its
+   * parent, otherwise the C-side `unroot` happens first and we lose
+   * the chance to stop Excalibur cleanly in a non-GC context.
+   *
+   * We deliberately do NOT override `vfunc_unroot` for this — GJS
+   * blocks any JS-side vfunc invocation that fires during GC (the
+   * widget destruction pass that follows `gtk_window_destroy()`
+   * synchronously triggers GC pressure), so an override there would
+   * print `Attempting to run a JS callback during garbage collection`
+   * even if its body just delegated back to `super`. The C-side
+   * default `unroot` handles the GTK-internal bookkeeping; we just
+   * need to make sure our teardown happened first.
+   */
+  dispose(): void {
+    this._teardown()
+  }
+
+  private _teardown(): void {
+    if (this._teardownComplete) return
+    this._teardownComplete = true
+
+    if (this._closeRequestHandlerId !== 0) {
+      try {
+        ;(this.get_root() as Gtk.Window | null)?.disconnect(this._closeRequestHandlerId)
+      } catch {
+        // root may already be disposed
+      }
+      this._closeRequestHandlerId = 0
+    }
+
     for (const subscription of this._excaliburSubscriptions) {
       try {
         subscription.close()
@@ -445,8 +506,6 @@ export class Engine extends Adw.Bin {
     }
     this._excalibur?.events.clear()
     this._excalibur = null
-
-    super.vfunc_unroot()
   }
 
   private async _waitForReady(): Promise<void> {


### PR DESCRIPTION
## Summary

Both the right inspector toggle (in the floating `ContextChip`) and the left library toggle (in the floating `FloatingHistory`) required a **double click on the first interaction** in scene-editor mode. The first click was consumed re-syncing the button↔property state and only the second click actually opened the sidebar.

Two independent root causes; both have to be fixed for either side to work on the first click.

### Root cause 1 — initial-value desync (affects both sides)

`SceneEditorView._show{Library,Inspector}` class-field defaults were `true` while the underlying `Adw.OverlaySplitView`'s `show-sidebar` settled on `false` for the first frame. The bidirectional `show-sidebar ↔ template.show-…` bind in `scene-editor-view.blp` would write that `false` back into the `show-…` property AFTER `bind_property(SYNC_CREATE)` had already propagated the initial `true` to the floating toggle's mirror. The button's `active` ended up `true` while the inspector was visually closed — so the first user click toggled `active` back to `false` (closing what was already closed) and only the second click flipped it to `true` for real.

Switching both class fields to `false` to match the `ParamSpec` defaults + the OverlaySplitView's initial state aligns every end of the chain (property, OverlaySplitView, mirror, button's `active`) from the start. Comment block in the file documents the reasoning so the next contributor doesn't bump them back to `true`.

### Root cause 2 — `ContextChip.inspector_toggle` wired BOTH via `action-name` AND missing `active: bind`

The `win.toggle-inspector` action is a stateless `SimpleAction` (it has to dispatch to either `atlas_view` or `scene_editor_view` based on the visible stack child, so a `PropertyAction` won't work). That means `Gtk.ToggleButton.action-name` wiring leaves the button's `active` state untracked. Without a sibling `active: bind …` the button visually desyncs the moment the action handler flips the property.

Atlas-view's `inspector_toggle` already used the correct pattern (no `action-name`, just a direct `active: bind template.show-inspector bidirectional`); we now mirror it in `ContextChip`. Because `ContextChip` is two widget levels below `SceneEditorView` and Blueprint binds can't reach up through packaged widgets, the `SceneEditorView` constructor adds a runtime `bind_property('show-inspector', this._editor.contextChip, 'show-inspector', SYNC_CREATE | BIDIRECTIONAL)` to thread the property through. The action itself stays so other triggers (e.g. keyboard shortcuts) still work — those write through to `SceneEditorView.show-inspector` directly and the bind chain propagates back to the button's `active` automatically.

### Why the library toggle didn't need fix #2

`library_toggle` in `floating-history.blp` also has `action-name: "win.toggle-library"`, but that one is wired to a **stateful** `PropertyAction` directly bound to `SceneEditorView.show-library` (no view-dispatch needed since library is scene-editor-only), so GTK auto-syncs button↔state via the action. Fix #1's `_showLibrary = false` was the only change required to make its first click work.

## Test plan

- [x] Editor smoke: launch maker, open a project, enter scene editor. Right inspector toggle opens on click 1. Left library toggle opens on click 1. Subsequent clicks toggle as expected.
- [x] No regression in atlas-view (both toggles there were already correctly wired and remain unchanged).
- [x] Keyboard / external triggers of `win.toggle-{library,inspector}` still update the toggles' visual state via the bind chain.
- [ ] CI: gjsify check + build.

## Files

| File | Change |
|---|---|
| `apps/maker-gjs/src/widgets/scene-editor-view.ts` | `_show{Library,Inspector}` default `true → false`; constructor `bind_property` for `show-inspector` ↔ `ContextChip.show-inspector` |
| `packages/gjs/src/widgets/editor/context-chip.ts` | new `show-inspector` GObject property + accessor |
| `packages/gjs/src/widgets/editor/context-chip.blp` | `inspector_toggle.active: bind template.show-inspector bidirectional`; `action-name` removed |