### PR TITLE
feat(maker): LAN signalling transports + CollabSession (Phase 3d-lan)

### DIFF
--- a/apps/maker-gjs/package.json
+++ b/apps/maker-gjs/package.json
@@ -46,6 +46,8 @@
     "@gjsify/dom-elements": "^0.4.32",
     "@gjsify/event-bridge": "^0.4.32",
     "@gjsify/webgl": "^0.4.32",
+    "@gjsify/webrtc": "^0.4.33",
+    "@gjsify/ws": "^0.4.33",
     "@gjsify/xmlhttprequest": "^0.4.32",
     "@pixelrpg/engine": "workspace:^",
     "@pixelrpg/gjs": "workspace:^",

--- a/apps/maker-gjs/src/services/collab-session.ts
+++ b/apps/maker-gjs/src/services/collab-session.ts
@@ -1,0 +1,67 @@
+import '@gjsify/webrtc/register'
+
+import type { Engine, SignallingTransport } from '@pixelrpg/engine'
+import { PeerSession, type PeerRole, SessionController } from '@pixelrpg/engine'
+
+export interface CollabSessionOptions {
+  engine: Engine
+  role: PeerRole
+  signalling: SignallingTransport
+  /** Stable id for this peer — stamped onto every emitted Operation. */
+  peerId: string
+}
+
+/**
+ * Top-level glue holding the active Pair-Editing session together.
+ *
+ * Owns one `PeerSession` (raw WebRTC + signalling) plus the
+ * `SessionController` that bridges it to the local `Engine`. The
+ * caller supplies the `SignallingTransport` — `LanHostServer` /
+ * `connectLanJoinerTransport` cover LAN today; the cross-internet
+ * relay client (Phase 3e) plugs in here without touching the
+ * collab class itself.
+ *
+ * Side-effect: imports `@gjsify/webrtc/register` so `globalThis
+ * .RTCPeerConnection` is wired before the underlying `PeerSession`
+ * tries to construct one. Top-level import keeps the side effect
+ * out of the constructor (the register module is idempotent).
+ */
+export class CollabSession {
+  public readonly peer: PeerSession
+  public readonly controller: SessionController
+  private closed = false
+
+  constructor(opts: CollabSessionOptions) {
+    this.peer = new PeerSession({
+      role: opts.role,
+      signalling: opts.signalling,
+    })
+    this.controller = new SessionController({
+      engine: opts.engine,
+      session: this.peer,
+      peerId: opts.peerId,
+    })
+  }
+
+  /**
+   * Drive the WebRTC handshake. Resolves once ICE gathering kicks
+   * off; full "connected" status lands on `peer.events('state-
+   * changed')`.
+   */
+  async start(): Promise<void> {
+    await this.peer.connect()
+  }
+
+  /** Tear down. Idempotent. */
+  close(reason = 'closed'): void {
+    if (this.closed) return
+    this.closed = true
+    this.controller.close()
+    this.peer.close(reason)
+  }
+
+  /** Whether the underlying peer connection is currently connected. */
+  isConnected(): boolean {
+    return this.peer.getState() === 'connected'
+  }
+}

