### PR TITLE
refactor: codebase sweep — dead code prune + consolidations

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -145,16 +145,20 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     this.signals.connect(this._atlas_view, 'scene-moved', (_v: AtlasView, id: string, x: number, y: number) => {
       this._persistAtlasPosition(id, x, y)
     })
-    // Atlas + scene-editor views forward their mode-rail's
-    // `mode-changed` signal at the view level. Re-route both through
-    // the central `win.mode` action so navigation is consistent — the
-    // action's change-state handler picks the right ViewStack page.
-    this.signals.connect(this._atlas_view, 'mode-changed', (_v: AtlasView, mode: string) => {
+    // Every view's mode-rail forwards `mode-changed` at the view
+    // level. Re-route all four through the central `win.mode` action
+    // so navigation is consistent — the action's change-state handler
+    // picks the right ViewStack page. Mutation handling + persistence
+    // belongs to the per-mode controllers (constructed below);
+    // view-side stays presentational.
+    const setMode = (mode: string) =>
       this._modeAction?.change_state(GLib.Variant.new_string(mode))
-    })
-    this.signals.connect(this._scene_editor_view, 'mode-changed', (_v: SceneEditorView, mode: string) => {
-      this._modeAction?.change_state(GLib.Variant.new_string(mode))
-    })
+    this.signals.connect(this._atlas_view, 'mode-changed', (_v: AtlasView, mode: string) => setMode(mode))
+    this.signals.connect(this._scene_editor_view, 'mode-changed', (_v: SceneEditorView, mode: string) =>
+      setMode(mode),
+    )
+    this.signals.connect(this._cast_view, 'mode-changed', (_v: CastView, mode: string) => setMode(mode))
+    this.signals.connect(this._tiles_view, 'mode-changed', (_v: TilesView, mode: string) => setMode(mode))
 
     // Scene editor → host bridge. The inspector mutates
     // `MapResource.mapData` in place via `engine.setLayerVisible` /
