### PR TITLE
chore(deps): bump @gjsify/* ^0.4.31 → ^0.4.32

### DIFF
--- a/apps/game-browser/package.json
+++ b/apps/game-browser/package.json
@@ -17,7 +17,7 @@
     "excalibur": "^0.32.0"
   },
   "devDependencies": {
-    "@gjsify/cli": "^0.4.31",
+    "@gjsify/cli": "^0.4.32",
     "http-server": "^14.1.1",
     "typescript": "^6.0.3"
   }

--- a/apps/maker-gjs/package.json
+++ b/apps/maker-gjs/package.json
@@ -28,7 +28,7 @@
   "author": "Pascal Garber <pascal@artandcode.studio>",
   "license": "GPL-3.0",
   "devDependencies": {
-    "@gjsify/cli": "^0.4.31",
+    "@gjsify/cli": "^0.4.32",
     "typescript": "^6.0.3"
   },
   "dependencies": {
@@ -40,11 +40,11 @@
     "@girs/glib-2.0": "^2.88.0-4.0.4",
     "@girs/gobject-2.0": "^2.88.0-4.0.4",
     "@girs/gtk-4.0": "^4.23.0-4.0.4",
-    "@gjsify/canvas2d": "^0.4.31",
-    "@gjsify/dom-elements": "^0.4.31",
-    "@gjsify/event-bridge": "^0.4.31",
-    "@gjsify/webgl": "^0.4.31",
-    "@gjsify/xmlhttprequest": "^0.4.31",
+    "@gjsify/canvas2d": "^0.4.32",
+    "@gjsify/dom-elements": "^0.4.32",
+    "@gjsify/event-bridge": "^0.4.32",
+    "@gjsify/webgl": "^0.4.32",
+    "@gjsify/xmlhttprequest": "^0.4.32",
     "@pixelrpg/engine": "workspace:^",
     "@pixelrpg/gjs": "workspace:^",
     "excalibur": "^0.32.0"

--- a/apps/storybook-gjs/package.json
+++ b/apps/storybook-gjs/package.json
@@ -23,13 +23,13 @@
     "@girs/glib-2.0": "^2.88.0-4.0.4",
     "@girs/gobject-2.0": "^2.88.0-4.0.4",
     "@girs/gtk-4.0": "^4.23.0-4.0.4",
-    "@gjsify/dom-elements": "^0.4.31",
+    "@gjsify/dom-elements": "^0.4.32",
     "@pixelrpg/games-zelda-like": "workspace:^",
     "@pixelrpg/gjs": "workspace:^",
     "@pixelrpg/story-gjs": "workspace:^"
   },
   "devDependencies": {
-    "@gjsify/cli": "^0.4.31",
+    "@gjsify/cli": "^0.4.32",
     "typescript": "^6.0.3"
   }
 }

--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -4,7 +4,7 @@
     "@biomejs/biome@^2.4.16",
     "typescript@^6.0.3",
     "excalibur@^0.32.0",
-    "@gjsify/cli@^0.4.31",
+    "@gjsify/cli@^0.4.32",
     "http-server@^14.1.1",
     "@girs/adw-1@^1.10.0-4.0.4",
     "@girs/gdk-4.0@^4.0.0-4.0.4",
@@ -14,11 +14,11 @@
     "@girs/glib-2.0@^2.88.0-4.0.4",
     "@girs/gobject-2.0@^2.88.0-4.0.4",
     "@girs/gtk-4.0@^4.23.0-4.0.4",
-    "@gjsify/canvas2d@^0.4.31",
-    "@gjsify/dom-elements@^0.4.31",
-    "@gjsify/event-bridge@^0.4.31",
-    "@gjsify/webgl@^0.4.31",
-    "@gjsify/xmlhttprequest@^0.4.31",
+    "@gjsify/canvas2d@^0.4.32",
+    "@gjsify/dom-elements@^0.4.32",
+    "@gjsify/event-bridge@^0.4.32",
+    "@gjsify/webgl@^0.4.32",
+    "@gjsify/xmlhttprequest@^0.4.32",
     "serve@^14.2.6",
     "vitest@^4.1.7",
     "@girs/graphene-1.0@^1.0.0-4.0.4",
@@ -966,38 +966,38 @@
       }
     },
     "node_modules/@gjsify/abort-controller": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.4.31.tgz",
-      "integrity": "sha512-2Z9PcjAAk1KNmRNQhraUp74QsYJJWW5d9ckIB3/6saUaWLGKQG51jVMA8iJ+WmFJ3eYIUzqiwnpdOr8OBFZmjA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.4.32.tgz",
+      "integrity": "sha512-ex4AkECztjFtM67fHKvc4CJfsARm7CRyhYTjMfTIQsIzzgxnMSywoiNELCOlQr7d7jdkzQ2n7qRUwPPZWuqi2A==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.31"
+        "@gjsify/dom-events": "^0.4.32"
       }
     },
     "node_modules/@gjsify/assert": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.4.31.tgz",
-      "integrity": "sha512-/qU4KDmso0QjmqCA+C9qmWeYHfZKHPCJd9Uk0VpOZiAfCmo1S4I3hUeDnRZPTc8mgh41SwXdZbuhvNc5VNIUNg=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.4.32.tgz",
+      "integrity": "sha512-1rQF8FNqwRAZBGg9rHHo+q3AQJPGrLRa4jJNJHoC9BU2J9D218rzt/18h5ffUHOmPg48gqsm2vaqPIgaWbJ9uA=="
     },
     "node_modules/@gjsify/async_hooks": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.4.31.tgz",
-      "integrity": "sha512-nced6W4G4zxmPHHYdeRHzBv12DUQ5Fh9l4qCbKs0qjr6V7LdQutHlFb90Aio9W38ePEuJe6EUk9tWP7wtIucbQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.4.32.tgz",
+      "integrity": "sha512-5c7ORTTXWL504o1+h6zK42OvEheWhp6HO4OvYy1tU2whcKk0bWx0V/ajGIJooGfwTj3k+FSRBfoncscV0vJVCw==",
       "dependencies": {
-        "@gjsify/events": "^0.4.31"
+        "@gjsify/events": "^0.4.32"
       }
     },
     "node_modules/@gjsify/buffer": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.4.31.tgz",
-      "integrity": "sha512-0AyYW0dv99hRUCs2PmUTa+TA+qHzbrwhTsjDjmp83YUMfJtSlx9N7magm3e/LxH9f0c5eMVvNkArPV7gZ7eXaw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.4.32.tgz",
+      "integrity": "sha512-iVQvlbJhEcCUqrGwmUyTqD4Nm/B4CblZhHBAM4uUmyS7lc8z8wggVCYOkrdI53P+GZUG0OPMpYVsTHnvLneuWw==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/canvas2d": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d/-/canvas2d-0.4.31.tgz",
-      "integrity": "sha512-JbytGqim4dmv2vU4lzfTHM2GiRzcLCdMUlt+ihalAwecsCdbA1GuuAbFgxYSZXzqXiKhzHTghYtR/n6vWVHbRQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d/-/canvas2d-0.4.32.tgz",
+      "integrity": "sha512-m3Cqayy9vsNC5iAw+lFGiNq4JNTF3o4U36PIoZ4yZ1yXKGp/bCmOrdkfKr5wiARH3FInw9crr55PSp4Qs+RjWg==",
       "dependencies": {
         "@girs/gdk-4.0": "4.0.0-4.0.1",
         "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
@@ -1007,17 +1007,17 @@
         "@girs/gtk-4.0": "4.23.0-4.0.1",
         "@girs/pango-1.0": "1.57.1-4.0.1",
         "@girs/pangocairo-1.0": "1.0.0-4.0.1",
-        "@gjsify/canvas2d-core": "^0.4.31",
-        "@gjsify/dom-elements": "^0.4.31",
-        "@gjsify/dom-events": "^0.4.31",
-        "@gjsify/event-bridge": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/canvas2d-core": "^0.4.32",
+        "@gjsify/dom-elements": "^0.4.32",
+        "@gjsify/dom-events": "^0.4.32",
+        "@gjsify/event-bridge": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/canvas2d-core": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d-core/-/canvas2d-core-0.4.31.tgz",
-      "integrity": "sha512-qRhVN4PK2uKg1Cy+uiiemx1Wo7sMJnq0yFDckVHX426xO/koEhv8GoukrVlqQ70mfs/6LV7YQMuhG3fMutrCVQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d-core/-/canvas2d-core-0.4.32.tgz",
+      "integrity": "sha512-LqtYxIJJCLAUpqyOsbwACvnjUPjxlM2NIl5IlKKnJ2G3YA/1Kt7wyYolrRJ1LxLyya83TYG04PJeDC1TIuLQYg==",
       "dependencies": {
         "@girs/gdk-4.0": "4.0.0-4.0.1",
         "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
@@ -1721,15 +1721,15 @@
       }
     },
     "node_modules/@gjsify/child_process": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.4.31.tgz",
-      "integrity": "sha512-XolzdmsOaIi9G0xurAp5QjOoZRYgYMWzajnJPiZ8OY/fnstu6H1+jMNdHjswivNt6M6Q96/nyhqPrNzNh44qGA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.4.32.tgz",
+      "integrity": "sha512-nJNU93RYpW8MbEUPi9uRgjUbx/59QfjFa6EbkRHS9PovNLMZyqk+aYvQT9y7axX1oSHXk/9fan+ae+cHaMua9Q==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.31",
-        "@gjsify/events": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/buffer": "^0.4.32",
+        "@gjsify/events": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0": {
@@ -1823,22 +1823,22 @@
       }
     },
     "node_modules/@gjsify/cli": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.4.31.tgz",
-      "integrity": "sha512-W9sclC1jQE6+bN3+bZMsC5LI37tUPO2vpNW4Bli4oG/4RdOSsRKNu6kvfEPw/L7nEPJ7RrJt6B+wwOm9AWWGEA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.4.32.tgz",
+      "integrity": "sha512-42spStbS5/f7lgGzyz5OdYiQDkAyZG9cAnLfMh0TaWNJq7mqHLG9VDBCZtU+leeJXwNi5P+7JrIhYtKtwtDWsQ==",
       "dependencies": {
-        "@gjsify/buffer": "^0.4.31",
-        "@gjsify/create-app": "^0.4.31",
-        "@gjsify/node-globals": "^0.4.31",
-        "@gjsify/node-polyfills": "^0.4.31",
-        "@gjsify/npm-registry": "^0.4.31",
-        "@gjsify/resolve-npm": "^0.4.31",
-        "@gjsify/rolldown-plugin-gjsify": "^0.4.31",
-        "@gjsify/rolldown-plugin-pnp": "^0.4.31",
-        "@gjsify/semver": "^0.4.31",
-        "@gjsify/tar": "^0.4.31",
-        "@gjsify/web-polyfills": "^0.4.31",
-        "@gjsify/workspace": "^0.4.31",
+        "@gjsify/buffer": "^0.4.32",
+        "@gjsify/create-app": "^0.4.32",
+        "@gjsify/node-globals": "^0.4.32",
+        "@gjsify/node-polyfills": "^0.4.32",
+        "@gjsify/npm-registry": "^0.4.32",
+        "@gjsify/resolve-npm": "^0.4.32",
+        "@gjsify/rolldown-plugin-gjsify": "^0.4.32",
+        "@gjsify/rolldown-plugin-pnp": "^0.4.32",
+        "@gjsify/semver": "^0.4.32",
+        "@gjsify/tar": "^0.4.32",
+        "@gjsify/web-polyfills": "^0.4.32",
+        "@gjsify/workspace": "^0.4.32",
         "cosmiconfig": "^9.0.1",
         "get-tsconfig": "^4.14.0",
         "pkg-types": "^2.3.1",
@@ -1850,54 +1850,54 @@
       }
     },
     "node_modules/@gjsify/cluster": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.4.31.tgz",
-      "integrity": "sha512-KCm2ULBxf4sfx39HISJlrWXJqw28aZqmRQVhlwsqmSYnUwWbqtT2hcdM0O3N0ozdLNzoCW4jUzPPxAFZuMIVaw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.4.32.tgz",
+      "integrity": "sha512-qCXK3M3WDCUkLKTtFt2CiMRoIBEr6796PUBHb+c5y9yNZpQyXJwS+tvL2QNf7RoDMLzmjaJHTtcbJzndyJiJrA==",
       "dependencies": {
-        "@gjsify/events": "^0.4.31"
+        "@gjsify/events": "^0.4.32"
       }
     },
     "node_modules/@gjsify/compression-streams": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.4.31.tgz",
-      "integrity": "sha512-5FwIHUZeT2zpan0c530BGwlvJHSP8HM4k1oLG9MQ5mAJMTPziwWtcwl1URVpq7H67u2htGwlWEDjKAjswhmJYw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.4.32.tgz",
+      "integrity": "sha512-kLAD3GOIRKDiVeqL1cHbhMJmtFogzI5pwSHcaWWpkcYdZxDvOgqtemmhPUo3kJ2onME3zQWXlE++8u2d4Vwx6w==",
       "dependencies": {
-        "@gjsify/web-streams": "^0.4.31"
+        "@gjsify/web-streams": "^0.4.32"
       }
     },
     "node_modules/@gjsify/console": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.4.31.tgz",
-      "integrity": "sha512-5KGBm6KcuqMnyGUNaMCHPi24yIitZRz5puVePvMIGCHgO+hxBCv/eIbEt9bkwbY5gxf5yX8e9U1/eCCbVZeJTA=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.4.32.tgz",
+      "integrity": "sha512-DEPHHabSiKVzOhLl1HRO/OVZGgvKOH6cqpRVeY9txqFm0uwtYxtdQas1nZUyyV/mbaOdg7nQLRMmAgPr/nbhqw=="
     },
     "node_modules/@gjsify/constants": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.4.31.tgz",
-      "integrity": "sha512-c9Wsgko9CejV+RzzeLm1Hl0iFl/xOBpIn+ARmegzTIk2gpFZqGrkz+jSzGN59sbIsGCFhdxMHpiZq6eXrubS5Q==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.4.32.tgz",
+      "integrity": "sha512-tpMgFqpAs+3//nuIrVX5SxOKTX2VwccpsMLpL02eIp0OPJ4oglieoB61GqG4Mi9hhNzgh9mnaEWEjnOIqMmhWw==",
       "dependencies": {
-        "@gjsify/crypto": "^0.4.31",
-        "@gjsify/fs": "^0.4.31",
-        "@gjsify/os": "^0.4.31"
+        "@gjsify/crypto": "^0.4.32",
+        "@gjsify/fs": "^0.4.32",
+        "@gjsify/os": "^0.4.32"
       }
     },
     "node_modules/@gjsify/create-app": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.4.31.tgz",
-      "integrity": "sha512-wSE2/oh4ontFKwDITr9NdQhTBQz6yY35GqmKajD7tA4+aCVMvG0JLHk42+h2LpPUTPzwr7m+lTaNAonayvXkKw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.4.32.tgz",
+      "integrity": "sha512-8l8CxXx68f5/WnG7ysTHBfHH4wBzdJqTMxly4VfCesShc9YBBDSelSJLyX4OnFJshI9bSvFkDRzJ57MrSPojFQ==",
       "dependencies": {
         "yargs": "^18.0.0"
       },
       "bin": "./lib/index.js"
     },
     "node_modules/@gjsify/crypto": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.4.31.tgz",
-      "integrity": "sha512-6v6Xjv83Fa7SGxj0BPoQ6UVN/TBwogeIYYOCOQmGkja0njIyM12RIACgdlAfMxuCZsgvEAPCxX2kHKwfvbnhvg==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.4.32.tgz",
+      "integrity": "sha512-NxalE+jeIPBNcnmGj2KJhwfxqZuBlFwF+oZ4wdlZ/oLWpAQzAdb5OCLO4p7uPdbVTM3l3Mw5jsB6wBL3gjoPkA==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.31",
-        "@gjsify/stream": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/buffer": "^0.4.32",
+        "@gjsify/stream": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0": {
@@ -1961,15 +1961,15 @@
       }
     },
     "node_modules/@gjsify/dgram": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.4.31.tgz",
-      "integrity": "sha512-QrlOp89Z05NuZUcDIfK3P4p/ut7TEIwD34Tb6tN3k1zNfrC7jbNHnbzQX22hJ2+rT9QZdnIC0mrgYgHXwK0tUg==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.4.32.tgz",
+      "integrity": "sha512-cMzg8uZQpe64tHuA4195D+0b/Xd/Gk0ki5X6JT9s4Ns/0oa2CytDgGZHuGSC2yE9GSW7OmINi0laCiihzzWQrQ==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.31",
-        "@gjsify/events": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/buffer": "^0.4.32",
+        "@gjsify/events": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0": {
@@ -2063,19 +2063,19 @@
       }
     },
     "node_modules/@gjsify/diagnostics_channel": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.4.31.tgz",
-      "integrity": "sha512-wrn38irkdD1bZaT1f1gZOpDTSdXZ8zUUrxsdTOZEc+dLNj4AhtzTrzsa3wTuRevTgMVPcqS64G3511tEZxJuPg=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.4.32.tgz",
+      "integrity": "sha512-j0MJsPtv343HRDkHedOdVSt8SU7DD9V6x7mnn3SAgcvecgJ0kr9ZZy09Om5qpugPRSW4U0Wz5LR8DQyWUZXu5A=="
     },
     "node_modules/@gjsify/dns": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.4.31.tgz",
-      "integrity": "sha512-qe6qLhWUSe1Jvm4kU2jeD2WR1W5CQOYGzj5QR05eAhXVqA3vCzWmcRlDBI4aWJX3NLXZbGOmaE6Tl6C2tC280g==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.4.32.tgz",
+      "integrity": "sha512-JhiNvUi87j7trnGxNjgPvpN38WkyuRg8tVv0L4bXl8yfaTaJe3zb8gDTLLl1c18fO3pvvqhftYk2kYx9YBrhIQ==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/net": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/net": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0": {
@@ -2169,17 +2169,17 @@
       }
     },
     "node_modules/@gjsify/dom-elements": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-elements/-/dom-elements-0.4.31.tgz",
-      "integrity": "sha512-Occ/nRnwaCD95Tni7zOAECK1oS7ISFWTSkfIBrD5cZcftHxPczbkXwrNhkdN0s4BYhjR90MHEVorqINs0RqYGg==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-elements/-/dom-elements-0.4.32.tgz",
+      "integrity": "sha512-BcdNaeQCjYlzUOpP+ElDaksS816EgW184mRL6/9tXyZL/B2cx5FBMHHhFaMlLxxNYoW/8XfFZuIiFQC4kcvWqQ==",
       "dependencies": {
         "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/abort-controller": "^0.4.31",
-        "@gjsify/canvas2d-core": "^0.4.31",
-        "@gjsify/dom-events": "^0.4.31",
-        "@gjsify/fetch": "^0.4.31"
+        "@gjsify/abort-controller": "^0.4.32",
+        "@gjsify/canvas2d-core": "^0.4.32",
+        "@gjsify/dom-events": "^0.4.32",
+        "@gjsify/fetch": "^0.4.32"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gdkpixbuf-2.0": {
@@ -2294,41 +2294,41 @@
       }
     },
     "node_modules/@gjsify/dom-events": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.4.31.tgz",
-      "integrity": "sha512-GzyXGuQ16B9lZ+TZnsvIvp62TTpBXsWrflJW4SpZPaGxJoEzzdYLNQFGdR6YbUufsaNHXmtfQbYMYiElPs0QWQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.4.32.tgz",
+      "integrity": "sha512-0QGTFmE7ucgt09S0dilSy+mwuG04f49RP/yB6J2NIxMWRlOxZDKwKZL4qUSlezuiEfsihxCudLGhcpPQh0GXsQ==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.4.31"
+        "@gjsify/dom-exception": "^0.4.32"
       }
     },
     "node_modules/@gjsify/dom-exception": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.4.31.tgz",
-      "integrity": "sha512-SELNUDnBjZbAX/LFIBY2BT8uZbUB0ZGxF9vUsSF/7zevq2sSbY1yeERGqARO5m36+45D3N8fC9x1gYNZV/UeoQ=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.4.32.tgz",
+      "integrity": "sha512-QCG5qy8XOqQPCwb1duNxeebYSqUcszAEg8/yxJBvKgnwjBDwBlOjsd0WoClLoC7TKyG+nkIeNh1t2PG3XeAIUw=="
     },
     "node_modules/@gjsify/domain": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.4.31.tgz",
-      "integrity": "sha512-ny6xQ1oJv3iQQWV/hlevSghns7Nl4rOEF/mByrz1yVPSBGo/wbTOlm1F4XbiOQIBYkxG0exjTWOvLjlvfJrmiw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.4.32.tgz",
+      "integrity": "sha512-wY1GJCm0JAZg0rB0lPwg+mBZ9F9pOej7ojUvVnLJroTJnnFJhmid3qK5D4tQBhNwCOriKGJuT6tqXg7hsu1Kow==",
       "dependencies": {
-        "@gjsify/events": "^0.4.31"
+        "@gjsify/events": "^0.4.32"
       }
     },
     "node_modules/@gjsify/domparser": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.4.31.tgz",
-      "integrity": "sha512-apgSZ3/gDtlcc+dTJbAMIFDrrSYlicCKv8fYYx5aGERZ/rUA++aPZkV2r6OtYg7SboSdrSlAATz4h9DMkqhCsw=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.4.32.tgz",
+      "integrity": "sha512-mKqLip/6U0U4mj8TtenHzFu6p9qvqn126bbeN9Y/CtRcI6mqBek+3cRjpTdz9+Y0EUrH/k4JnhEwMEVOtrOjXA=="
     },
     "node_modules/@gjsify/event-bridge": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/event-bridge/-/event-bridge-0.4.31.tgz",
-      "integrity": "sha512-K/8zkFHt2nuRMNjnGJEOtakNG4nNnXYBAm8Q5EpMWnlizWHzsXEChfrUCllaccQysZskK3965C+x/2iVqHjk1g==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/event-bridge/-/event-bridge-0.4.32.tgz",
+      "integrity": "sha512-rRiEzLDJShv9m27LVTDRhf41Nmpugt/FrPoAuUAytgP7M1YS1BUYEyc0p1lFUdrAgKhd8m57QZ9gD4ghlAXnUA==",
       "dependencies": {
         "@girs/gdk-4.0": "4.0.0-4.0.1",
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/gtk-4.0": "4.23.0-4.0.1",
-        "@gjsify/dom-events": "^0.4.31"
+        "@gjsify/dom-events": "^0.4.32"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0": {
@@ -2676,35 +2676,35 @@
       }
     },
     "node_modules/@gjsify/events": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.4.31.tgz",
-      "integrity": "sha512-0r5ACmAlJyIgd6ERoKu0JudRGqNILf0XA0/X43V2ceBZtJlbmX8hf5jd7AJH7XOsJzPzR3kjaIVxmaanUUTHzQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.4.32.tgz",
+      "integrity": "sha512-Fre49O63+Uvmn8CAAmePNiXVVvr3ROKExu8tEAyETKWMejPsQ2OIVtfSsdavTSzMDQ3DGii3S1GpzIqEH54y7Q==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/eventsource": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.4.31.tgz",
-      "integrity": "sha512-zyvOZB4ZQHM/3tQSCr1eZgh1fS3hNtmppIvxCrLE9rfz2PyNCg8f1rfcbiDunFLr2u/JXeL1BkmVxbchQHGIxQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.4.32.tgz",
+      "integrity": "sha512-7yJCiv9G07pzBRKBdqGIiOMBKTWbCMzxiS0xA/ds7vcL65yeEBaztGqJ7GVTZQvXKdz1QnjZYKL+CY/amveFxA==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.31",
-        "@gjsify/web-streams": "^0.4.31"
+        "@gjsify/dom-events": "^0.4.32",
+        "@gjsify/web-streams": "^0.4.32"
       }
     },
     "node_modules/@gjsify/fetch": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.4.31.tgz",
-      "integrity": "sha512-Ov/4hVVItGTfob3mj9UfX6VwS7RjHJ9V1eYcCAlHtx/gpcW2agHrNofam/JSajy8pZadG0XSs6uW1rvg/SKLcw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.4.32.tgz",
+      "integrity": "sha512-RFiUUClpHDJIrVtU8zpm5EegTDZ7GWTqBEpav+Es4gg8LLSdt0iVecGSUFynotPPlRPWjFE9hggsU6jBE0xsfg==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/formdata": "^0.4.31",
-        "@gjsify/http": "^0.4.31",
-        "@gjsify/url": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/formdata": "^0.4.32",
+        "@gjsify/http": "^0.4.32",
+        "@gjsify/url": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/gio-2.0": {
@@ -2786,22 +2786,22 @@
       }
     },
     "node_modules/@gjsify/formdata": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.4.31.tgz",
-      "integrity": "sha512-ODLfBEC9jVtvJ72Sm3pWHUS2T7j3v1sFo8iiiPoTBjz8VG5q2Pygzj4s0K7nsnKOvSqFw8KWTMxg45EyPZyv0g=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.4.32.tgz",
+      "integrity": "sha512-6tnOASMVbDNMYRKSddkmL22Ah3EcuwyxpyJHRBW85KxmEUhz896roh81ScmM0yQGSSYQ2KQOKRaaTpH/S48YIg=="
     },
     "node_modules/@gjsify/fs": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.4.31.tgz",
-      "integrity": "sha512-W4seeq6TRFVd6v/nvHcsmRvI+mSeGKbeZa9Cnd34GNl02ZEvfEz5JRjh80Nvz/QurcUNs3N12HBkjy0sCL57dA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.4.32.tgz",
+      "integrity": "sha512-oUCNNQ3xy7AYDNT7zItAjfaMNeGzW4KZX9GHYeFmchzBFX24FgEsbB+sH40YjJJRN7pwMOoNolmEfs3sx1ZB/w==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.31",
-        "@gjsify/events": "^0.4.31",
-        "@gjsify/stream": "^0.4.31",
-        "@gjsify/url": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/buffer": "^0.4.32",
+        "@gjsify/events": "^0.4.32",
+        "@gjsify/stream": "^0.4.32",
+        "@gjsify/url": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0": {
@@ -2895,34 +2895,34 @@
       }
     },
     "node_modules/@gjsify/gamepad": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.4.31.tgz",
-      "integrity": "sha512-pgI2a70EVPlNbuVU69F8GXjq8aGKXOT3uNLtmU96k6uaRnXNoCDS1Z4qlmjCeXrkHGQBzjfOKzqiWS8QpS6TDw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.4.32.tgz",
+      "integrity": "sha512-DDyTVjuYWFiDvrrr/QmsbzhHfkV8ejd8FbR9siek0yCWYBoDntRiaS3TUBiSDKDjZWQumIU92MFJGmnH4eVXIQ==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.31"
+        "@gjsify/dom-events": "^0.4.32"
       }
     },
     "node_modules/@gjsify/http": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.4.31.tgz",
-      "integrity": "sha512-75ZclOT4fAkCtZwepOpZYTS6lkRPiaFMae+UwXY4yu+2c5wLivUrYN2Le2eiv7ltiOYfvk+sGipmGQ4dJV50cw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.4.32.tgz",
+      "integrity": "sha512-S24LpsjKs+mS2s/iwRoVARsJOJGazEZSM5XRwOqFoUOeEZhjPbRl9bHYHswku3DBtlOOZM2Sl/4N51zRmBDxOw==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/buffer": "^0.4.31",
-        "@gjsify/events": "^0.4.31",
-        "@gjsify/http-soup-bridge": "^0.4.31",
-        "@gjsify/net": "^0.4.31",
-        "@gjsify/stream": "^0.4.31",
-        "@gjsify/url": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/buffer": "^0.4.32",
+        "@gjsify/events": "^0.4.32",
+        "@gjsify/http-soup-bridge": "^0.4.32",
+        "@gjsify/net": "^0.4.32",
+        "@gjsify/stream": "^0.4.32",
+        "@gjsify/url": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/http-soup-bridge": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.4.31.tgz",
-      "integrity": "sha512-l9rF+pjxfZkAy4JiZHj0Bthp+vBKRcgBCIusLnIWGGXMq77EW7STT/ArHVF9zmY4ieBawh/aBxxYNZw9ztyNWw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.4.32.tgz",
+      "integrity": "sha512-n8pqJgxx3duo4vEWVmpwWTf6j1Ucz5MFHEwQS6UnSC0wkJZ5Sz5rz4MJ3AWi7SmldHwr4rrD3iNJ9pbZdGNVAg==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/gjs": "4.0.1",
@@ -3082,23 +3082,23 @@
       }
     },
     "node_modules/@gjsify/http2": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.4.31.tgz",
-      "integrity": "sha512-E1f9LTCS7wAM7c7YNX7G6sCWFpbhvLfcNiC/hZRCt9RpqNu8QbGEKojbgbafVCiybDGujsnS3Fq6TDW7d7l4Lg==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.4.32.tgz",
+      "integrity": "sha512-4HUz/DjmTrKF095jmQtERfZudGgB5Pe+m4Y84d6QX7PhIzh0cJ7T4bvu5NRz2w7YRUoAjRA8qE1Or+9deZSUew==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/gobject-2.0": "2.88.0-4.0.1",
         "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/events": "^0.4.31",
-        "@gjsify/http2-native": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/events": "^0.4.32",
+        "@gjsify/http2-native": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/http2-native": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.4.31.tgz",
-      "integrity": "sha512-ArBwEQC3Gwd/8jibVWJEWt9V07oVtaZbbU33oeTvI4RcZIioI/VuPKLqjkofiKlCGF05+QOTxB5gX6so5RBjhA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.4.32.tgz",
+      "integrity": "sha512-R2u/Y7hYjJxGYXmw6beJJ0d37X3oHbhJbtPF6e2zgYoy9Z+LjvoaWeGTgZoa2tvEn4aCqfslfPXMH65OJJ2WvA==",
       "dependencies": {
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
@@ -3268,36 +3268,36 @@
       }
     },
     "node_modules/@gjsify/https": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.4.31.tgz",
-      "integrity": "sha512-GgB/jThl11YySz1eSR3OqoG0JzFp8wtXeHYiw8DjQddCy3v3p3TmhANIByAVelBDCT++/OFfWq5eNouMThj5/Q==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.4.32.tgz",
+      "integrity": "sha512-ellz+8zFWA/nbGtYaodJt5tBymyecPhVQge0q1bErxxWkMFdGBrCKM03DUDQcYwMvXyfcUH8QKN8CM9n3W+khg==",
       "dependencies": {
-        "@gjsify/http": "^0.4.31",
-        "@gjsify/tls": "^0.4.31"
+        "@gjsify/http": "^0.4.32",
+        "@gjsify/tls": "^0.4.32"
       }
     },
     "node_modules/@gjsify/inspector": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.4.31.tgz",
-      "integrity": "sha512-Nx6j5ptDQsN5SV72txCJCS2XTJTmKPCqpt28TNvVjqVA56KrUhxPvE8VSBQ4uE0TJMI6CPt/X4in5xoQ7bQbzA=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.4.32.tgz",
+      "integrity": "sha512-4p8cagAgQ1Uf86BKkkSNlx/++BO6HWf6DlAN4o+0E3s03EBYrGJ5FUFsscZXmfFMnDT2q+YG/kStPSlGWKiZYA=="
     },
     "node_modules/@gjsify/message-channel": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.4.31.tgz",
-      "integrity": "sha512-Bz18D0GuaaHKeDk/Hi69+1pHaA0yStZaBItEuyqx8WbRPhhctzm7TMPAQ7NfN7CFCojKcW1lntX/H+w+QrvWiQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.4.32.tgz",
+      "integrity": "sha512-Dx1VZDjR7XJZts05Gslvgnsjij6th5Xto2tvjOE0BN29mzHwn+5SDaXzbPBU+MGzP9ctEWr0UQOoxhHwCHw47Q==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.31"
+        "@gjsify/dom-events": "^0.4.32"
       }
     },
     "node_modules/@gjsify/module": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.4.31.tgz",
-      "integrity": "sha512-7rbvnJUEVTxXZ85dtoU18GPadPsS4oxvNiIobNWV4m68CuDyVJrD/KrpEeaBgIrPDNiejBjTnGhaW3xQkszRfg==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.4.32.tgz",
+      "integrity": "sha512-+8GJ6EtqXhyo3WzDcsfyGNiOzYEizb/sWSs0Q/N0rzq9UIz6Lve/gy2yAj6H/N5rKHnmVxI1s1jtn1o1KOLCLQ==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/gio-2.0": {
@@ -3379,16 +3379,16 @@
       }
     },
     "node_modules/@gjsify/net": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.4.31.tgz",
-      "integrity": "sha512-jqSn+jxH2ZXNSPFvKhPCFAHDv2XWPVRZall93IjzQgmyZhMmNhEG+7iT2njR4iJcAH4Hksbweuggj7z2ce0wXg==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.4.32.tgz",
+      "integrity": "sha512-RQeqk8hlNYggS8M7/m/KnYJYde+ni8HjpkG8nrebl+UonwP3AYteeLt0CaFyzZtcUXfJmM76Ixm6GgHu58XE4w==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.31",
-        "@gjsify/events": "^0.4.31",
-        "@gjsify/stream": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/buffer": "^0.4.32",
+        "@gjsify/events": "^0.4.32",
+        "@gjsify/stream": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/gio-2.0": {
@@ -3482,15 +3482,15 @@
       }
     },
     "node_modules/@gjsify/node-globals": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.4.31.tgz",
-      "integrity": "sha512-/glYbuoB6wEY4PgKa4N8bNjhopVy6xEufvK2llh5cA6pB2Dzxk0M6ow+EvTWT21N4iL98gaKRspZB3DVW+pdGw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.4.32.tgz",
+      "integrity": "sha512-OxgbAi2xgTUehLxYRcJmIiv8DrucfKet9zzPpe/mZq9bT32otWsQ5w0TCXG+6UWrZqwSV2sn19LBlEQd6H37Ng==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.31",
-        "@gjsify/process": "^0.4.31",
-        "@gjsify/url": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/buffer": "^0.4.32",
+        "@gjsify/process": "^0.4.32",
+        "@gjsify/url": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0": {
@@ -3554,65 +3554,65 @@
       }
     },
     "node_modules/@gjsify/node-polyfills": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.4.31.tgz",
-      "integrity": "sha512-VkDN+PV4RkOZtHTkEbYYGUhzL8IJ4O2j7v1Sf/Ex35OnLGJddjQVrqumCj6XG4t+uLBm0HUsx6zwUf8tz9A5/w==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.4.32.tgz",
+      "integrity": "sha512-eAmgelYvtmFiBL9PYTi2jgdUdlZOv7BWK+xQM0trLV8FZKnBTVXG4gabms+u7bMgzSAoE3f0E7oekA/9Yn/Aiw==",
       "dependencies": {
-        "@gjsify/assert": "^0.4.31",
-        "@gjsify/async_hooks": "^0.4.31",
-        "@gjsify/buffer": "^0.4.31",
-        "@gjsify/child_process": "^0.4.31",
-        "@gjsify/cluster": "^0.4.31",
-        "@gjsify/console": "^0.4.31",
-        "@gjsify/constants": "^0.4.31",
-        "@gjsify/crypto": "^0.4.31",
-        "@gjsify/dgram": "^0.4.31",
-        "@gjsify/diagnostics_channel": "^0.4.31",
-        "@gjsify/dns": "^0.4.31",
-        "@gjsify/domain": "^0.4.31",
-        "@gjsify/events": "^0.4.31",
-        "@gjsify/fs": "^0.4.31",
-        "@gjsify/http": "^0.4.31",
-        "@gjsify/http2": "^0.4.31",
-        "@gjsify/https": "^0.4.31",
-        "@gjsify/inspector": "^0.4.31",
-        "@gjsify/module": "^0.4.31",
-        "@gjsify/net": "^0.4.31",
-        "@gjsify/node-globals": "^0.4.31",
-        "@gjsify/os": "^0.4.31",
-        "@gjsify/path": "^0.4.31",
-        "@gjsify/perf_hooks": "^0.4.31",
-        "@gjsify/process": "^0.4.31",
-        "@gjsify/querystring": "^0.4.31",
-        "@gjsify/readline": "^0.4.31",
-        "@gjsify/sqlite": "^0.4.31",
-        "@gjsify/stream": "^0.4.31",
-        "@gjsify/string_decoder": "^0.4.31",
-        "@gjsify/sys": "^0.4.31",
-        "@gjsify/timers": "^0.4.31",
-        "@gjsify/tls": "^0.4.31",
-        "@gjsify/tty": "^0.4.31",
-        "@gjsify/url": "^0.4.31",
-        "@gjsify/util": "^0.4.31",
-        "@gjsify/v8": "^0.4.31",
-        "@gjsify/vm": "^0.4.31",
-        "@gjsify/worker_threads": "^0.4.31",
-        "@gjsify/zlib": "^0.4.31"
+        "@gjsify/assert": "^0.4.32",
+        "@gjsify/async_hooks": "^0.4.32",
+        "@gjsify/buffer": "^0.4.32",
+        "@gjsify/child_process": "^0.4.32",
+        "@gjsify/cluster": "^0.4.32",
+        "@gjsify/console": "^0.4.32",
+        "@gjsify/constants": "^0.4.32",
+        "@gjsify/crypto": "^0.4.32",
+        "@gjsify/dgram": "^0.4.32",
+        "@gjsify/diagnostics_channel": "^0.4.32",
+        "@gjsify/dns": "^0.4.32",
+        "@gjsify/domain": "^0.4.32",
+        "@gjsify/events": "^0.4.32",
+        "@gjsify/fs": "^0.4.32",
+        "@gjsify/http": "^0.4.32",
+        "@gjsify/http2": "^0.4.32",
+        "@gjsify/https": "^0.4.32",
+        "@gjsify/inspector": "^0.4.32",
+        "@gjsify/module": "^0.4.32",
+        "@gjsify/net": "^0.4.32",
+        "@gjsify/node-globals": "^0.4.32",
+        "@gjsify/os": "^0.4.32",
+        "@gjsify/path": "^0.4.32",
+        "@gjsify/perf_hooks": "^0.4.32",
+        "@gjsify/process": "^0.4.32",
+        "@gjsify/querystring": "^0.4.32",
+        "@gjsify/readline": "^0.4.32",
+        "@gjsify/sqlite": "^0.4.32",
+        "@gjsify/stream": "^0.4.32",
+        "@gjsify/string_decoder": "^0.4.32",
+        "@gjsify/sys": "^0.4.32",
+        "@gjsify/timers": "^0.4.32",
+        "@gjsify/tls": "^0.4.32",
+        "@gjsify/tty": "^0.4.32",
+        "@gjsify/url": "^0.4.32",
+        "@gjsify/util": "^0.4.32",
+        "@gjsify/v8": "^0.4.32",
+        "@gjsify/vm": "^0.4.32",
+        "@gjsify/worker_threads": "^0.4.32",
+        "@gjsify/zlib": "^0.4.32"
       }
     },
     "node_modules/@gjsify/npm-registry": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.4.31.tgz",
-      "integrity": "sha512-KwdfOAoilmi07+ahTnkIKqj/TNLfZ+6ou/fAMXP6TtcI0Afd96RYUmaxKMD1S1cjuKvrt/ZTX1E2sST/c7cyTw=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.4.32.tgz",
+      "integrity": "sha512-I+jBA06BK0IfpVWXDCPG4koiGl8Ku1t4H4qTCPWXZuex4uNWAuVWpGrjjPAcWRpRexL726cArF0tR4YqM8uQVg=="
     },
     "node_modules/@gjsify/os": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.4.31.tgz",
-      "integrity": "sha512-rgIPGspLZdBVedA0M0er7gMXTteRi6K1f4naFbPSqqIuekwac6ljGwadRLf77aru1QO71UH7US+yp1FK60ndbQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.4.32.tgz",
+      "integrity": "sha512-n43a7d4wJV2orgY87IGwizcWYtFsjnZWO+jhLJ3CypTQ65+d2V5fMqviHg0JCeDiXRO58zcDSp66YvRyNvGNwg==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/gio-2.0": {
@@ -3706,62 +3706,62 @@
       }
     },
     "node_modules/@gjsify/path": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.4.31.tgz",
-      "integrity": "sha512-eaXNC5iDYPwIXgxxXXUQUlK16HUBogPbpND4LpR2qS0bs8cV175ARoNwfCw5y4Nl8WJItw1uYw3VbePHlt7y0A=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.4.32.tgz",
+      "integrity": "sha512-Ooxs5vGRcWklOSzcuC4zevTrv8kpQTW2vAfFkkv+EL/A+Izk9Mj0zq2wMlg+FigUZG4vjoHq5UsyPvu12MkvZA=="
     },
     "node_modules/@gjsify/perf_hooks": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.4.31.tgz",
-      "integrity": "sha512-NV5Uwz3pwgU78O5JPr/BLa3FZw/OivCv1mzceACNfAS+OvgpgBnmBMpbjEMYaP81bbD4iuuPWhp+hpMtZPNUxQ=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.4.32.tgz",
+      "integrity": "sha512-P8nD3Sk1HTmzKK6GQmkkGetxUedMjRrw9XULfkMiMGSTxrp9DWG+bwfkqgfvcelE27TUgP68dKvzLGtXCs5nug=="
     },
     "node_modules/@gjsify/process": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.4.31.tgz",
-      "integrity": "sha512-1Hayz978OOLnF8LdAsYLfC+rnbEE1gAzCQ41mUiQehhM3uNzHcUMqJP2mvFljuOTmFBGJwA+16W2D82JXtWmCA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.4.32.tgz",
+      "integrity": "sha512-QxUMXKCju+LVh0MenWfa8k8TvY9FNv3Qtv0qE95MCsO6dgszhW86VhHWodCx3sJYabc9qNRASAY6OKzGQybNBQ==",
       "dependencies": {
-        "@gjsify/events": "^0.4.31",
-        "@gjsify/terminal-native": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/events": "^0.4.32",
+        "@gjsify/terminal-native": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/querystring": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.4.31.tgz",
-      "integrity": "sha512-XU/b1kls8JiZ9d3NHoSFuXRt7XhZNL+JKk+PLFT6Ao1Uqpy7eC/igDw0IgiCtqFjQKWPjKCbGnmJmrkN+1LuTA=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.4.32.tgz",
+      "integrity": "sha512-bPauc5NzUXkbpvCAh8+/u8HMNjCu5q+W6SuAISbw1GJZRxi/GvQSI+heq1xfMbi73At9YnRZ4a+5Ag8WMD07cA=="
     },
     "node_modules/@gjsify/readline": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.4.31.tgz",
-      "integrity": "sha512-7rDpJG1UGLyxO6viUtFpRk6wpe5d3C104W87ZbsLq4C+R/ZEjxtRVK5PAJaw21aaQt1bs2jB0sOHlQrBDQfhbA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.4.32.tgz",
+      "integrity": "sha512-AKpF1li0wGGLEkWkAWNETlu7FBTNTl/nI78anoyMTGzFDxz/KWvifzncKGl70EoREYODvT88ZO16MHgtPh3O3A==",
       "dependencies": {
-        "@gjsify/events": "^0.4.31"
+        "@gjsify/events": "^0.4.32"
       }
     },
     "node_modules/@gjsify/resolve-npm": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.4.31.tgz",
-      "integrity": "sha512-L9IffCWcl9kK/QZP+p+3vdRtGeZcRcR4m7cIEh4radDkWqxx5gs28aaAgx98CCynKZ7h1LGaNraIl+H6VmmSeQ=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.4.32.tgz",
+      "integrity": "sha512-kusljchXQaRcbNtFRmZ9EVSrtWVMseuQMR2oACZISrsR9pbdo3iWaTHQroltUEZBGnAeNJRqDWL0giUaJ0eRTg=="
     },
     "node_modules/@gjsify/rolldown-plugin-deepkit": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.4.31.tgz",
-      "integrity": "sha512-yENm0ytdMqBQj0By7GVAV063cvR7D2AbCfJIkqMRQpoFkOhbnpYkUeW7V7LLCDBwtbVTLcQCi6yJ7kU5a4rwsA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.4.32.tgz",
+      "integrity": "sha512-1V3FRzcvnb/6CzD6DFRBGNsNNZSymTzWsXx0HbIYjarx6LL5UQqfb4aAvgFZXQ8PubMzCnWWpMmrchsE+5yAbg==",
       "dependencies": {
         "@deepkit/type-compiler": "^1.0.19",
         "typescript": "^6.0.3"
       }
     },
     "node_modules/@gjsify/rolldown-plugin-gjsify": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.4.31.tgz",
-      "integrity": "sha512-s6rcKw/o4gG+zGR2+Hf7fiAGC4rpEXrGmKNN5tadwkDp+dNhG14FOUVaFWrhDzaAlrJpRPZ6uPH4kPPN4pvYGQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.4.32.tgz",
+      "integrity": "sha512-yVi2cySuhaRUkrX6noggwXyCmcr/cuOF0a7w2VN1wBmqrg9UQPJI2nFnBlk9KJ7bMAIPBDnULKBpzDa4JvSuVA==",
       "dependencies": {
-        "@gjsify/console": "^0.4.31",
-        "@gjsify/resolve-npm": "^0.4.31",
-        "@gjsify/rolldown-plugin-deepkit": "^0.4.31",
-        "@gjsify/rolldown-plugin-pnp": "^0.4.31",
-        "@gjsify/vite-plugin-blueprint": "^0.4.31",
+        "@gjsify/console": "^0.4.32",
+        "@gjsify/resolve-npm": "^0.4.32",
+        "@gjsify/rolldown-plugin-deepkit": "^0.4.32",
+        "@gjsify/rolldown-plugin-pnp": "^0.4.32",
+        "@gjsify/vite-plugin-blueprint": "^0.4.32",
         "@rollup/pluginutils": "^5.3.0",
         "acorn": "^8.16.0",
         "acorn-walk": "^8.3.5",
@@ -3770,14 +3770,14 @@
       }
     },
     "node_modules/@gjsify/rolldown-plugin-pnp": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.4.31.tgz",
-      "integrity": "sha512-/yhq/FC32nErtycIfMOdfji/MX2fdmRLcc2x95hFNpB8LA7m/A76ccdaBSbseQLyXOeyXmj2TdWvGEje1VXo0g=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.4.32.tgz",
+      "integrity": "sha512-sODowh2NigaMJ6dS3r1/O9YQD8boQCEr96F7hEH2v42ShLipUNCgikC8ghu6Owl7h6dIfSckSB+Hef7bzoa+0w=="
     },
     "node_modules/@gjsify/sab-native": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.4.31.tgz",
-      "integrity": "sha512-ZGauy/x5THKIwGAICPpYCV15Lwlp/xN+o+CpvvKGHga+ypJCUoNfoQXT0rsSgBwLAR5E4cTIDcQXMcNUt66Pfw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.4.32.tgz",
+      "integrity": "sha512-SBUhwibnnSTQbUUPKo9f9vcHSKIENxAa6G0kAAxoSKKekY+MF7dcvG7KAHjPBz3Nieu2zSNhGQQebki8SYxdbA==",
       "dependencies": {
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
@@ -3846,14 +3846,14 @@
       }
     },
     "node_modules/@gjsify/semver": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.4.31.tgz",
-      "integrity": "sha512-l29Q0z5Wro4DqBSYA8xjPT4u5o9a313MYz3ERtSjys5lb1wNr/InXFsM7koK3qTRwZUdWirR8xJUTsce02tTCQ=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.4.32.tgz",
+      "integrity": "sha512-YzvGUiRXzwWNF+TZzJp7+QT65lfuK3+XrIuVc9PlrbA3F3afPcEaAbZW0GTnPB4TOGJylPXfrK6/JUWRDt+cFQ=="
     },
     "node_modules/@gjsify/sqlite": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.4.31.tgz",
-      "integrity": "sha512-TTL1htZiemxb0W/f3QA+wbCH9K2fC17l0/VS5/GqxFk0XVku0C+swGSZEssxFbWfaWR/3AKUrE24USxGxdO8xA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.4.32.tgz",
+      "integrity": "sha512-O9O+BuftZBFC1qBR7ptpeGx38R9yCJK9WedlzGvok4A1Pt2jRQ8xgHoRi1DubE4Hh2AWmVL9/k+dDSVkrxnBIg==",
       "dependencies": {
         "@girs/gda-6.0": "6.0.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
@@ -3963,40 +3963,40 @@
       }
     },
     "node_modules/@gjsify/stream": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.4.31.tgz",
-      "integrity": "sha512-T/YCaTgolpbGFJ1gmvwFfczwYFLUX1tR3SY2hGLqXm0UPj60KIQzshcgmWA1g2GHkurwR32O8B4qnjkWYa1R+w==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.4.32.tgz",
+      "integrity": "sha512-ss/urRwCYKmPS4QIvlm4ULfwgIvKZTCVTl8SX66Gw5kcBitxnPdOkhTLP+QO7PUc06/nzovQn/yF9NGf64ZYMA==",
       "dependencies": {
-        "@gjsify/events": "^0.4.31",
-        "@gjsify/utils": "^0.4.31",
-        "@gjsify/web-streams": "^0.4.31"
+        "@gjsify/events": "^0.4.32",
+        "@gjsify/utils": "^0.4.32",
+        "@gjsify/web-streams": "^0.4.32"
       }
     },
     "node_modules/@gjsify/string_decoder": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.4.31.tgz",
-      "integrity": "sha512-/qdwYGmv0OQQoMLlJHIVJGGi+HGgYSDMmftum6EKe7fEibIuVIvbHyInN29UuidBUuZGtsv+IgRt/QJQy6uOKw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.4.32.tgz",
+      "integrity": "sha512-Zh5++PUI3Sw6fHAbUxeAQczHt6z2X0B6vSjHMgCe6VFFGI2AN3vIiH5LGNt7s4Kg2VzsG/IxIdPVLNQufBM6yQ==",
       "dependencies": {
-        "@gjsify/buffer": "^0.4.31"
+        "@gjsify/buffer": "^0.4.32"
       }
     },
     "node_modules/@gjsify/sys": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.4.31.tgz",
-      "integrity": "sha512-cVHgAUpB+xKNKkJqAD0aeEP+f6254wIECYTQDBa8NvJcuBPE6Z5D/mDX5cmm/Bl6VhG6yEzQYGD8dHTFC1ldeQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.4.32.tgz",
+      "integrity": "sha512-xNDo8OuFuwMl6gZ7fV4w/jmH9DJVzxrftwnfK3k7R6h3aWyYfTjowigEAk1iAblyDApm9ITW6i3p5RL39C75qg==",
       "dependencies": {
-        "@gjsify/util": "^0.4.31"
+        "@gjsify/util": "^0.4.32"
       }
     },
     "node_modules/@gjsify/tar": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.4.31.tgz",
-      "integrity": "sha512-7pFDPBcnZFIK3AkHJoBPDnaVaq87lmp7kAeuXs1pV2gOWqwwLX+hugAK85xlu9lqNYOrce997GU4j2WxsBsmcA=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.4.32.tgz",
+      "integrity": "sha512-C/EeHCZ81D4RQsSIg92MPbNm5uOhILgtE9mSWdtOkWW1rFpTzHAo3kWDopHaEfMTSGAl+dbmnBnTqG0V+uSVNg=="
     },
     "node_modules/@gjsify/terminal-native": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.4.31.tgz",
-      "integrity": "sha512-aSc2tcs+gVP9DeVkG4LYtdTpqR7oVdH47oBsSnA4UaXrwvbO8ZLotLkpxhWeMEyUuscfFtxJdNQk6SeWs7hrTQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.4.32.tgz",
+      "integrity": "sha512-y+FlFalCZt/3uX902adkcMnONG73MgzhwhFiqoOGNSVfE4Cu0tj40qos4Vkq+RNzkHhoH5i3mdNWSicwWXrYog==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/gobject-2.0": "2.88.0-4.0.1"
@@ -4105,26 +4105,26 @@
       }
     },
     "node_modules/@gjsify/timers": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.4.31.tgz",
-      "integrity": "sha512-zFMBN3COZeWdsDcL28SW3RKJqR4PXcaPM2alalNU8cbpNNfa/v3ngFHoIDDz2Y10tjsISozYFqSVSGCbpYO3nA=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.4.32.tgz",
+      "integrity": "sha512-UIBVY95K/dyh5KWe/ATp5byHHZKbVmbjx3YcgA+I+AAuvcRtn052AZY1cS19hwCMPFbfoPyMjPLYVTm7G0shaw=="
     },
     "node_modules/@gjsify/tls": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.4.31.tgz",
-      "integrity": "sha512-Mnf/bHXebV4ZfXo93ohfcXziduGRUHLyvfnBGc+UWpmiP9iBt1/sxX4WtYPkguLFQK6it1VgXEaQykfy8oLEjg==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.4.32.tgz",
+      "integrity": "sha512-r5R03XEGdiUZbu7SgMGlZk8GgKQZG5enRDMyey5DcXFZhxg+w0yRp5/wGlIYa8fbo1FvY5Qxk2KVUum55MV20w==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/net": "^0.4.31",
-        "@gjsify/tls-native": "^0.4.31",
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/net": "^0.4.32",
+        "@gjsify/tls-native": "^0.4.32",
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/tls-native": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.4.31.tgz",
-      "integrity": "sha512-MsDufx1qTSsCpUYmsU/XrqOr9IfSKYQW86OPsthfvu4Zfy7Uq5iSqdQhtIwJbmJN+SErdW5AEOtM+ZAei8lqUw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.4.32.tgz",
+      "integrity": "sha512-Z4EdQgeqOrBhBh4px+87z26Y3icwu53LsoBWnuJn9ad0E5Xy9rs6jByGCAHsSKsD5/JyjQnFlG4o2f8HVJDKSw==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/gobject-2.0": "2.88.0-4.0.1"
@@ -4323,13 +4323,13 @@
       }
     },
     "node_modules/@gjsify/tty": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.4.31.tgz",
-      "integrity": "sha512-01PvF1ghZ1KbBnRGCIZ2aTr0mwGWhJbLBDzZYzoB1fbUOPjuOaCWgqhdnNfTuk/M5Uw3WzEIcjgH8ptDjUUGNQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.4.32.tgz",
+      "integrity": "sha512-09996mu2WxGWWwh6XyfUUMMYOr1HePJfBmu7xDb6/9JtkjLxjWyzpEc9Kd24ozPoCVvjmHUBOI5uZwHDLDuv+g==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/stream": "^0.4.31",
-        "@gjsify/terminal-native": "^0.4.31"
+        "@gjsify/stream": "^0.4.32",
+        "@gjsify/terminal-native": "^0.4.32"
       }
     },
     "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0": {
@@ -4393,9 +4393,9 @@
       }
     },
     "node_modules/@gjsify/url": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.4.31.tgz",
-      "integrity": "sha512-IrjQHJ3j4JZIW3Y4M7DNkc/xKj9+OQe1oLBklj22Ojb2+TTJtpyNJ25/WtgL2BhJeXHLpp5DW04xQGm2CQQjZg==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.4.32.tgz",
+      "integrity": "sha512-/CKabFMTlznwWWDZYtRgNr/bfQ6NVCSRDznx+dJX+PeEUGl2pGGKo6S6PZVDzMXSOixjeSsh5DjVQC9v5IqMaw==",
       "dependencies": {
         "@girs/glib-2.0": "2.88.0-4.0.1"
       }
@@ -4461,14 +4461,14 @@
       }
     },
     "node_modules/@gjsify/util": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.4.31.tgz",
-      "integrity": "sha512-kd145b/cMJ4Qo6GWNFYCrsxS8tUIWnEUriX9DqnKg2LoqmGRgmy0hyELyi9x2vt4sWZzQhDd7Eshl8iZHe1uJg=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.4.32.tgz",
+      "integrity": "sha512-RchRjf6tmKMG2BQeJ6d/ybrn68jhC42Oo11hmNJcrtKixn5XCezeBC3gDglIyp+g8k+1vXCgsY60A5dI5T4xrQ=="
     },
     "node_modules/@gjsify/utils": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.4.31.tgz",
-      "integrity": "sha512-Ow3IWAKFyVpbm9BmFwmQGRQ7HSZNh3TbagXEe6NwG3uWWskPUJ2l3/Agg0hoe/UQuZY99KU7E/YYrE905edCjw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.4.32.tgz",
+      "integrity": "sha512-fPE4YR2czWeEx6VoWHJ3Na7bxctu3qBPmSpF0/K8OKBC/Y9Y9M+zvK6VRMKSvIqFsSx0mq5bmAvR++bjsHd8Zg==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/giounix-2.0": "2.0.0-4.0.1",
@@ -4555,110 +4555,110 @@
       }
     },
     "node_modules/@gjsify/v8": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.4.31.tgz",
-      "integrity": "sha512-au/6Ue1FmcpZUCR4JyCggi5c0wyR9e5SJZ+Lj8dw1+GDhxcqGlpO21TT9yv/Oonh/PsKneu55P2Sf/1t8eFULQ=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.4.32.tgz",
+      "integrity": "sha512-EjXmvF6lXZehcNRVqTNMv+MefDPwRrIKjPWI1xLpLV3Z3XAyH4FlLw5NfjmsdsXII5+fIfdIcDBO0XYvrBDjCQ=="
     },
     "node_modules/@gjsify/vite-plugin-blueprint": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.4.31.tgz",
-      "integrity": "sha512-1GaSXjHBFCPaHzaABsqLVjZqB56GzhKnFKEDPFjlLUY25gj+eUJHqc+Q1zVWbO1ztFRQYGyrGKkbfZVCZcKZpQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.4.32.tgz",
+      "integrity": "sha512-G5PNXmrBV/jaqtaleoJXd+KEPgo6ZWVulp58QP50hlszLO7fyS9iE0hR4OwNqsYx5E4SbevxXwocauNk1E1RXQ==",
       "dependencies": {
         "execa": "^9.6.1",
         "minify-xml": "^4.5.2"
       }
     },
     "node_modules/@gjsify/vm": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.4.31.tgz",
-      "integrity": "sha512-6A09+pdO8hP+I4xwe1EkUCEzmIQigIznpLalLhf0j1RJGOF8Qcm/PWdmuDt1nloMtZlonK0ikx3d2sa5XcsTjA=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.4.32.tgz",
+      "integrity": "sha512-9LyM38GcbSfvAhaQC2h96rQ5EFkxbzM6CQQdDYUgZyT5VT/jcLPfLa7BrIgb2VO4qrjiTwiHSA04ubssB3MNrg=="
     },
     "node_modules/@gjsify/web-globals": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.4.31.tgz",
-      "integrity": "sha512-Kvg7P6hlconhB2MacvVbij7V5OCfQmZNq6YVV3dikzUus1NczJgpTZMZQbS8ScMSnHsrwpDDQ9OS79Lp2+X8bg==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.4.32.tgz",
+      "integrity": "sha512-/awHagXfKdEVeSkuDXaHYHZsTHQ5OBXKNBeIMgf2U7j5DTd+FW2GbgmaMCRNqf9wUvGP7tGQoXbFjxVZyucoYg==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.4.31",
-        "@gjsify/buffer": "^0.4.31",
-        "@gjsify/compression-streams": "^0.4.31",
-        "@gjsify/dom-events": "^0.4.31",
-        "@gjsify/dom-exception": "^0.4.31",
-        "@gjsify/eventsource": "^0.4.31",
-        "@gjsify/formdata": "^0.4.31",
-        "@gjsify/gamepad": "^0.4.31",
-        "@gjsify/perf_hooks": "^0.4.31",
-        "@gjsify/url": "^0.4.31",
-        "@gjsify/web-streams": "^0.4.31",
-        "@gjsify/webaudio": "^0.4.31",
-        "@gjsify/webcrypto": "^0.4.31"
+        "@gjsify/abort-controller": "^0.4.32",
+        "@gjsify/buffer": "^0.4.32",
+        "@gjsify/compression-streams": "^0.4.32",
+        "@gjsify/dom-events": "^0.4.32",
+        "@gjsify/dom-exception": "^0.4.32",
+        "@gjsify/eventsource": "^0.4.32",
+        "@gjsify/formdata": "^0.4.32",
+        "@gjsify/gamepad": "^0.4.32",
+        "@gjsify/perf_hooks": "^0.4.32",
+        "@gjsify/url": "^0.4.32",
+        "@gjsify/web-streams": "^0.4.32",
+        "@gjsify/webaudio": "^0.4.32",
+        "@gjsify/webcrypto": "^0.4.32"
       }
     },
     "node_modules/@gjsify/web-polyfills": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.4.31.tgz",
-      "integrity": "sha512-OKE40ti3eM33pTiruhfy2Jxrg2FN58K6mwW2/bM7HOW797zTkZecDs+I5bgWQUqJVkhbyVJHdv4N89L4vB/a9g==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.4.32.tgz",
+      "integrity": "sha512-eE1oRtYqB/wOxCpnzsemQ1frq1wpDI7GHJ08XevjfFhH63cilrwKXrkJb8MMYPG6sLbCVL56cJlQYhGuS7VGxg==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.4.31",
-        "@gjsify/compression-streams": "^0.4.31",
-        "@gjsify/dom-events": "^0.4.31",
-        "@gjsify/dom-exception": "^0.4.31",
-        "@gjsify/domparser": "^0.4.31",
-        "@gjsify/eventsource": "^0.4.31",
-        "@gjsify/fetch": "^0.4.31",
-        "@gjsify/formdata": "^0.4.31",
-        "@gjsify/gamepad": "^0.4.31",
-        "@gjsify/message-channel": "^0.4.31",
-        "@gjsify/web-globals": "^0.4.31",
-        "@gjsify/web-streams": "^0.4.31",
-        "@gjsify/webassembly": "^0.4.31",
-        "@gjsify/webaudio": "^0.4.31",
-        "@gjsify/webcrypto": "^0.4.31",
-        "@gjsify/websocket": "^0.4.31",
-        "@gjsify/webstorage": "^0.4.31",
-        "@gjsify/xmlhttprequest": "^0.4.31"
+        "@gjsify/abort-controller": "^0.4.32",
+        "@gjsify/compression-streams": "^0.4.32",
+        "@gjsify/dom-events": "^0.4.32",
+        "@gjsify/dom-exception": "^0.4.32",
+        "@gjsify/domparser": "^0.4.32",
+        "@gjsify/eventsource": "^0.4.32",
+        "@gjsify/fetch": "^0.4.32",
+        "@gjsify/formdata": "^0.4.32",
+        "@gjsify/gamepad": "^0.4.32",
+        "@gjsify/message-channel": "^0.4.32",
+        "@gjsify/web-globals": "^0.4.32",
+        "@gjsify/web-streams": "^0.4.32",
+        "@gjsify/webassembly": "^0.4.32",
+        "@gjsify/webaudio": "^0.4.32",
+        "@gjsify/webcrypto": "^0.4.32",
+        "@gjsify/websocket": "^0.4.32",
+        "@gjsify/webstorage": "^0.4.32",
+        "@gjsify/xmlhttprequest": "^0.4.32"
       }
     },
     "node_modules/@gjsify/web-streams": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.4.31.tgz",
-      "integrity": "sha512-28criSkxf2DCDFIkMn+N3Zvh1hwhTjI7OfGz72IS6rSt6mXCuWp+hRM5lMDhaND0OZFaHJgCquNSiQyRac6tzQ==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.4.32.tgz",
+      "integrity": "sha512-oJsEDXjqjxcGcXDpGe0BRneBJUs+r2Hk1feCOuUHqqpAed7rAhVz2kDhbJUhMkZzYWu8QYSPSy3NKKM3zqqsVQ==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.31"
+        "@gjsify/utils": "^0.4.32"
       }
     },
     "node_modules/@gjsify/webassembly": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.4.31.tgz",
-      "integrity": "sha512-D5CO6SM8OQTkNfTTb4rBCZL1myKPN1QBGs4MVpyoPjPOvrl3G/ml63ADmSTWJlWDgKF+F4FiBj91cTszJQqzag=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.4.32.tgz",
+      "integrity": "sha512-RN/DDyX0cud9FZrV813ZBaKB0/QcaCAjXzBGj2Iq9Wlb1FupFidrsiYwOPjNcG/zkBym0bT1oGdWbbAAVY062w=="
     },
     "node_modules/@gjsify/webaudio": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.4.31.tgz",
-      "integrity": "sha512-/nOzND2HCUQPkdNvHcAGPOukaf1eTNqtv4UIVqBr3HjdCWnvyeUdHme1Z8O+E0fDgQtFYmVG9oAR2KqOhNWEyw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.4.32.tgz",
+      "integrity": "sha512-2GIxvSD5CMsKQrX5pE6dQCKp2+rAgNyiDwOr/Gn38h/2N5IbgjaoNjPcbjXr1G46Xa/nklw1jkXfVCo8Nu9Dyg==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.31"
+        "@gjsify/dom-events": "^0.4.32"
       }
     },
     "node_modules/@gjsify/webcrypto": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.4.31.tgz",
-      "integrity": "sha512-yTKPCR4i/2Ra6yr4mr/tQOkuncqsHXXu5k7+kRi+9i5k7zrLoUhy2QtZMMrZeOgm91SCUJvBkhYeIFLiB+TX6Q==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.4.32.tgz",
+      "integrity": "sha512-Qqhgi7lCvn28V87v6Z47lRZgdJYJsCD/8z2NMT4GrsYx8/68/j4uikDV2FnCWe9gjHMfDXDhanvckSAZBrzmQw==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.4.31"
+        "@gjsify/dom-exception": "^0.4.32"
       }
     },
     "node_modules/@gjsify/webgl": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/webgl/-/webgl-0.4.31.tgz",
-      "integrity": "sha512-zFI80BKjGtzBoOFlJgOJjvpon3/i6pyrbGDIFySt73lxSp9bnEJUC/vu7fwn/HXlAHf36ITK+kiRV5/fajS0cw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/webgl/-/webgl-0.4.32.tgz",
+      "integrity": "sha512-uD0YNrdWcfM+AAbCI3vTUChX62W3Z+NQwT0a0M9BS+zDdXGxAkoMR0plpDU0iw8rIr91TBElOUTo9/4eKa52yw==",
       "dependencies": {
         "@girs/gjs": "4.0.1",
         "@girs/gtk-4.0": "4.23.0-4.0.1",
         "@girs/gwebgl-0.1": "0.1.0-4.0.0-rc.5",
-        "@gjsify/dom-elements": "^0.4.31",
-        "@gjsify/dom-events": "^0.4.31",
-        "@gjsify/event-bridge": "^0.4.31",
-        "@gjsify/utils": "^0.4.31",
+        "@gjsify/dom-elements": "^0.4.32",
+        "@gjsify/dom-events": "^0.4.32",
+        "@gjsify/event-bridge": "^0.4.32",
+        "@gjsify/utils": "^0.4.32",
         "bit-twiddle": "^1.0.2",
         "glsl-tokenizer": "^2.1.5"
       }
@@ -4905,15 +4905,15 @@
       }
     },
     "node_modules/@gjsify/websocket": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.4.31.tgz",
-      "integrity": "sha512-9V8/xn3jfHRYC98bCyxbsJuJT8qI0HkPrrfzaJhpWpgHBAUrp6aDRfJomiklEtWn6t0pUbtL8zFJ6xoFe6zUcA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.4.32.tgz",
+      "integrity": "sha512-FrSOM/l3Mo6RgG6TQeE87E45/8WHtxerkNu36V9Kshy5hfHJn2gPCj/o4zoEz7jq6rBZukwvvgp1pBxiRH8cIg==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
         "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/dom-events": "^0.4.31"
+        "@gjsify/dom-events": "^0.4.32"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/gio-2.0": {
@@ -4995,20 +4995,20 @@
       }
     },
     "node_modules/@gjsify/webstorage": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.4.31.tgz",
-      "integrity": "sha512-fU+TFhp7qZTaleGdKaR+FwDtsy7dh6p/XA0e6e5Z9ULXgRZluDOFEWyVb5nerIlx4IjOYIoZLrCi45NMoVm4OQ=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.4.32.tgz",
+      "integrity": "sha512-whVUJ6O3K9ToJ0PA/Nvuf8OAMsSpuG5xRumkC6GTsP7RnnTU3xoerdm8LMh6MnmTSqnleC+dQ6tBTmlHKoHqPQ=="
     },
     "node_modules/@gjsify/worker_threads": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.4.31.tgz",
-      "integrity": "sha512-2NYbB9pmQ+rkvakm+uItvxA+YaRg++6UNgZ4UYwdINcZLEsNDEK4mqqlIN6+XDomRImHcDbLXeXxZmKvlN8zaA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.4.32.tgz",
+      "integrity": "sha512-SGgZJ2DExlQp0sXUjUY+zHdQH3lAGqbwKq6Y3zze9pkbXmHBTU48+LHTxCcAcvYtDxe8dDzFhdDp2j5cKN6+1Q==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/events": "^0.4.31",
-        "@gjsify/message-channel": "^0.4.31",
-        "@gjsify/sab-native": "^0.4.31"
+        "@gjsify/events": "^0.4.32",
+        "@gjsify/message-channel": "^0.4.32",
+        "@gjsify/sab-native": "^0.4.32"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0": {
@@ -5102,19 +5102,19 @@
       }
     },
     "node_modules/@gjsify/workspace": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.4.31.tgz",
-      "integrity": "sha512-o5wLrVSgJ/P7VckA/ASeIYX5+/zGvFeH9nW38RSdYE9Kgn9nJBFSrPADekxlD/hLs+j6g24a9x3mjAvIeLO9ww=="
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.4.32.tgz",
+      "integrity": "sha512-GIibrC4nwxrN7aHTEeSuAU4bvyW6cigGp5zuPC4P8YjV3M4obr96QKcwYCuBv+X6CKcqxPeqEeFxgNrSdJzWYw=="
     },
     "node_modules/@gjsify/xmlhttprequest": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.4.31.tgz",
-      "integrity": "sha512-/d2zsGf4TkspxNqHSwNLvxyD8IKSX1FALTtcq6BiWWhLjp8LQg49+TqXdvrG1Hq/9sQE8DFSIZt/ylkaE7pxKA==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.4.32.tgz",
+      "integrity": "sha512-Y/iDGYIvCPB058pccKv/GAXniKrdudZdzufUPIWVVnAVZDsELsq/EATFiHRDrhO96yhft2L/vPMetxGvni6Guw==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/gjs": "4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/fetch": "^0.4.31"
+        "@gjsify/fetch": "^0.4.32"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gio-2.0": {
@@ -5196,9 +5196,9 @@
       }
     },
     "node_modules/@gjsify/zlib": {
-      "version": "0.4.31",
-      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.4.31.tgz",
-      "integrity": "sha512-JnNuoAid+DqCVFCzKLNlC8XZo4fDUuutUpDW/kGg3jGY6asPQGgcU4aFU5/objgKTeq8kvoWQJmQusb3o9+FYw==",
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.4.32.tgz",
+      "integrity": "sha512-rYqWgloC9lY9tHCymKLPEKyc6DVithx3xuOCbhLt1gBq+dYZXO1UtMKKJV2Q2N5nAOUepvvEDY0DacuVvLiwXA==",
       "dependencies": {
         "@girs/gio-2.0": "2.88.0-4.0.1",
         "@girs/glib-2.0": "2.88.0-4.0.1"
@@ -6284,9 +6284,9 @@
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dependencies": {
         "function-bind": "^1.1.2"
       }

--- a/packages/gjs/package.json
+++ b/packages/gjs/package.json
@@ -16,10 +16,10 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@gjsify/canvas2d": "^0.4.31",
-    "@gjsify/dom-elements": "^0.4.31",
-    "@gjsify/event-bridge": "^0.4.31",
-    "@gjsify/webgl": "^0.4.31",
+    "@gjsify/canvas2d": "^0.4.32",
+    "@gjsify/dom-elements": "^0.4.32",
+    "@gjsify/event-bridge": "^0.4.32",
+    "@gjsify/webgl": "^0.4.32",
     "@pixelrpg/engine": "workspace:*",
     "@pixelrpg/story-gjs": "workspace:^",
     "excalibur": "^0.32.0"


### PR DESCRIPTION
## Summary

Bumps `@gjsify/{cli,canvas2d,dom-elements,event-bridge,webgl,xmlhttprequest}` from ^0.4.31 to ^0.4.32 across the workspace.

`v0.4.32` contains the [`@gjsify/fs.rmSync` NOFOLLOW fix](https://github.com/gjsify/gjsify/pull/366) — re-running `gjsify install` on a checkout with preexisting workspace symlinks no longer wipes `packages/{engine,gjs,story-gjs}/src/` + `games/zelda-like/`.

## Test plan

- [x] `gjsify install` clean, workspace source dirs preserved across re-install
- [x] `gjsify foreach check -v -t` 0 errors
- [x] `gjsify foreach build -v -t` 0 errors
- [x] `@pixelrpg/engine test` 66/66 passing
- [ ] CI green