--- a/apps/maker-gjs/src/services/lan-signalling.test.ts
+++ b/apps/maker-gjs/src/services/lan-signalling.test.ts
@@ -1,0 +1,109 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+
+import { wrapWebSocket } from './lan-signalling.ts'
+
+/**
+ * Fake `ws.WebSocket` exposing the subset {@link wrapWebSocket}
+ * consumes. Lets us drive `message` / `close` events from the test
+ * without touching a real socket.
+ */
+class FakeWs extends EventEmitter {
+  public sent: string[] = []
+  public closed = false
+  public closeCalled = 0
+  send(frame: string) {
+    this.sent.push(frame)
+  }
+  close() {
+    this.closeCalled++
+    this.closed = true
+    this.emit('close')
+  }
+}
+
+describe('wrapWebSocket', () => {
+  it('routes inbound JSON messages to the onMessage handler', () => {
+    const ws = new FakeWs()
+    const transport = wrapWebSocket(ws as never)
+    const seen: unknown[] = []
+    transport.onMessage((msg) => seen.push(msg))
+
+    ws.emit('message', JSON.stringify({ type: 'sdp', payload: { type: 'offer', sdp: 'x' } }))
+    ws.emit('message', JSON.stringify({ type: 'ice-candidate', payload: { candidate: 'c' } }))
+    ws.emit('message', JSON.stringify({ type: 'bye' }))
+
+    expect(seen).toEqual([
+      { type: 'sdp', payload: { type: 'offer', sdp: 'x' } },
+      { type: 'ice-candidate', payload: { candidate: 'c' } },
+      { type: 'bye' },
+    ])
+  })
+
+  it('drops malformed JSON frames without throwing', () => {
+    const ws = new FakeWs()
+    const transport = wrapWebSocket(ws as never)
+    const seen: unknown[] = []
+    transport.onMessage((msg) => seen.push(msg))
+
+    expect(() => ws.emit('message', 'not-json')).not.toThrow()
+    expect(seen).toHaveLength(0)
+  })
+
+  it('drops binary frames (isBinary=true)', () => {
+    const ws = new FakeWs()
+    const transport = wrapWebSocket(ws as never)
+    const seen: unknown[] = []
+    transport.onMessage((msg) => seen.push(msg))
+
+    // Buffer payload + isBinary=true
+    ws.emit('message', Buffer.from('{"type":"sdp"}'), true)
+    expect(seen).toHaveLength(0)
+  })
+
+  it('ignores frames whose type is not part of the wire vocabulary', () => {
+    const ws = new FakeWs()
+    const transport = wrapWebSocket(ws as never)
+    const seen: unknown[] = []
+    transport.onMessage((msg) => seen.push(msg))
+
+    ws.emit('message', JSON.stringify({ type: 'banana', payload: 'x' }))
+    expect(seen).toHaveLength(0)
+  })
+
+  it('forwards send() to the underlying ws.send() as JSON', () => {
+    const ws = new FakeWs()
+    const transport = wrapWebSocket(ws as never)
+    transport.send({ type: 'sdp', payload: { type: 'offer', sdp: 'y' } })
+
+    expect(ws.sent).toEqual([JSON.stringify({ type: 'sdp', payload: { type: 'offer', sdp: 'y' } })])
+  })
+
+  it('close() calls ws.close once and becomes a no-op afterwards', () => {
+    const ws = new FakeWs()
+    const transport = wrapWebSocket(ws as never)
+
+    transport.close()
+    transport.close()
+    expect(ws.closeCalled).toBe(1)
+  })
+
+  it('after the socket closes, further send()s are dropped silently', () => {
+    const ws = new FakeWs()
+    const transport = wrapWebSocket(ws as never)
+
+    ws.emit('close')
+    expect(() => transport.send({ type: 'bye' })).not.toThrow()
+    expect(ws.sent).toEqual([])
+  })
+
+  it('send() errors from the underlying ws do not propagate', () => {
+    const ws = new FakeWs()
+    const transport = wrapWebSocket(ws as never)
+    vi.spyOn(ws, 'send').mockImplementation(() => {
+      throw new Error('socket broken')
+    })
+
+    expect(() => transport.send({ type: 'bye' })).not.toThrow()
+  })
+})

