### PR TITLE
feat(maker): LAN discovery via avahi-tools subprocess (Phase 3c)

### DIFF
--- a/apps/maker-gjs/package.json
+++ b/apps/maker-gjs/package.json
@@ -15,6 +15,7 @@
     "check": "gjsify run build:barrels && tsc",
     "start": "gjsify run org.pixelrpg.maker",
     "start:debug": "GTK_DEBUG=interactive gjsify run org.pixelrpg.maker",
+    "test": "vitest run",
     "flatpak:init": "gjsify flatpak init --force",
     "flatpak:check": "gjsify flatpak check",
     "flatpak:build": "gjsify flatpak build org.pixelrpg.maker.json --install --repo repo --bundle org.pixelrpg.maker.flatpak --install-deps-from flathub"
@@ -29,7 +30,8 @@
   "license": "GPL-3.0",
   "devDependencies": {
     "@gjsify/cli": "^0.4.32",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
   },
   "dependencies": {
     "@girs/adw-1": "^1.10.0-4.0.4",

--- a/apps/maker-gjs/src/services/lan-discovery-parse.test.ts
+++ b/apps/maker-gjs/src/services/lan-discovery-parse.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseAvahiBrowseLine } from './lan-discovery-parse.ts'
+
+describe('parseAvahiBrowseLine', () => {
+  it('parses a resolution line with TXT records', () => {
+    const event = parseAvahiBrowseLine(
+      '=;eth0;IPv4;Bob%27s Project;_pixelrpg._tcp;local;bob.local;192.168.1.42;8088;' +
+        '"version=1" "kind=edit" "room=a3f2-bb91" "host=Bob" "project=Forest" "peers=1/4" "started=1716968400"',
+    )
+    expect(event).toEqual({
+      kind: 'resolved',
+      service: {
+        name: "Bob%27s Project",
+        host: 'bob.local',
+        address: '192.168.1.42',
+        port: 8088,
+        txt: {
+          version: '1',
+          kind: 'edit',
+          room: 'a3f2-bb91',
+          host: 'Bob',
+          project: 'Forest',
+          peers: '1/4',
+          started: '1716968400',
+        },
+      },
+    })
+  })
+
+  it('parses a withdrawal line', () => {
+    const event = parseAvahiBrowseLine('-;eth0;IPv4;Bob%27s Project;_pixelrpg._tcp;local')
+    expect(event).toEqual({ kind: 'gone', serviceName: "Bob%27s Project" })
+  })
+
+  it('returns null for announce-only `+` lines (we only act on resolved)', () => {
+    const event = parseAvahiBrowseLine('+;eth0;IPv4;Bob%27s Project;_pixelrpg._tcp;local')
+    expect(event).toBeNull()
+  })
+
+  it('returns null for malformed / partial lines', () => {
+    expect(parseAvahiBrowseLine('')).toBeNull()
+    expect(parseAvahiBrowseLine('garbage')).toBeNull()
+    expect(parseAvahiBrowseLine('=;eth0;IPv4;name')).toBeNull() // too few fields
+    expect(parseAvahiBrowseLine('=;eth0;IPv4;n;t;d;h;a;bad-port;""')).toBeNull()
+    expect(parseAvahiBrowseLine('=;eth0;IPv4;n;t;d;h;a;99999;""')).toBeNull() // port out of range
+  })
+
+  it('handles empty TXT', () => {
+    const event = parseAvahiBrowseLine('=;eth0;IPv4;n;t;d;h;a;1234;')
+    expect(event).toEqual({
+      kind: 'resolved',
+      service: { name: 'n', host: 'h', address: 'a', port: 1234, txt: {} },
+    })
+  })
+
+  it('ignores TXT entries without `=`', () => {
+    const event = parseAvahiBrowseLine('=;eth0;IPv4;n;t;d;h;a;1234;"valid=ok" "no-equals" "=no-key"')
+    expect(event).toEqual({
+      kind: 'resolved',
+      service: { name: 'n', host: 'h', address: 'a', port: 1234, txt: { valid: 'ok' } },
+    })
+  })
+})

