### PR TITLE
feat(maker): relay signalling + pixelrpg:// URL helpers (Phase 3e core)

### DIFF
--- a/apps/maker-gjs/src/services/pixelrpg-url.spec.ts
+++ b/apps/maker-gjs/src/services/pixelrpg-url.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from '@gjsify/unit'
+
+import { parsePixelrpgUrl, pickPixelrpgIntent } from './pixelrpg-url.ts'
+
+export default async () => {
+  await describe('parsePixelrpgUrl', async () => {
+    await it('parses the canonical pixelrpg://join/<roomid>', async () => {
+      expect(parsePixelrpgUrl('pixelrpg://join/a3f2bb91')).toStrictEqual({ kind: 'join', roomId: 'a3f2bb91' })
+    })
+
+    await it('tolerates a leading double slash (some launchers add it)', async () => {
+      expect(parsePixelrpgUrl('pixelrpg:///join/a3f2bb91')).toStrictEqual({ kind: 'join', roomId: 'a3f2bb91' })
+    })
+
+    await it('strips trailing query / fragment', async () => {
+      expect(parsePixelrpgUrl('pixelrpg://join/a3f2bb91?source=chat')).toStrictEqual({
+        kind: 'join',
+        roomId: 'a3f2bb91',
+      })
+      expect(parsePixelrpgUrl('pixelrpg://join/a3f2bb91#friend')).toStrictEqual({ kind: 'join', roomId: 'a3f2bb91' })
+    })
+
+    await it('rejects an unknown scheme', async () => {
+      expect(parsePixelrpgUrl('https://example.com/join/abc')).toBeNull()
+    })
+
+    await it('rejects an unknown action', async () => {
+      expect(parsePixelrpgUrl('pixelrpg://settings/foo')).toBeNull()
+    })
+
+    await it('rejects malformed / missing room id', async () => {
+      expect(parsePixelrpgUrl('pixelrpg://join/')).toBeNull()
+      expect(parsePixelrpgUrl('pixelrpg://join/has spaces')).toBeNull()
+      expect(parsePixelrpgUrl('pixelrpg://join/abc/def')).toStrictEqual({ kind: 'join', roomId: 'abc' })
+    })
+
+    await it('rejects a wildly-malformed payload', async () => {
+      expect(parsePixelrpgUrl('')).toBeNull()
+      expect(parsePixelrpgUrl('pixelrpg://')).toBeNull()
+      expect(parsePixelrpgUrl('pixelrpg://abc')).toBeNull()
+    })
+  })
+
+  await describe('pickPixelrpgIntent', async () => {
+    await it('returns the first valid intent in argv', async () => {
+      const argv = ['/usr/bin/org.pixelrpg.maker', '--debug', 'pixelrpg://join/a3f2bb91', 'pixelrpg://join/zz9z9z9z']
+      expect(pickPixelrpgIntent(argv)).toStrictEqual({ kind: 'join', roomId: 'a3f2bb91' })
+    })
+
+    await it('returns null when no pixelrpg URL is present', async () => {
+      expect(pickPixelrpgIntent(['/usr/bin/org.pixelrpg.maker'])).toBeNull()
+      expect(pickPixelrpgIntent(['arg1', 'arg2', 'arg3'])).toBeNull()
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/pixelrpg-url.ts
+++ b/apps/maker-gjs/src/services/pixelrpg-url.ts
@@ -1,0 +1,52 @@
+/**
+ * `pixelrpg://` URL scheme handling.
+ *
+ * The maker registers as `x-scheme-handler/pixelrpg` (via its
+ * `.desktop` file MimeType entry, set up by the next phase of UI
+ * work). When a browser / chat client opens a `pixelrpg://join/
+ * <roomid>` URL, the OS spawns the maker with the URL as a CLI
+ * argument; the entrypoint runs {@link parsePixelrpgUrl} over
+ * `argv` to pluck out the join intent.
+ *
+ * Kept platform-indep (no `@girs/*` imports) so it's unit-testable
+ * under Node.
+ */
+
+export type PixelrpgIntent = { kind: 'join'; roomId: string }
+
+/**
+ * Parse one URL string. Returns `null` for anything that isn't a
+ * `pixelrpg://join/<roomid>` of the expected shape.
+ */
+export function parsePixelrpgUrl(url: string): PixelrpgIntent | null {
+  if (!url.startsWith('pixelrpg://')) return null
+  // Use a forgiving URL parse — the scheme isn't registered with the
+  // WHATWG URL parser as "special", so the host parsing is a bit
+  // quirky. Slice the scheme off and hand-split the rest.
+  const tail = url.slice('pixelrpg://'.length)
+  // Expected forms:
+  //   join/<roomid>            (canonical)
+  //   /join/<roomid>           (some launchers double the slash)
+  const segments = tail.replace(/^\/+/, '').split(/[/?#]/).filter(Boolean)
+  if (segments.length < 2) return null
+  const [action, value] = segments
+  if (action === 'join' && value && /^[A-Za-z0-9_-]{1,64}$/.test(value)) {
+    return { kind: 'join', roomId: value }
+  }
+  return null
+}
+
+/**
+ * Scan an argv array for the first valid `pixelrpg://` URL and
+ * return the parsed intent, or `null` when nothing matches. Used by
+ * `main.ts` on startup; the Application's `command-line` signal
+ * uses the same helper to handle already-running second-instance
+ * invocations.
+ */
+export function pickPixelrpgIntent(argv: readonly string[]): PixelrpgIntent | null {
+  for (const arg of argv) {
+    const intent = parsePixelrpgUrl(arg)
+    if (intent) return intent
+  }
+  return null
+}

--- a/apps/maker-gjs/src/services/relay-signalling.spec.ts
+++ b/apps/maker-gjs/src/services/relay-signalling.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from '@gjsify/unit'
+
+import { defaultRelayUrl, generateRoomId } from './relay-signalling.ts'
+
+export default async () => {
+  await describe('generateRoomId', async () => {
+    await it('returns an 8-character id from the unambiguous alphabet', async () => {
+      const id = generateRoomId()
+      expect(id).toHaveLength(8)
+      expect(id).toMatch(/^[abcdefghijkmnpqrstuvwxyz23456789]{8}$/)
+    })
+
+    await it('returns distinct ids on consecutive calls (collision unlikely at 2.8e12)', async () => {
+      const ids = new Set<string>()
+      for (let i = 0; i < 50; i++) ids.add(generateRoomId())
+      expect(ids.size).toBe(50)
+    })
+  })
+
+  await describe('defaultRelayUrl', async () => {
+    await it('reads PIXELRPG_RELAY_URL when set', async () => {
+      const prev = process.env.PIXELRPG_RELAY_URL
+      process.env.PIXELRPG_RELAY_URL = 'wss://custom.example/sig'
+      try {
+        expect(defaultRelayUrl()).toBe('wss://custom.example/sig')
+      } finally {
+        if (prev === undefined) delete process.env.PIXELRPG_RELAY_URL
+        else process.env.PIXELRPG_RELAY_URL = prev
+      }
+    })
+
+    await it('falls back to the hosted endpoint when env is unset', async () => {
+      const prev = process.env.PIXELRPG_RELAY_URL
+      delete process.env.PIXELRPG_RELAY_URL
+      try {
+        expect(defaultRelayUrl()).toMatch(/^wss?:\/\//)
+      } finally {
+        if (prev !== undefined) process.env.PIXELRPG_RELAY_URL = prev
+      }
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/relay-signalling.ts
+++ b/apps/maker-gjs/src/services/relay-signalling.ts
@@ -1,0 +1,74 @@
+import type { SignallingTransport } from '@pixelrpg/engine'
+import { WebSocket } from 'ws'
+
+import { wrapWebSocket } from './lan-signalling.ts'
+
+/**
+ * Cross-network signalling — both peers connect to the workspace's
+ * `@pixelrpg/signalling-server` relay over a plain WebSocket. The
+ * relay only routes opaque SDP / ICE / bye envelopes; the
+ * `wrapWebSocket` adapter (shared with the LAN path) parses them
+ * into the platform-indep `SignallingTransport` shape `PeerSession`
+ * consumes.
+ *
+ * Reuses the entire wrapWebSocket frame-handling code path — the
+ * only difference from LAN is the URL.
+ */
+
+export interface RelayConnectOptions {
+  /** Relay endpoint, e.g. `wss://signalling.pixelrpg.example`. */
+  relayUrl: string
+  /** Room id pulled from the `pixelrpg://join/<roomid>` link or generated for hosting. */
+  roomId: string
+  /** Role this peer plays in the room — host issues the offer, joiner answers. */
+  role: 'host' | 'joiner'
+}
+
+/**
+ * Open a WebSocket to the relay's `/room/<roomid>?role=…` endpoint
+ * and wrap it as a `SignallingTransport`. Throws if the upgrade
+ * handshake fails — caller surfaces gracefully ("could not reach
+ * relay" toast).
+ */
+export async function connectRelaySignalling(opts: RelayConnectOptions): Promise<SignallingTransport> {
+  const url = `${opts.relayUrl.replace(/\/$/, '')}/room/${encodeURIComponent(opts.roomId)}?role=${opts.role}`
+  const ws = new WebSocket(url)
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error) => {
+      ws.off('open', onOpen)
+      reject(err)
+    }
+    const onOpen = () => {
+      ws.off('error', onError)
+      resolve()
+    }
+    ws.once('open', onOpen)
+    ws.once('error', onError)
+  })
+  return wrapWebSocket(ws)
+}
+
+/**
+ * Resolve the default relay endpoint from env (or fall back). The
+ * env var lets a self-hoster point the maker at their own deployment
+ * without rebuilding; the default targets the future
+ * `signalling.pixelrpg.example` endpoint the workspace will host.
+ */
+export function defaultRelayUrl(): string {
+  return process.env.PIXELRPG_RELAY_URL ?? 'wss://signalling.pixelrpg.example'
+}
+
+/**
+ * Generate a fresh, share-friendly room id. Eight lowercase
+ * alphanumerics — collision odds across concurrent live rooms are
+ * negligible given the 5-minute idle reap (~2.8 × 10¹²
+ * possibilities). Avoids ambiguous chars (0/o, 1/l).
+ */
+export function generateRoomId(): string {
+  const alphabet = 'abcdefghijkmnpqrstuvwxyz23456789'
+  let id = ''
+  for (let i = 0; i < 8; i++) {
+    id += alphabet[Math.floor(Math.random() * alphabet.length)]
+  }
+  return id
+}

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -2,5 +2,7 @@ import { run } from '@gjsify/unit'
 
 import lanDiscoveryParseSuite from './services/lan-discovery-parse.spec.js'
 import lanSignallingSuite from './services/lan-signalling.spec.js'
+import pixelrpgUrlSuite from './services/pixelrpg-url.spec.js'
+import relaySignallingSuite from './services/relay-signalling.spec.js'
 
-run({ lanDiscoveryParseSuite, lanSignallingSuite })
+run({ lanDiscoveryParseSuite, lanSignallingSuite, pixelrpgUrlSuite, relaySignallingSuite })


### PR DESCRIPTION
## Summary

Phase 3e core — cross-internet signalling client + `pixelrpg://` URL parser. UI wiring (Welcome view discovery list, header Share button + popover, application URL-handler registration) follows in a separate UI PR.

## What's new

| File | Role |
|---|---|
| `services/relay-signalling.ts` | `connectRelaySignalling({relayUrl, roomId, role})` opens WS to relay's `/room/<id>?role=…`, wraps as `SignallingTransport` via the same adapter the LAN path uses. `defaultRelayUrl()` reads `PIXELRPG_RELAY_URL` env (self-hosters point at their own deployment). `generateRoomId()` 8-char unambiguous alphabet (no 0/o/1/l) |
| `services/relay-signalling.spec.ts` | 4 unit tests (@gjsify/unit) — covers env override, fallback, id shape + uniqueness |
| `services/pixelrpg-url.ts` | `parsePixelrpgUrl(url)` + `pickPixelrpgIntent(argv)` — forgiving parser for `pixelrpg://join/<roomid>` |
| `services/pixelrpg-url.spec.ts` | 9 unit tests (@gjsify/unit) |
| `src/test.mts` | Aggregator updated to include both new suites |

## Test plan

- [x] `@pixelrpg/maker-gjs test` → 40 expects, ✅ gjs ✅ node (was 20, +20 from these two suites)
- [x] `gjsify foreach check + build` → clean
- [ ] CI green