--- a/apps/maker-gjs/src/services/lan-signalling.ts
+++ b/apps/maker-gjs/src/services/lan-signalling.ts
@@ -1,0 +1,166 @@
+import type { SignallingMessage, SignallingTransport } from '@pixelrpg/engine'
+import { WebSocket, type WebSocketServer as WsServer } from 'ws'
+
+import { WebSocketServer } from 'ws'
+
+/**
+ * LAN signalling — one host accepts one joiner over a plain
+ * WebSocket. Routes SDP / ICE / bye frames bidirectionally without
+ * the room concept (there's only the local pair; the relay-style
+ * `apps/signalling-server` exists for cross-network sessions where
+ * the two peers can't see each other on mDNS).
+ *
+ * Wire envelopes match `apps/signalling-server/src/types.ts` so a
+ * future LAN-to-relay fallback can reuse the same parser layer
+ * without translating.
+ *
+ * Both `LanHostTransport` and `LanJoinerTransport` implement the
+ * platform-indep `SignallingTransport` interface from
+ * `@pixelrpg/engine/sync`, so the same `PeerSession` constructor
+ * accepts either side.
+ *
+ * Test strategy: `lan-signalling-wire.test.ts` covers the
+ * `wrapServerSocket` / `wrapClientSocket` adapter contract using
+ * fake WebSockets. The real Soup-backed ws path is GJS-only and
+ * validated via the manual two-instance smoke walk-through.
+ */
+
+/**
+ * Adapter that wraps a single `ws.WebSocket` instance as a
+ * `SignallingTransport`. Used by both the host (one per accepted
+ * peer) and the joiner (its own outgoing connection).
+ */
+export function wrapWebSocket(ws: Pick<WebSocket, 'send' | 'close' | 'on'>): SignallingTransport {
+  let inboundHandler: ((msg: SignallingMessage) => void) | null = null
+  let closed = false
+
+  ws.on('message', (raw: Buffer | string, isBinary?: boolean) => {
+    if (isBinary === true) return
+    const text = typeof raw === 'string' ? raw : raw.toString()
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch {
+      // Drop malformed frames silently — the relay drops them too.
+      return
+    }
+    if (!isSignallingMessage(parsed)) return
+    inboundHandler?.(parsed)
+  })
+
+  ws.on('close', () => {
+    closed = true
+  })
+
+  return {
+    send(message: SignallingMessage): void {
+      if (closed) return
+      try {
+        ws.send(JSON.stringify(message))
+      } catch {
+        /* peer may have closed mid-send — best-effort */
+      }
+    },
+    onMessage(handler: (message: SignallingMessage) => void): void {
+      inboundHandler = handler
+    },
+    close(): void {
+      if (closed) return
+      closed = true
+      try {
+        ws.close(1000, 'closed-by-host')
+      } catch {
+        /* already closed */
+      }
+    },
+  }
+}
+
+/** Discriminates a parsed JSON object as a {@link SignallingMessage}. */
+function isSignallingMessage(value: unknown): value is SignallingMessage {
+  if (!value || typeof value !== 'object') return false
+  const t = (value as { type?: unknown }).type
+  return t === 'sdp' || t === 'ice-candidate' || t === 'bye'
+}
+
+export interface LanHostServerOptions {
+  port: number
+  /** Bind address. Default `127.0.0.1` — set to `0.0.0.0` for LAN visibility. */
+  host?: string
+  /**
+   * Fires once per accepted peer WebSocket. The host's owning
+   * service typically constructs a `PeerSession` + `SessionController`
+   * on top. Subsequent connections while one is active are rejected
+   * with `1013` (try-again-later) — Pair-Editing is point-to-point.
+   */
+  onPeerConnected: (transport: SignallingTransport) => void
+}
+
+export interface LanHostServerHandle {
+  readonly address: { host: string; port: number }
+  close(): Promise<void>
+}
+
+/**
+ * Bind a `WebSocketServer` for joiner connections. Accepts ONE peer
+ * at a time — a second connect attempt closes immediately with code
+ * `1013` so the joiner-side surfaces "host is busy" rather than
+ * stalling on a dead negotiation.
+ */
+export async function startLanHostServer(opts: LanHostServerOptions): Promise<LanHostServerHandle> {
+  const wss: WsServer = new WebSocketServer({
+    host: opts.host ?? '127.0.0.1',
+    port: opts.port,
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    wss.once('listening', resolve)
+    wss.once('error', reject)
+  })
+
+  let activePeer: WebSocket | null = null
+
+  wss.on('connection', (ws: WebSocket) => {
+    if (activePeer) {
+      ws.close(1013, 'host-busy')
+      return
+    }
+    activePeer = ws
+    ws.on('close', () => {
+      if (activePeer === ws) activePeer = null
+    })
+    opts.onPeerConnected(wrapWebSocket(ws))
+  })
+
+  return {
+    address: { host: opts.host ?? '127.0.0.1', port: opts.port },
+    async close() {
+      await new Promise<void>((resolve) => wss.close(() => resolve()))
+    },
+  }
+}
+
+/**
+ * Open a `WebSocket` to a discovered host and wrap it as a
+ * `SignallingTransport`. Throws if the connect handshake fails;
+ * caller decides whether to retry / surface to UI.
+ */
+export async function connectLanJoinerTransport(
+  hostAddress: string,
+  port: number,
+): Promise<SignallingTransport> {
+  const ws = new WebSocket(`ws://${hostAddress}:${port}/`)
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error) => {
+      ws.off('open', onOpen)
+      reject(err)
+    }
+    const onOpen = () => {
+      ws.off('error', onError)
+      resolve()
+    }
+    ws.once('open', onOpen)
+    ws.once('error', onError)
+  })
+  return wrapWebSocket(ws)
+}

--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -18,10 +18,12 @@
     "@gjsify/dom-elements@^0.4.32",
     "@gjsify/event-bridge@^0.4.32",
     "@gjsify/webgl@^0.4.32",
+    "@gjsify/webrtc@^0.4.33",
+    "@gjsify/ws@^0.4.33",
     "@gjsify/xmlhttprequest@^0.4.32",