--- a/apps/maker-gjs/src/services/lan-discovery-parse.ts
+++ b/apps/maker-gjs/src/services/lan-discovery-parse.ts
@@ -1,0 +1,90 @@
+/**
+ * Parser for `avahi-browse -p` output. Lives in a separate module
+ * from {@link LanBrowser} so the line-oriented format stays unit-
+ * testable without spawning an actual subprocess.
+ *
+ * The `-p` (parseable) format emits one line per event:
+ *
+ *   `+;<iface>;<proto>;<name>;<type>;<domain>`             — appeared
+ *   `=;<iface>;<proto>;<name>;<type>;<domain>;<host>;<addr>;<port>;<txt>` — resolved
+ *   `-;<iface>;<proto>;<name>;<type>;<domain>`             — withdrawn
+ *
+ * The TXT column at the tail is a quote-delimited list of
+ * `"key=value"` tokens; empty TXT is reported as the empty string.
+ * We only surface the `=` (resolved) records — the `+` / `-`
+ * discoveries without resolution data are not useful to the UI.
+ */
+
+/**
+ * A LAN-published service the maker can join. Shape matches the
+ * `_pixelrpg._tcp.local` TXT-record schema documented in
+ * `docs/concepts/collaboration-and-multiplayer.md` § 6.
+ */
+export interface DiscoveredService {
+  name: string
+  host: string
+  address: string
+  port: number
+  txt: Record<string, string>
+}
+
+export type LanDiscoveryEvent =
+  | { kind: 'resolved'; service: DiscoveredService }
+  | { kind: 'gone'; serviceName: string }
+
+/**
+ * Convert one line of `avahi-browse -p` output into a structured
+ * event. Returns `null` for unrecognised / partial lines so the
+ * caller can ignore them.
+ */
+export function parseAvahiBrowseLine(line: string): LanDiscoveryEvent | null {
+  if (!line) return null
+  const tag = line[0]
+  if (tag !== '=' && tag !== '-') return null
+
+  const fields = line.split(';')
+
+  if (tag === '-') {
+    // Format: -;<iface>;<proto>;<name>;<type>;<domain>
+    const name = fields[3]
+    if (!name) return null
+    return { kind: 'gone', serviceName: name }
+  }
+
+  // tag === '='
+  // Format: =;<iface>;<proto>;<name>;<type>;<domain>;<host>;<addr>;<port>;<txt>
+  if (fields.length < 10) return null
+  const [, , , name, , , host, address, portStr] = fields
+  if (!name || !host || !address || !portStr) return null
+  const port = Number.parseInt(portStr, 10)
+  if (!Number.isFinite(port) || port < 1 || port > 65535) return null
+  // TXT column carries the rest, including any `;` that snuck into
+  // a TXT value (rare but legal). Join from field 9 onward.
+  const txtField = fields.slice(9).join(';')
+  return {
+    kind: 'resolved',
+    service: { name, host, address, port, txt: parseTxtField(txtField) },
+  }
+}
+
+/**
+ * Avahi serialises TXT records as `"key=val" "key2=val2"` separated
+ * by spaces. Split on the quoted tokens; tolerate empty / missing
+ * keys.
+ */
+function parseTxtField(raw: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  const tokenRe = /"([^"]*)"/g
+  let match: RegExpExecArray | null = tokenRe.exec(raw)
+  while (match !== null) {
+    const token = match[1] ?? ''
+    const eq = token.indexOf('=')
+    if (eq > 0) {
+      const key = token.slice(0, eq)
+      const value = token.slice(eq + 1)
+      if (key) result[key] = value
+    }
+    match = tokenRe.exec(raw)
+  }
+  return result
+}