@@ -162,16 +166,6 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     // existing `scene-moved` → `_persistAtlasPosition` flow.
     this.signals.connect(this._scene_editor_view, 'persist-requested', () => {
       this._persistCurrentMap()
-    })
-
-    // Cast + Tiles views — mode-rail navigation forwarded centrally.
-    // Mutation handling + persistence belongs to the per-mode
-    // controllers (constructed below); view-side stays presentational.
-    this.signals.connect(this._cast_view, 'mode-changed', (_v: CastView, mode: string) => {
-      this._modeAction?.change_state(GLib.Variant.new_string(mode))
-    })
-    this.signals.connect(this._tiles_view, 'mode-changed', (_v: TilesView, mode: string) => {
-      this._modeAction?.change_state(GLib.Variant.new_string(mode))
     })
 
     if (!this._castCtl) {

--- a/apps/maker-gjs/src/widgets/cast-view.ts
+++ b/apps/maker-gjs/src/widgets/cast-view.ts
@@ -65,7 +65,7 @@ export class CastView extends Adw.Bin {
   private _activeAnimationId: string | null = null
   private _spriteSet: GdkSpriteSetResource | null = null
   private _galleryRowsById = new Map<string, Adw.ActionRow>()
-  private _signals = new SignalScope()
+  private signals = new SignalScope()
 
   private _onRenameRequested: ((charId: string, name: string) => void) | null = null
   private _onSetPlayerRequested: ((charId: string, isPlayer: boolean) => void) | null = null
@@ -139,23 +139,23 @@ export class CastView extends Adw.Bin {
    */
   vfunc_map(): void {
     super.vfunc_map()
-    this._signals.connect(this._mode_rail, 'mode-changed', (_v: ModeRail, mode: string) => {
+    this.signals.connect(this._mode_rail, 'mode-changed', (_v: ModeRail, mode: string) => {
       this.emit('mode-changed', mode)
     })
-    this._signals.connect(this._anim_list, 'animation-selected', (_v: AnimationList, animId: string) => {
+    this.signals.connect(this._anim_list, 'animation-selected', (_v: AnimationList, animId: string) => {
       this._activeAnimationId = animId
       this._inspector.setAnimation(this._currentAnimation())
     })
-    this._signals.connect(this._inspector, 'name-changed', (_v: CastInspector, name: string) => {
+    this.signals.connect(this._inspector, 'name-changed', (_v: CastInspector, name: string) => {
       if (this._activeCharacterId) this._onRenameRequested?.(this._activeCharacterId, name)
     })
-    this._signals.connect(this._inspector, 'player-changed', (_v: CastInspector, isPlayer: boolean) => {
+    this.signals.connect(this._inspector, 'player-changed', (_v: CastInspector, isPlayer: boolean) => {
       if (this._activeCharacterId) this._onSetPlayerRequested?.(this._activeCharacterId, isPlayer)
     })
-    this._signals.connect(this._inspector, 'speed-changed', (_v: CastInspector, tilesPerSec: number) => {
+    this.signals.connect(this._inspector, 'speed-changed', (_v: CastInspector, tilesPerSec: number) => {
       if (this._activeCharacterId) this._onSetSpeedRequested?.(this._activeCharacterId, tilesPerSec)
     })
-    this._signals.connect(this._inspector, 'duration-changed', (_v: CastInspector, ms: number) => {
+    this.signals.connect(this._inspector, 'duration-changed', (_v: CastInspector, ms: number) => {
       if (this._activeCharacterId && this._activeAnimationId) {
         this._onSetDurationRequested?.(this._activeCharacterId, this._activeAnimationId, ms)
       }
@@ -314,7 +314,7 @@ export class CastView extends Adw.Bin {
   }
 
   vfunc_unmap(): void {
-    this._signals.disconnectAll()
+    this.signals.disconnectAll()
     super.vfunc_unmap()
   }
 }

--- a/apps/maker-gjs/src/widgets/tiles-view.ts
+++ b/apps/maker-gjs/src/widgets/tiles-view.ts
@@ -42,7 +42,7 @@ export class TilesView extends Adw.Bin {
   private _libraryCollapsed = false
   private _inspectorCollapsed = false
 
-  private _signals = new SignalScope()
+  private signals = new SignalScope()
   private _spriteSets: { id: string; resource: SpriteSetResource; gdk: GdkSpriteSetResource | null }[] = []
   private _activeSpriteSetIdx = 0
   private _selectedSpriteId: number | null = null
@@ -118,25 +118,25 @@ export class TilesView extends Adw.Bin {
    */
   vfunc_map(): void {
     super.vfunc_map()
-    this._signals.connect(this._mode_rail, 'mode-changed', (_v: ModeRail, mode: string) => {
+    this.signals.connect(this._mode_rail, 'mode-changed', (_v: ModeRail, mode: string) => {
       this.emit('mode-changed', mode)
     })
-    this._signals.connect(this._tileset_combo, 'notify::selected', () => {
+    this.signals.connect(this._tileset_combo, 'notify::selected', () => {
       if (this._suppressComboNotify) return
       const idx = this._tileset_combo.get_selected()
       this._activeSpriteSetIdx = idx
       this._loadActivePalette()
     })
-    this._signals.connect(this._palette, 'tile-selected', (_p: TilePalette, tileId: number) => {
+    this.signals.connect(this._palette, 'tile-selected', (_p: TilePalette, tileId: number) => {
       this._selectedSpriteId = tileId
       this._refreshInspector()
     })
-    this._signals.connect(this._inspector, 'solid-changed', (_v: TileInspector, solid: boolean) => {
+    this.signals.connect(this._inspector, 'solid-changed', (_v: TileInspector, solid: boolean) => {
       const active = this._activeSpriteSet()
       if (!active || this._selectedSpriteId == null) return
       this._onSolidChanged?.(active.id, this._selectedSpriteId, solid)
     })
-    this._signals.connect(this._inspector, 'surface-changed', (_v: TileInspector, surface: string) => {
+    this.signals.connect(this._inspector, 'surface-changed', (_v: TileInspector, surface: string) => {
       const active = this._activeSpriteSet()
       if (!active || this._selectedSpriteId == null) return
       this._onSurfaceChanged?.(active.id, this._selectedSpriteId, surface === '' ? null : surface)
@@ -316,7 +316,7 @@ export class TilesView extends Adw.Bin {
   }
 
   vfunc_unmap(): void {
-    this._signals.disconnectAll()
+    this.signals.disconnectAll()
     super.vfunc_unmap()
   }
 }

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -18,6 +18,7 @@ import { GameProjectResource } from './resource/GameProjectResource.ts'
 import { MapScene } from './scenes/map.scene.ts'
 import { applyEditorViewMode } from './services/editor-view.ts'
 import { refreshAllTileGraphics } from './services/tile-graphics.manager.ts'
+import { DEFAULT_LAYER_TIER } from './types/data/LayerData.ts'
 import { EngineEvent, type EngineEventMap, EngineStatus, type ProjectLoadOptions } from './types/index.ts'
 import { SessionState } from './utils/session-state.ts'
 
@@ -402,7 +403,7 @@ export class Engine {
     // tier alone needs the visibility filter re-applied. The other
     // tier tilemaps don't carry the layer's sprites, so iterating
     // them would be a no-op-with-cost.
-    const targetTier = layer.tier ?? 'ground'
+    const targetTier = layer.tier ?? DEFAULT_LAYER_TIER
     for (const entity of scene.world.entityManager.entities) {
       if (entity instanceof TileMap) {
         if (entity.get(TileMapTierComponent)?.tier === targetTier) {

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -317,20 +317,32 @@ export class Engine {
   }
 
   /**
+   * Resolve `(scene, stack)` for the active map, or `null` when there
+   * is no active map scene or no undo stack on it. Callers gate on a
+   * single tuple lookup instead of duplicating the scene + component
+   * fetch across every undo/redo entry point.
+   */
+  private _undoContext(): { scene: MapScene; stack: UndoStackComponent } | null {
+    const scene = this._activeMapScene()
+    if (!scene) return null
+    const stack = SessionState.get(scene, UndoStackComponent)
+    if (!stack) return null
+    return { scene, stack }
+  }
+
+  /**
    * Undo the most recent applied command. Reverts the command, drops
    * the cursor by one, fires the `notifyMutation` so subscribers
    * refresh button enabled-states. No-op when `!canUndo()`.
    */
   undo(): boolean {
-    const scene = this._activeMapScene()
-    if (!scene) return false
-    const stack = SessionState.get(scene, UndoStackComponent)
-    if (!stack || !stack.canUndo) return false
-    const command = stack.commands[stack.cursor - 1]
+    const ctx = this._undoContext()
+    if (!ctx || !ctx.stack.canUndo) return false
+    const command = ctx.stack.commands[ctx.stack.cursor - 1]
     if (!command) return false
-    command.revert(scene)
-    stack.cursor -= 1
-    SessionState.notifyMutation(scene, stack)
+    command.revert(ctx.scene)
+    ctx.stack.cursor -= 1
+    SessionState.notifyMutation(ctx.scene, ctx.stack)
     return true
   }
 
@@ -339,28 +351,22 @@ export class Engine {
    * command and advances the cursor. No-op when `!canRedo()`.
    */
   redo(): boolean {
-    const scene = this._activeMapScene()
-    if (!scene) return false
-    const stack = SessionState.get(scene, UndoStackComponent)
-    if (!stack || !stack.canRedo) return false
-    const command = stack.commands[stack.cursor]
+    const ctx = this._undoContext()
+    if (!ctx || !ctx.stack.canRedo) return false
+    const command = ctx.stack.commands[ctx.stack.cursor]
     if (!command) return false
-    command.apply(scene)
-    stack.cursor += 1
-    SessionState.notifyMutation(scene, stack)
+    command.apply(ctx.scene)
+    ctx.stack.cursor += 1
+    SessionState.notifyMutation(ctx.scene, ctx.stack)
     return true
   }
 
   canUndo(): boolean {
-    const scene = this._activeMapScene()
-    if (!scene) return false
-    return SessionState.get(scene, UndoStackComponent)?.canUndo ?? false
+    return this._undoContext()?.stack.canUndo ?? false
   }
 
   canRedo(): boolean {
-    const scene = this._activeMapScene()
-    if (!scene) return false
-    return SessionState.get(scene, UndoStackComponent)?.canRedo ?? false
+    return this._undoContext()?.stack.canRedo ?? false
   }
 
   /**

--- a/packages/engine/src/resource/MapResource.ts
+++ b/packages/engine/src/resource/MapResource.ts
@@ -5,13 +5,10 @@ import { TIER_Z, TileMapTierComponent } from '../components/tilemap-tier.compone
 import { MapFormat } from '../format/MapFormat'
 import { collectHiddenLayerIds } from '../services/layer-visibility.ts'
 import type { LayerData, LayerTier, MapData, MapResourceOptions } from '../types'
+import { DEFAULT_LAYER_TIER, LAYER_TIERS } from '../types/data/LayerData.ts'
 import { loadTextFile } from '../utils'
 import { extractDirectoryPath, getFilename, joinPaths } from '../utils/url'
 import { SpriteSetResource } from './SpriteSetResource.ts'
-
-/** All tiers a `MapResource` builds tilemaps for. Order is canonical
- * for iteration when order doesn't otherwise matter. */
-const ALL_TIERS: readonly LayerTier[] = ['ground', 'hero', 'overlay'] as const
 
 /**
  * Resource class for loading custom Map format into Excalibur.
@@ -113,7 +110,7 @@ export class MapResource implements Loadable<TileMap> {
    */
   private createTileMaps(data: MapData): void {
     MapFormat.validate(data)
-    for (const tier of ALL_TIERS) {
+    for (const tier of LAYER_TIERS) {
       const tilemap = this.buildSingleTileMap(data, tier)
       tilemap.addComponent(new TileMapTierComponent(tier))
       tilemap.z = TIER_Z[tier]
@@ -166,7 +163,7 @@ export class MapResource implements Loadable<TileMap> {
     if (!layer.sprites || !Array.isArray(layer.sprites) || layer.sprites.length === 0) {
       return
     }
-    const tier: LayerTier = layer.tier ?? 'ground'
+    const tier: LayerTier = layer.tier ?? DEFAULT_LAYER_TIER
     const tileMap = this.tileMapsByTier.get(tier)
     const initialSprites = this.initialSpritesByTier.get(tier)
     if (!tileMap || !initialSprites) return
@@ -220,7 +217,7 @@ export class MapResource implements Loadable<TileMap> {
       // Loadable<TileMap> contract — point `data` at the ground
       // tilemap. Callers that need a specific tier should walk the
       // scene by `TileMapTierComponent` instead.
-      const groundTileMap = this.tileMapsByTier.get('ground')
+      const groundTileMap = this.tileMapsByTier.get(DEFAULT_LAYER_TIER)
       if (!groundTileMap) throw new Error('Failed to build ground tilemap')
       this.data = groundTileMap
 
@@ -240,7 +237,7 @@ export class MapResource implements Loadable<TileMap> {
       throw new Error('Map resource not loaded')
     }
 
-    for (const tier of ALL_TIERS) {
+    for (const tier of LAYER_TIERS) {
       const tileMap = this.tileMapsByTier.get(tier)
       const initial = this.initialSpritesByTier.get(tier)
       if (!tileMap || !initial) continue
@@ -304,7 +301,7 @@ export class MapResource implements Loadable<TileMap> {
   getTileMapForLayer(layerId: string): TileMap | undefined {
     const layer = this._mapData?.layers.find((l) => l.id === layerId)
     if (!layer) return undefined
-    return this.getTileMapForTier(layer.tier ?? 'ground')
+    return this.getTileMapForTier(layer.tier ?? DEFAULT_LAYER_TIER)
   }
 
   /** Iterate every tilemap built for this map (one per tier). */

--- a/packages/engine/src/systems/object-spawn.system.ts
+++ b/packages/engine/src/systems/object-spawn.system.ts
@@ -14,6 +14,7 @@ import {
 import { TIER_Z } from '../components/tilemap-tier.component.ts'
 import type { MapResource } from '../resource/MapResource.ts'
 import { isLayerVisible } from '../services/layer-visibility.ts'
+import { DEFAULT_LAYER_TIER } from '../types/data/LayerData.ts'
 import type {
   ItemProperties,
   NpcProperties,
@@ -160,9 +161,8 @@ export class ObjectSpawnSystem extends System {
     // the same render depth as their tier's tilemap, so e.g.
     // decoration actors on the 'hero' tier interleave with the
     // hero-tier tilemap rather than overdrawing the entire map.
-    // Default 'ground' matches the LayerData fallback.
     const layer = mapData?.layers.find((l) => l.id === placement.layerId)
-    actor.z = TIER_Z[layer?.tier ?? 'ground']
+    actor.z = TIER_Z[layer?.tier ?? DEFAULT_LAYER_TIER]
     // Respect the layer's visibility flag at spawn. Runtime
     // toggles re-sync via `Engine.setLayerVisible`.
     if (!isLayerVisible(this.mapResource, placement.layerId)) {

--- a/packages/engine/src/systems/tile-editor.system.ts
+++ b/packages/engine/src/systems/tile-editor.system.ts
@@ -25,6 +25,7 @@ import type { MapScene } from '../scenes/map.scene.ts'
 import { createPencilPreviewActor, type PencilPreviewHover, refreshPencilPreview } from '../services/pencil-preview.ts'
 import { findTileIdForSpriteInfo } from '../services/sprite-info.resolver.ts'
 import type { LayerTier } from '../types/data/index.ts'
+import { DEFAULT_LAYER_TIER } from '../types/data/LayerData.ts'
 import { EngineEvent, type EngineEventMap } from '../types/index.ts'
 import { EDITOR_CONSTANTS } from '../utils/constants.ts'
 import { SessionState } from '../utils/session-state.ts'
@@ -135,18 +136,19 @@ export class TileEditorSystem extends System {
 
   /**
    * Resolve which tier the active layer maps to. Falls back to
-   * `'ground'` when no active layer has been picked yet (typical
-   * for a freshly-loaded map before any inspector interaction) or
-   * when the active layer id no longer exists in the map data.
+   * `DEFAULT_LAYER_TIER` when no active layer has been picked yet
+   * (typical for a freshly-loaded map before any inspector
+   * interaction) or when the active layer id no longer exists in
+   * the map data.
    */
   private resolveActiveTier(): LayerTier {
-    if (!this.scene) return 'ground'
+    if (!this.scene) return DEFAULT_LAYER_TIER
     const explicitLayerId = SessionState.get(this.scene, ActiveLayerComponent)?.layerId ?? null
     const layerId = this.resolveLayerId(explicitLayerId)
-    if (!layerId) return 'ground'
+    if (!layerId) return DEFAULT_LAYER_TIER
     const mapResource = (this.scene as MapScene).mapResource
     const layer = mapResource?.mapData?.layers.find((l) => l.id === layerId)
-    return layer?.tier ?? 'ground'
+    return layer?.tier ?? DEFAULT_LAYER_TIER
   }
 
   /**

--- a/packages/engine/src/types/data/LayerData.ts
+++ b/packages/engine/src/types/data/LayerData.ts
@@ -25,6 +25,16 @@ import type { Properties, SpriteDataMap } from './index'
  */
 export type LayerTier = 'ground' | 'hero' | 'overlay'
 
+/** All `LayerTier` values in render order (low → high z). */
+export const LAYER_TIERS: readonly LayerTier[] = ['ground', 'hero', 'overlay'] as const
+
+/**
+ * Fallback tier when `LayerData.tier` is missing — matches the
+ * pre-tier-model rendering (everything on the ground-plane tilemap)
+ * so legacy project files continue to work.
+ */
+export const DEFAULT_LAYER_TIER: LayerTier = 'ground'
+
 /**
  * One layer within a tile map. Every layer is a tile layer in the
  * object-system schema; the legacy `type: 'tile' | 'object'` split

--- a/packages/engine/src/utils/constants.ts
+++ b/packages/engine/src/utils/constants.ts
@@ -1,112 +1,34 @@
 /**
- * Constants used throughout the map editor system
+ * Constants used throughout the map editor system.
+ *
+ * Only entries with a live consumer in `packages/` or `apps/` live
+ * here. Each entry's call site is documented inline to surface stale
+ * entries as the codebase evolves — if a site disappears, prune the
+ * constant rather than leaving it as orphaned configuration.
  */
-
 export const EDITOR_CONSTANTS = {
-  // Zoom settings
+  // `CameraControlSystem.handleZoomEvent`: per-wheel-notch zoom delta
+  // and the absolute floor the camera clamps to (avoid an inverted /
+  // imperceptibly-small viewport).
   ZOOM_STEP: 0.2,
   MIN_ZOOM: 0.1,
-  DEFAULT_ZOOM: 1.0,
 
-  // System priorities
-  EDITOR_SYSTEM_PRIORITY: 10,
-
-  // Tile dimensions validation
-  MIN_TILE_WIDTH: 1,
-  MIN_TILE_HEIGHT: 1,
-  MAX_TILE_WIDTH: 1024,
-  MAX_TILE_HEIGHT: 1024,
-
-  // Coordinate validation
-  MIN_COORDINATE: -999999,
-  MAX_COORDINATE: 999999,
-
-  // Fallback colors for tiles
-  FALLBACK_COLORS: [
-    '#FF0000', // Red
-    '#00FF00', // Green
-    '#0000FF', // Blue
-    '#FFFF00', // Yellow
-    '#FF00FF', // Magenta
-    '#00FFFF', // Cyan
-    '#800080', // Purple
-    '#FFA500', // Orange
-  ] as const,
-
-  // Default layer name when no layer is specified
+  // `TileEditorSystem.resolveLayerId`: fallback id when the active
+  // layer is unset and the map has no `layers[0]` to fall back on.
+  // Newly-created maps from the blank template still ship at least
+  // one layer, so this is the cold-start safety net only.
   DEFAULT_LAYER_NAME: 'default',
 
-  // Sprite validation
-  MIN_SPRITE_INDEX: 0,
-  MIN_TILE_ID: 0,
-  MIN_FIRST_GID: 0,
-
-  // Canvas settings
-  DEFAULT_STROKE_WIDTH: 1,
-  DEFAULT_FONT_SIZE: 10,
-  DEFAULT_FONT_FAMILY: 'Arial',
-
-  // Brush tool hover preview — half-transparent ghost of the active
-  // tile rendered by `TileEditorSystem` at the hovered tile so the
-  // user sees what would be placed before clicking. Low enough that
-  // the underlying tile is clearly visible; high enough that the
-  // ghost is unambiguously *the* preview (not noise / glare).
+  // `pencil-preview.applyHoverPreview`: opacity of the brush ghost
+  // rendered at the hovered tile. Low enough that the underlying tile
+  // stays clearly visible, high enough that the ghost still reads as
+  // *the* preview rather than noise.
   PAINT_PREVIEW_OPACITY: 0.5,
 
-  // Object-placement selection highlight (`SelectionHighlightSystem`).
-  // Bright orange ring drawn on top of the selected placement actor
-  // so the user can tell which entry in the Objects inspector list
-  // corresponds to which on-map sprite. Colour picked for contrast
-  // against the typical green / brown RPG palette and against the
-  // kind-marker outlines (cyan / yellow / green / purple / teal /
-  // salmon) so a selected functional placement still reads as
-  // "selected" rather than "another marker".
+  // `selection-highlight.attachSelectionRing`: bright-orange ring on
+  // top of the selected placement actor. Colour picked for contrast
+  // against the typical green / brown RPG palette and the kind-marker
+  // outlines (cyan / yellow / green / purple / teal / salmon).
   SELECTION_HIGHLIGHT_COLOR: '#ff8800',
   SELECTION_HIGHLIGHT_LINE_WIDTH: 2,
 } as const
-
-/**
- * Get a fallback color based on an index
- * @param index The index to get color for
- * @returns A color string
- */
-export function getFallbackColor(index: number): string {
-  const safeIndex = Math.abs(index) % EDITOR_CONSTANTS.FALLBACK_COLORS.length
-  return EDITOR_CONSTANTS.FALLBACK_COLORS[safeIndex] || EDITOR_CONSTANTS.FALLBACK_COLORS[0]
-}
-
-/**
- * Validate tile dimensions
- * @param width Tile width
- * @param height Tile height
- * @returns True if dimensions are valid
- */
-export function areTileDimensionsValid(width: number, height: number): boolean {
-  return (
-    typeof width === 'number' &&
-    typeof height === 'number' &&
-    width >= EDITOR_CONSTANTS.MIN_TILE_WIDTH &&
-    height >= EDITOR_CONSTANTS.MIN_TILE_HEIGHT &&
-    width <= EDITOR_CONSTANTS.MAX_TILE_WIDTH &&
-    height <= EDITOR_CONSTANTS.MAX_TILE_HEIGHT
-  )
-}
-
-/**
- * Validate coordinates
- * @param x X coordinate
- * @param y Y coordinate
- * @returns True if coordinates are valid
- */
-export function areCoordinatesValid(x: number, y: number): boolean {
-  return (
-    typeof x === 'number' &&
-    typeof y === 'number' &&
-    x >= EDITOR_CONSTANTS.MIN_COORDINATE &&
-    y >= EDITOR_CONSTANTS.MIN_COORDINATE &&
-    x <= EDITOR_CONSTANTS.MAX_COORDINATE &&
-    y <= EDITOR_CONSTANTS.MAX_COORDINATE &&
-    Number.isFinite(x) &&
-    Number.isFinite(y)
-  )
-}

--- a/packages/engine/src/utils/url.ts
+++ b/packages/engine/src/utils/url.ts
@@ -36,7 +36,7 @@ export function extractDirectoryPath(filePath: string): string {
  * @param path The path to normalize
  * @returns Normalized path with trailing slash if it had one
  */
-export function normalizePath(path: string): string {
+function normalizePath(path: string): string {
   // Special handling for URLs with protocol to preserve double slash
   if (path.match(/^https?:\/\//)) {
     const urlParts = path.split('://')

--- a/packages/gjs/src/widgets/editor/teleport-overlay.ts
+++ b/packages/gjs/src/widgets/editor/teleport-overlay.ts
@@ -4,11 +4,23 @@ import Graphene from '@girs/graphene-1.0'
 import Gsk from '@girs/gsk-4.0'
 import Gtk from '@girs/gtk-4.0'
 import Pango from '@girs/pango-1.0'
-import PangoCairo from '@girs/pangocairo-1.0'
 import type { SampleScene, SampleTeleport } from '../../__demo__/world-sample'
 
 const TITLE_BAR_HEIGHT = 24
 const ACCENT_FALLBACK = '#3584e4'
+
+const CURVE_OFFSET_MAX = 80
+const CURVE_OFFSET_FACTOR = 0.25
+const STROKE_WIDTH = 2
+const STROKE_DASH: [number, number] = [6, 4]
+const OPACITY_NORMAL = 0.85
+const OPACITY_DIMMED = 0.25
+const SOURCE_RING_RADIUS = 5
+const SOURCE_CORE_RADIUS = 3.2
+const DEST_RADIUS = 4
+const LABEL_FONT_SIZE_PT = 10
+const LABEL_PADDING_X = 8
+const LABEL_PADDING_Y = 2
 
 interface Endpoint {
   x: number
@@ -79,53 +91,53 @@ export class TeleportOverlay extends Gtk.Widget {
     for (const s of this._scenes) byId.set(s.id, s)
 
     const accent = this._lookupAccent()
-    const whiteRgba = new Gdk.RGBA()
-    whiteRgba.parse('#ffffff')
+    const white = new Gdk.RGBA()
+    white.parse('#ffffff')
 
-    const stroke = new Gsk.Stroke(2)
-    stroke.set_dash([6, 4])
+    const stroke = new Gsk.Stroke(STROKE_WIDTH)
+    stroke.set_dash(STROKE_DASH)
     stroke.set_line_cap(Gsk.LineCap.ROUND)
 
     for (const t of this._teleports) {
       const a = this._endpoint(byId, t.from, t.fx, t.fy)
       const b = this._endpoint(byId, t.to, t.tx, t.ty)
       if (!a || !b) continue
-
-      const involves = this._selectedId
-        ? t.from === this._selectedId || t.to === this._selectedId
-        : true
-      const dimmed = this._selectedId != null && !involves
-
-      const mx = (a.x + b.x) / 2
-      const my = (a.y + b.y) / 2
-      const dx = b.x - a.x
-      const dy = b.y - a.y
-      const len = Math.hypot(dx, dy) || 1
-      const off = Math.min(80, len * 0.25)
-      const c1x = mx - (dy / len) * off
-      const c1y = my + (dx / len) * off
-
-      snapshot.push_opacity(dimmed ? 0.25 : 0.85)
-
-      // Dashed bezier curve.
-      const builder = new Gsk.PathBuilder()
-      builder.move_to(a.x, a.y)
-      builder.quad_to(c1x, c1y, b.x, b.y)
-      const path = builder.to_path()
-      snapshot.push_stroke(path, stroke)
-      snapshot.append_color(accent, this._coverRect())
-      snapshot.pop()
-
-      // Source marker (white core, accent ring).
-      this._drawDisc(snapshot, a.x, a.y, 5, accent)
-      this._drawDisc(snapshot, a.x, a.y, 3.2, whiteRgba)
-      // Dest marker (filled accent).
-      this._drawDisc(snapshot, b.x, b.y, 4, accent)
-
-      if (!dimmed) this._drawLabel(snapshot, c1x, c1y, t.label, accent, whiteRgba)
-
-      snapshot.pop()
+      this._drawTeleport(snapshot, t, a, b, stroke, accent, white)
     }
+  }
+
+  /** Render one teleport (curve + markers + optional label) into the snapshot. */
+  private _drawTeleport(
+    snapshot: Gtk.Snapshot,
+    t: SampleTeleport,
+    a: Endpoint,
+    b: Endpoint,
+    stroke: Gsk.Stroke,
+    accent: Gdk.RGBA,
+    white: Gdk.RGBA,
+  ): void {
+    const involves = this._selectedId ? t.from === this._selectedId || t.to === this._selectedId : true
+    const dimmed = this._selectedId != null && !involves
+    const control = controlPoint(a, b)
+
+    snapshot.push_opacity(dimmed ? OPACITY_DIMMED : OPACITY_NORMAL)
+
+    // Dashed quadratic Bézier from source to dest.
+    const builder = new Gsk.PathBuilder()
+    builder.move_to(a.x, a.y)
+    builder.quad_to(control.x, control.y, b.x, b.y)
+    snapshot.push_stroke(builder.to_path(), stroke)
+    snapshot.append_color(accent, this._coverRect())
+    snapshot.pop()
+
+    // Source: white core + accent ring. Dest: solid accent disc.
+    this._drawDisc(snapshot, a.x, a.y, SOURCE_RING_RADIUS, accent)
+    this._drawDisc(snapshot, a.x, a.y, SOURCE_CORE_RADIUS, white)
+    this._drawDisc(snapshot, b.x, b.y, DEST_RADIUS, accent)
+
+    if (!dimmed) this._drawLabel(snapshot, control.x, control.y, t.label, accent, white)
+
+    snapshot.pop()
   }
 
   private _endpoint(
@@ -168,33 +180,34 @@ export class TeleportOverlay extends Gtk.Widget {
     bg: Gdk.RGBA,
     fg: Gdk.RGBA,
   ): void {
-    const ctx = this.get_pango_context()
-    const layout = Pango.Layout.new(ctx)
-    const attrList = Pango.AttrList.new()
-    const fontDesc = ctx.get_font_description()?.copy() ?? Pango.FontDescription.new()
-    fontDesc.set_size(10 * Pango.SCALE)
-    fontDesc.set_weight(Pango.Weight.BOLD)
-    layout.set_font_description(fontDesc)
-    layout.set_text(text, -1)
-    layout.set_attributes(attrList)
+    const layout = this._layoutFor(text)
     const [w, h] = layout.get_pixel_size()
-    const paddingX = 8
-    const paddingY = 2
-    const pillW = w + paddingX * 2
-    const pillH = h + paddingY * 2
+    const pillW = w + LABEL_PADDING_X * 2
+    const pillH = h + LABEL_PADDING_Y * 2
     const pillRect = new Graphene.Rect()
     pillRect.init(cx - pillW / 2, cy - pillH / 2, pillW, pillH)
     const rounded = new Gsk.RoundedRect()
     rounded.init_from_rect(pillRect, pillH / 2)
+
     snapshot.push_rounded_clip(rounded)
     snapshot.append_color(bg, pillRect)
     snapshot.pop()
+
     snapshot.save()
     snapshot.translate(new Graphene.Point({ x: cx - w / 2, y: cy - h / 2 }))
     snapshot.append_layout(layout, fg)
     snapshot.restore()
-    // Suppress unused-import warning at build time.
-    void PangoCairo
+  }
+
+  private _layoutFor(text: string): Pango.Layout {
+    const ctx = this.get_pango_context()
+    const layout = Pango.Layout.new(ctx)
+    const fontDesc = ctx.get_font_description()?.copy() ?? Pango.FontDescription.new()
+    fontDesc.set_size(LABEL_FONT_SIZE_PT * Pango.SCALE)
+    fontDesc.set_weight(Pango.Weight.BOLD)
+    layout.set_font_description(fontDesc)
+    layout.set_text(text, -1)
+    return layout
   }
 
   private _lookupAccent(): Gdk.RGBA {
@@ -210,6 +223,21 @@ export class TeleportOverlay extends Gtk.Widget {
     }
     return this._accentColor
   }
+}
+
+/**
+ * Quadratic-Bézier control point biased perpendicular to the segment
+ * midpoint — `offset = min(80, length × 0.25)`. Mirrors the curve math
+ * from the original design exports (`option-g-synthesis.jsx`).
+ */
+function controlPoint(a: Endpoint, b: Endpoint): Endpoint {
+  const mx = (a.x + b.x) / 2
+  const my = (a.y + b.y) / 2
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  const len = Math.hypot(dx, dy) || 1
+  const off = Math.min(CURVE_OFFSET_MAX, len * CURVE_OFFSET_FACTOR)
+  return { x: mx - (dy / len) * off, y: my + (dx / len) * off }
 }
 
 GObject.type_ensure(TeleportOverlay.$gtype)

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -402,36 +402,34 @@ export class Engine extends Adw.Bin {
   }
 
   private _forwardEvents(engine: ExcaliburEngine): void {
+    // Relays each event to the widget's own EventEmitter (typed payload
+    // for engine-aware consumers) and — if `gobjectArg` is provided —
+    // also emits a GObject signal carrying a single extracted field
+    // for Blueprint bindings + classic signal handlers.
+    const fwd = <K extends keyof EngineEventMap>(
+      event: K,
+      gobjectArg?: (payload: EngineEventMap[K]) => unknown,
+    ) =>
+      engine.events.on(event, (p) => {
+        this.events.emit(event, p)
+        if (gobjectArg) this.emit(event, gobjectArg(p))
+      })
+
     this._excaliburSubscriptions.push(
       engine.events.on(EngineEvent.STATUS_CHANGED, (p) => {
+        // STATUS_CHANGED additionally drives `this.status` (a GObject
+        // property), so it stays out of the `fwd` factory.
         this.status = p.status
         this.events.emit(EngineEvent.STATUS_CHANGED, p)
         this.emit(EngineEvent.STATUS_CHANGED, p.status)
       }),
-      engine.events.on(EngineEvent.PROJECT_LOADED, (p) => {
-        this.events.emit(EngineEvent.PROJECT_LOADED, p)
-        this.emit(EngineEvent.PROJECT_LOADED, p.projectPath)
-      }),
-      engine.events.on(EngineEvent.MAP_LOADED, (p) => {
-        this.events.emit(EngineEvent.MAP_LOADED, p)
-        this.emit(EngineEvent.MAP_LOADED, p.mapId)
-      }),
-      engine.events.on(EngineEvent.ERROR, (p) => {
-        this.events.emit(EngineEvent.ERROR, p)
-        this.emit(EngineEvent.ERROR, p.message)
-      }),
-      engine.events.on(EngineEvent.TILE_CLICKED, (p) => {
-        this.events.emit(EngineEvent.TILE_CLICKED, p)
-      }),
-      engine.events.on(EngineEvent.TILE_HOVERED, (p) => {
-        this.events.emit(EngineEvent.TILE_HOVERED, p)
-      }),
-      engine.events.on(EngineEvent.TILE_PLACED, (p) => {
-        this.events.emit(EngineEvent.TILE_PLACED, p)
-      }),
-      engine.events.on(EngineEvent.TILE_PICKED, (p) => {
-        this.events.emit(EngineEvent.TILE_PICKED, p)
-      }),
+      fwd(EngineEvent.PROJECT_LOADED, (p) => p.projectPath),
+      fwd(EngineEvent.MAP_LOADED, (p) => p.mapId),
+      fwd(EngineEvent.ERROR, (p) => p.message),
+      fwd(EngineEvent.TILE_CLICKED),
+      fwd(EngineEvent.TILE_HOVERED),
+      fwd(EngineEvent.TILE_PLACED),
+      fwd(EngineEvent.TILE_PICKED),
     )
   }
 


### PR DESCRIPTION
## Summary

Open-ended refactor pass — five focused commits, each independently reversible. No behaviour change. Build / type-check / engine tests all green.

| # | What |
|---|---|
| 1 | `Engine.events` forwarding factory (8 hand-rolled relays → typed `fwd` closure); `_undoContext()` helper eliminates 5× duplication of `_activeMapScene + SessionState.get(UndoStackComponent)`; `TeleportOverlay.vfunc_snapshot` split into `_drawTeleport` + pure `controlPoint`, magic numbers named, dead `PangoCairo` import dropped |
| 2 | Promote `'ground'` literal default + `ALL_TIERS` module-private to exported `DEFAULT_LAYER_TIER` + `LAYER_TIERS` on `LayerData` (10 call sites updated) |
| 3 | De-export dead `normalizePath` (only internal caller); unify `signals` field naming across maker views (was split `signals` / `_signals`) |
| 4 | Prune dead `EDITOR_CONSTANTS` entries — `DEFAULT_ZOOM`, `EDITOR_SYSTEM_PRIORITY`, `MIN/MAX_TILE_*`, `MIN/MAX_COORDINATE`, `FALLBACK_COLORS`, `DEFAULT_STROKE_WIDTH/FONT_*`, `MIN_SPRITE_INDEX/TILE_ID/FIRST_GID`, `getFallbackColor()`, `areTileDimensionsValid()`, `areCoordinatesValid()` — all zero call sites. Kept entries annotated with their actual consumer (113 → 36 lines) |
| 5 | Consolidate 4 identical `mode-changed → win.mode` forwardings in `application-window.ts` into a single `setMode` closure |

## What I deliberately did NOT do

- **Splitting 700-line classes** (`ApplicationWindow`, `SceneEditorView`, `Engine`). They're above the AGENTS.md 200-line guideline but each is well-organised internally — splitting would be an architecture decision needing per-view controller boundaries, not a sweep.
- **"Missing SignalScope" claims on 11 widgets** in `packages/gjs/src/widgets/{editor,cast}/`. Verified — only connect to their own `InternalChildren` (Blueprint-composed children that die with the widget), so the `vfunc_map`/`vfunc_unmap` pattern is not needed there. Existing pattern is correct.
- **Magic-number extraction for `?? 16` tile-size fallbacks** in player/object systems. Inlined `?? 16` is briefer and more obvious than `?? FALLBACK_TILE_PX`; the value is universal across 16-bit-era RPG tooling.

## Test plan

- [x] `gjsify foreach check -v -t` 0 errors
- [x] `gjsify foreach build -v -t` 0 errors
- [x] `@pixelrpg/engine test` 66/66 passing
- [ ] CI green