+    "vitest@^4.1.7",
     "@gjsify/ws@^0.4.32",
     "@types/ws@^8.5.12",
-    "vitest@^4.1.7",
     "ws@^8.18.0",
     "serve@^14.2.6",
     "@girs/graphene-1.0@^1.0.0-4.0.4",
@@ -495,6 +497,104 @@
         "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
+    "node_modules/@girs/gjsifywebrtc-0.1": {
+      "version": "0.1.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gjsifywebrtc-0.1/-/gjsifywebrtc-0.1-0.1.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-6o0oB5TzXM+YB2+RJgdFBVESAUpno7V9mmb6RRaHn51qu4oHBWgUE00kDa3PtsbpR0vwXaZ/PQBksXZ5rfMMMw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gstwebrtc-1.0": "1.0.0-4.0.0-rc.5",
+        "@girs/gstsdp-1.0": "1.0.0-4.0.0-rc.5",
+        "@girs/gst-1.0": "1.28.1-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gjsifywebrtc-0.1/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.5.tgz",
+      "integrity": "sha512-32j02MyJD5GdlfORLnQ5CdC5m+AwWcpnK3AJvKo9JzB/LIlynvNgxQE0SdFM3WYwkqoYvASHR76mLyOVVjbZeA==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gjsifywebrtc-0.1/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
+      "version": "1.0.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-KcZ4EDI6qVKPzLF4V6B4LuUKzA5krH3nnzJAljge51PLYFeMDb2cHVuIxZ159y84cRGddZxlGDvgqcc3i8b3rQ==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gjsifywebrtc-0.1/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
+      "version": "2.88.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-LshhybqjNp3m0Pub2EnzkvRNXQMear/fcpYvzyXBAAPHBzvQpi+MCzTfhBf7VjqtNKaENdLOcMEPwkeZE3EmuA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gjsifywebrtc-0.1/node_modules/@girs/glib-2.0": {
+      "version": "2.88.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-v05lTgvcEvX26gj2lMIqDgNeRzDp/vUNkPAb76tAD8BBVJ9HvV3hUpV4qeXZozU7CD37Lsk9pfAkKCJrOh6XQQ==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gjsifywebrtc-0.1/node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-ZhgllRPf32vtPti1BdYbZRHEixN4rm6WrHUq+rBH0y4d2zPq0x7Y1p+N3n/A6/byVKteEh0PbAAxnKhJaFeAlA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gjsifywebrtc-0.1/node_modules/@girs/gobject-2.0": {
+      "version": "2.88.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-h18mC/PjkxhrmmjR6bBYW4e0c3mVzjGoy33Ljlu8E3Ebp8pHSrY0J4ycPwpK9oq44bLEPACA4BlYCRoWIvHX7w==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gjsifywebrtc-0.1/node_modules/@girs/gst-1.0": {
+      "version": "1.28.1-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gst-1.0/-/gst-1.0-1.28.1-4.0.0-rc.5.tgz",
+      "integrity": "sha512-r0A8GksSf/IL4TQiwr++OTqnFzOPSAKO/5KB0wmrgApP4Whilu/72Yvq5A/ISDZ95+ntoXbB6o7qB54EXH8s2g==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gjsifywebrtc-0.1/node_modules/@girs/gstwebrtc-1.0": {
+      "version": "1.0.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gstwebrtc-1.0/-/gstwebrtc-1.0-1.0.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-qsmRXeHMNUPBL9owVtwXx88GQMI24GwiKUT9LKaxVuhZnUuMG8aUTZ8fgQQ6/21jgp5PSmhwKgFOpxDR4/B0Sw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/gst-1.0": "1.28.1-4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gstsdp-1.0": "1.0.0-4.0.0-rc.5",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
     "node_modules/@girs/glib-2.0": {
       "version": "2.88.0-4.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.17.tgz",
@@ -606,6 +706,245 @@
         "@girs/glib-2.0": "2.88.0-4.0.0-rc.17",
         "@girs/cairo-1.0": "1.0.0-4.0.0-rc.17",
         "@girs/gobject-2.0": "2.88.0-4.0.0-rc.17"
+      }
+    },
+    "node_modules/@girs/gst-1.0": {
+      "version": "1.28.1-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gst-1.0/-/gst-1.0-1.28.1-4.0.1.tgz",
+      "integrity": "sha512-lCt/7+4Pw4l7mdkkajAUSwTbKV6RjhTaLxtw29c96xp60CQNcMxYu4WDxvVYZhaQht0Euy9evPRzEMLNLbbP2w==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gst-1.0/node_modules/@girs/gjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gst-1.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gst-1.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gst-1.0/node_modules/@girs/glib-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gst-1.0/node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gst-1.0/node_modules/@girs/gobject-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gstsdp-1.0": {
+      "version": "1.0.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gstsdp-1.0/-/gstsdp-1.0-1.0.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-/PNPzTOQUXv2AHwtDiJyfSPPlna/p+mTpw9EnKWFG9O1laPsfJPZJTR/M3CrsbUh0lPyHaSWtSkGnLV3Q0F3lw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/gst-1.0": "1.28.1-4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gstsdp-1.0/node_modules/@girs/gjs": {
+      "version": "4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-rc.5.tgz",
+      "integrity": "sha512-32j02MyJD5GdlfORLnQ5CdC5m+AwWcpnK3AJvKo9JzB/LIlynvNgxQE0SdFM3WYwkqoYvASHR76mLyOVVjbZeA==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/cairo-1.0": "1.0.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gstsdp-1.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
+      "version": "1.0.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-KcZ4EDI6qVKPzLF4V6B4LuUKzA5krH3nnzJAljge51PLYFeMDb2cHVuIxZ159y84cRGddZxlGDvgqcc3i8b3rQ==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gstsdp-1.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
+      "version": "2.88.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-LshhybqjNp3m0Pub2EnzkvRNXQMear/fcpYvzyXBAAPHBzvQpi+MCzTfhBf7VjqtNKaENdLOcMEPwkeZE3EmuA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gstsdp-1.0/node_modules/@girs/glib-2.0": {
+      "version": "2.88.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-v05lTgvcEvX26gj2lMIqDgNeRzDp/vUNkPAb76tAD8BBVJ9HvV3hUpV4qeXZozU7CD37Lsk9pfAkKCJrOh6XQQ==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gstsdp-1.0/node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-ZhgllRPf32vtPti1BdYbZRHEixN4rm6WrHUq+rBH0y4d2zPq0x7Y1p+N3n/A6/byVKteEh0PbAAxnKhJaFeAlA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gstsdp-1.0/node_modules/@girs/gobject-2.0": {
+      "version": "2.88.0-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.0-rc.5.tgz",
+      "integrity": "sha512-h18mC/PjkxhrmmjR6bBYW4e0c3mVzjGoy33Ljlu8E3Ebp8pHSrY0J4ycPwpK9oq44bLEPACA4BlYCRoWIvHX7w==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gstsdp-1.0/node_modules/@girs/gst-1.0": {
+      "version": "1.28.1-4.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@girs/gst-1.0/-/gst-1.0-1.28.1-4.0.0-rc.5.tgz",
+      "integrity": "sha512-r0A8GksSf/IL4TQiwr++OTqnFzOPSAKO/5KB0wmrgApP4Whilu/72Yvq5A/ISDZ95+ntoXbB6o7qB54EXH8s2g==",
+      "dependencies": {
+        "@girs/gjs": "4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.0-rc.5",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-rc.5",
+        "@girs/gobject-2.0": "2.88.0-4.0.0-rc.5"
+      }
+    },
+    "node_modules/@girs/gstwebrtc-1.0": {
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gstwebrtc-1.0/-/gstwebrtc-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-TUhH1WpInkzJux7awgEGgW0RniuixyccRM1lT9wIrcnld8fd4DBs9DeHGBH/uzM/W3zFh0gpaFvVneXdo82AjA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/gst-1.0": "1.28.1-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gstsdp-1.0": "1.0.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/glib-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gobject-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gstsdp-1.0": {
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gstsdp-1.0/-/gstsdp-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-QOXjcoVN8UgyIG+RXaR+IiUWd7q239lVqNvtG9h5uHloYERdhm0d4S+D8vl0xf+zo8ub2AktTuOhnSOaQDYzEQ==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/gst-1.0": "1.28.1-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@girs/gtk-4.0": {
@@ -4967,6 +5306,90 @@
         "@girs/gobject-2.0": "2.88.0-4.0.1",
         "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
         "@girs/freetype2-2.0": "2.0.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/webrtc": {
+      "version": "0.4.33",
+      "resolved": "https://registry.npmjs.org/@gjsify/webrtc/-/webrtc-0.4.33.tgz",
+      "integrity": "sha512-PksOC/+g+5pvsA8kzif2KMgxS99PQvdhC/dkBYx3OmyiQHnIFFWJJAa6XZ0TEj1aO0w0SiqatpB6E/zroBvvyg==",
+      "dependencies": {
+        "@gjsify/buffer": "^0.4.33",
+        "@gjsify/dom-events": "^0.4.33",
+        "@gjsify/dom-exception": "^0.4.33",
+        "@gjsify/webrtc-native": "^0.4.33"
+      }
+    },
+    "node_modules/@gjsify/webrtc-native": {
+      "version": "0.4.33",
+      "resolved": "https://registry.npmjs.org/@gjsify/webrtc-native/-/webrtc-native-0.4.33.tgz",
+      "integrity": "sha512-Y4I8yoAvoucwkISolYZQjB2tW+JAY6efCYtj4sZDfWloFbqrrd2JGBro90O14H5mTwYsU+KOWfEv/J51fID/Nw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/gjsifywebrtc-0.1": "0.1.0-4.0.0-rc.5",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1",
+        "@girs/gst-1.0": "1.28.1-4.0.1",
+        "@girs/gstwebrtc-1.0": "1.0.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/webrtc-native/node_modules/@girs/gjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
+      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
+      "dependencies": {
+        "@girs/gio-2.0": "2.88.0-4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/cairo-1.0": "1.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/webrtc-native/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
+      "version": "1.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
+      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/webrtc-native/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gmodule-2.0": "2.0.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/webrtc-native/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
+      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/webrtc-native/node_modules/@girs/glib-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/gobject-2.0": "2.88.0-4.0.1"
+      }
+    },
+    "node_modules/@gjsify/webrtc-native/node_modules/@girs/gobject-2.0": {
+      "version": "2.88.0-4.0.1",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
+      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "dependencies": {
+        "@girs/gjs": "4.0.1",
+        "@girs/glib-2.0": "2.88.0-4.0.1"
       }
     },
     "node_modules/@gjsify/websocket": {


### PR DESCRIPTION
## Summary

Completes the engine-side wiring from Phase 3d (#81) with the maker-side glue for end-to-end LAN Pair-Editing. UI integration (Welcome view discovery list, header Share button + popover) follows in Phase 3e along with the `pixelrpg://` URL handler + cross-internet flow.

## What's new

New deps in `@pixelrpg/maker-gjs`:
- `@gjsify/webrtc` `^0.4.33` — RTCPeerConnection via GstWebRTC
- `@gjsify/ws` `^0.4.33` — ws-compat WebSocket / WebSocketServer over Soup 3.0

| File | Role |
|---|---|
| `services/lan-signalling.ts` | `wrapWebSocket` adapter (one `ws.WebSocket` → `SignallingTransport`), `startLanHostServer` (binds WS server, accepts one peer), `connectLanJoinerTransport` (opens `ws://host:port/`) |
| `services/lan-signalling.test.ts` | 8 unit tests for the adapter — routing, JSON tolerance, binary-drop, send fan-out, idempotent close, post-close silent drop, send-error swallow |
| `services/collab-session.ts` | `CollabSession` class owning one `PeerSession` + `SessionController` pair. Caller supplies the transport (LAN today, relay tomorrow). Top-level `@gjsify/webrtc/register` import wires `globalThis.RTCPeerConnection` |

## Design notes

- **Point-to-point**: host accepts ONE joiner; a second connect attempt closes with `1013` ("host-busy"). Pair-Editing v1 is point-to-point; fan-out belongs to the future host-sequencer phase.
- **Shared wire vocab**: SDP / ICE / bye envelopes match `apps/signalling-server/src/types.ts` verbatim, so a LAN→relay fallback can reuse the same parsing layer.
- **Symmetric adapter**: same `wrapWebSocket(ws)` shape works for both server-emitted peer sockets (host side) and client-opened sockets (joiner side).

## Test plan

- [x] `@pixelrpg/maker-gjs test` → 14/14 (was 6, +8 lan-signalling)
- [x] `gjsify foreach check + build` → clean
- [x] Maker bundle builds with `@gjsify/webrtc` + `@gjsify/ws` linked
- [ ] CI green
- [ ] Manual two-instance LAN smoke (deferred to Phase 3e UI wiring; requires Avahi + WebRTC + Maker UI to surface "Sessions on this network")

## Next phase

Phase 3e — Welcome-view discovery pane, header Share button + popover, `pixelrpg://join/<roomid>` URL handler, cross-internet client via the signalling-server.