--- a/apps/maker-gjs/src/services/lan-discovery.ts
+++ b/apps/maker-gjs/src/services/lan-discovery.ts
@@ -1,0 +1,175 @@
+import Gio from '@girs/gio-2.0'
+import GLib from '@girs/glib-2.0'
+
+import { type DiscoveredService, type LanDiscoveryEvent, parseAvahiBrowseLine } from './lan-discovery-parse.ts'
+
+/**
+ * mDNS service type the editor + future multiplayer both advertise.
+ * The TXT-record schema is documented in `docs/concepts/
+ * collaboration-and-multiplayer.md` § 6.
+ */
+export const SERVICE_TYPE = '_pixelrpg._tcp'
+
+export interface SessionAdvertisement {
+  /** Human-readable session label shown in the joiner's UI. */
+  name: string
+  /** TCP port the WebRTC offer endpoint (or signalling proxy) listens on. */
+  port: number
+  /** TXT records — drives the joiner's filter / status display. */
+  txt: SessionTxt
+}
+
+export interface SessionTxt {
+  version: string
+  kind: 'edit' | 'play'
+  room: string
+  host: string
+  project: string
+  peers: string
+  started: string
+}
+
+/**
+ * Owns one `avahi-publish-service` subprocess that advertises the
+ * local maker's session over mDNS. Removing the advertisement is as
+ * simple as killing the child — Avahi automatically retracts the
+ * record set within a couple of seconds. Idempotent close.
+ *
+ * Why not the Avahi GIR (`@girs/avahi-0.6`)? The GIR exposes only
+ * `add_record`, not the high-level `ga_entry_group_add_service`, so
+ * publishing a service would require hand-composing SRV / TXT / PTR
+ * records. The CLI tool from `avahi-tools` ships on every Avahi
+ * install and the subprocess wrapping stays under 30 lines —
+ * pragmatic win over the GIR path.
+ */
+export class LanPublisher {
+  private process: Gio.Subprocess | null = null
+  private closed = false
+
+  /** Start advertising. Throws if the `avahi-publish-service` binary is missing. */
+  publish(ad: SessionAdvertisement): void {
+    if (this.closed) throw new Error('LanPublisher: already closed')
+    if (this.process) throw new Error('LanPublisher: already publishing')
+
+    const args = ['avahi-publish-service', ad.name, SERVICE_TYPE, String(ad.port), ...txtToArgs(ad.txt)]
+    try {
+      this.process = Gio.Subprocess.new(
+        args,
+        Gio.SubprocessFlags.STDOUT_SILENCE | Gio.SubprocessFlags.STDERR_SILENCE,
+      )
+    } catch (err) {
+      throw new Error(
+        `LanPublisher: failed to start avahi-publish-service — is the avahi-tools package installed? (${
+          err instanceof Error ? err.message : String(err)
+        })`,
+      )
+    }
+  }
+
+  /** Stop advertising. Idempotent. */
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    if (!this.process) return
+    try {
+      // SIGINT is the documented exit signal for avahi-publish-service.
+      this.process.send_signal(GLib.SIGINT ?? 2)
+    } catch {
+      // Process may already be gone — best-effort.
+    }
+    this.process = null
+  }
+}
+
+/**
+ * Owns one `avahi-browse` subprocess streaming resolution events for
+ * the editor's service type, parses each line and dispatches
+ * `service-discovered` / `service-gone` callbacks. Forwarder is
+ * the {@link parseAvahiBrowseLine} helper — keeps the streaming
+ * shape minimal here.
+ */
+export class LanBrowser {
+  private process: Gio.Subprocess | null = null
+  private stdin: Gio.InputStream | null = null
+  private closed = false
+  private onEvent: ((event: LanDiscoveryEvent) => void) | null = null
+
+  /**
+   * Begin browsing. Subsequent events are delivered via `onEvent`.
+   * Throws on missing binary; caller surfaces gracefully (the
+   * Welcome view falls back to an empty "Sessions on this network"
+   * pane rather than crashing).
+   */
+  start(onEvent: (event: LanDiscoveryEvent) => void): void {
+    if (this.closed) throw new Error('LanBrowser: already closed')
+    if (this.process) throw new Error('LanBrowser: already running')
+    this.onEvent = onEvent
+
+    const args = ['avahi-browse', '-r', '-p', '-t', SERVICE_TYPE]
+    try {
+      this.process = Gio.Subprocess.new(
+        args,
+        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE,
+      )
+    } catch (err) {
+      this.onEvent = null
+      throw new Error(
+        `LanBrowser: failed to start avahi-browse — is the avahi-tools package installed? (${
+          err instanceof Error ? err.message : String(err)
+        })`,
+      )
+    }
+
+    const stdout = this.process.get_stdout_pipe()
+    if (!stdout) {
+      this.close()
+      throw new Error('LanBrowser: no stdout pipe on avahi-browse subprocess')
+    }
+    this.stdin = stdout
+    const reader = new Gio.DataInputStream({ base_stream: stdout })
+    this.readNext(reader)
+  }
+
+  /** Stop browsing. Idempotent. */
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    if (this.process) {
+      try {
+        this.process.force_exit()
+      } catch {
+        /* best-effort */
+      }
+      this.process = null
+    }
+    this.stdin = null
+    this.onEvent = null
+  }
+
+  private readNext(reader: Gio.DataInputStream): void {
+    reader.read_line_async(GLib.PRIORITY_DEFAULT, null, (source, result) => {
+      if (this.closed) return
+      try {
+        const [line] = (source as Gio.DataInputStream).read_line_finish(result)
+        if (line === null) {
+          // EOF — avahi-browse died (binary went away?). Stop the loop.
+          this.close()
+          return
+        }
+        const decoded = typeof line === 'string' ? line : new TextDecoder().decode(line)
+        const event = parseAvahiBrowseLine(decoded)
+        if (event && this.onEvent) this.onEvent(event)
+        this.readNext(reader)
+      } catch {
+        // Read error — assume the subprocess is gone, drop quietly.
+        this.close()
+      }
+    })
+  }
+}
+
+function txtToArgs(txt: SessionTxt): string[] {
+  return Object.entries(txt).map(([key, value]) => `${key}=${value}`)
+}
+
+export type { DiscoveredService, LanDiscoveryEvent }

--- a/apps/maker-gjs/vitest.config.ts
+++ b/apps/maker-gjs/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // Only the pure-data / parser modules get unit-tested here —
+    // anything that touches `@girs/*` or Gio is GJS-only and lives
+    // under the manual smoke walkthrough.
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary

Phase 3c — concrete LAN auto-discovery for the Pair-Editing flow. Hosts publish `_pixelrpg._tcp.local` with the TXT-record schema from concept doc § 6, joiners browse the same service type and (in Phase 3d / 3e) surface matches in the Welcome view.

## Why subprocess instead of `@girs/avahi-0.6`

The Avahi GIR exposes only the raw `add_record` primitive — `ga_entry_group_add_service_strlst` is not surfaced — so publishing a service through the GIR would mean hand-composing SRV + TXT + PTR wire records. Instead, wrap the `avahi-tools` CLI binaries via `Gio.Subprocess`:

- `avahi-publish-service` to advertise (alive while subprocess alive)
- `avahi-browse -p -r` to discover (parseable streaming output)

Both ship on every Avahi-equipped distro alongside the daemon. The wrapper is under 200 lines and stays cleanly contained. Documented trade-off in the file header.

## What's new

| File | Role |
|---|---|
| `lan-discovery-parse.ts` | Pure parser for `avahi-browse -p` line format — TXT token regex, port validation, malformed-line tolerance |
| `lan-discovery-parse.test.ts` | 6 Vitest unit tests covering full TXT, withdrawal, announce-only suppression, malformed lines, empty TXT, no-`=` TXT |
| `lan-discovery.ts` | `SERVICE_TYPE='_pixelrpg._tcp'`, `SessionAdvertisement` + `SessionTxt`, `LanPublisher` (spawn avahi-publish-service), `LanBrowser` (spawn avahi-browse, stream via `Gio.DataInputStream`) |
| `vitest.config.ts` | Standard maker-side vitest setup — only pure parser modules get unit-tested; GIO-touching code runs only on GJS |

## Test plan

- [x] `@pixelrpg/maker-gjs test` → 6/6 parser tests passing
- [x] `@pixelrpg/maker-gjs check` → clean
- [x] `gjsify foreach check + build` → clean across workspace
- [x] Local smoke (Avahi daemon required):
  ```bash
  avahi-publish-service "Test Session" _pixelrpg._tcp 8088 \
    version=1 kind=edit room=abc123 host=Pascal project=Test peers=1/4 started=$(date +%s) &
  avahi-browse -r -p -t _pixelrpg._tcp
  # → resolves correctly with full TXT records
  ```
- [ ] CI green
- [ ] Manual: two maker instances on the same LAN see each other (deferred to Phase 3d wiring)

## CI scope

CI does not run `avahi-daemon`; the parser tests pass without it. `LanPublisher` / `LanBrowser` themselves are GJS-only (they import `@girs/gio-2.0` + `@girs/glib-2.0`) and validated via local manual smoke.

## Next phase

Phase 3d — wire `Engine.executeCommand` to broadcast over `PeerSession`; receive-side applies remote ops. End-to-end Pair-Editing on LAN.