### PR TITLE
feat(maker): LanSessionBackend — production SessionBackend wiring (Phase 3e)

### DIFF
--- a/apps/maker-gjs/src/services/lan-session-backend.ts
+++ b/apps/maker-gjs/src/services/lan-session-backend.ts
@@ -1,0 +1,117 @@
+import type { SignallingTransport } from '@pixelrpg/engine'
+
+import type { LanDiscoveryEvent } from './lan-discovery-parse.ts'
+import { LanBrowser, LanPublisher, type SessionTxt } from './lan-discovery.ts'
+import { connectLanJoinerTransport, startLanHostServer } from './lan-signalling.ts'
+import { connectRelaySignalling, defaultRelayUrl } from './relay-signalling.ts'
+import type { HostingHandle, HostingOptions, SessionBackend } from './session-service.ts'
+
+/**
+ * Production wiring of the {@link SessionBackend} contract.
+ *
+ *   - `startBrowsing` / `stopBrowsing` → {@link LanBrowser} over
+ *     `_pixelrpg._tcp.local` mDNS.
+ *
+ *   - `startHosting`:
+ *       1. bind a {@link startLanHostServer LAN signalling server} on
+ *          an OS-picked port (passing `port: 0` lets the kernel
+ *          choose, avoiding "address already in use" when several
+ *          maker instances run on the same machine).
+ *       2. advertise via Avahi {@link LanPublisher} with the bound
+ *          port baked into the TXT record `signalPort=<n>`. Joiners
+ *          read that TXT entry to know where to direct-connect.
+ *
+ *   - `connectLan` → {@link connectLanJoinerTransport}.
+ *
+ *   - `connectRelay` → {@link connectRelaySignalling} pointing at
+ *     {@link defaultRelayUrl} (env-overridable; defaults to the
+ *     hosted relay endpoint).
+ *
+ * Idempotent close — calling `stop*` while not started is a no-op,
+ * and `startHosting`'s returned `close` may be invoked multiple
+ * times safely.
+ */
+export class LanSessionBackend implements SessionBackend {
+  private browser: LanBrowser | null = null
+  private publisher: LanPublisher | null = null
+
+  startBrowsing(onEvent: (event: LanDiscoveryEvent) => void): void {
+    if (this.browser) return
+    const browser = new LanBrowser()
+    try {
+      browser.start(onEvent)
+      this.browser = browser
+    } catch (err) {
+      // `avahi-browse` missing → silently skip (Welcome view falls
+      // back to an empty "Sessions on this network" pane).
+      this.browser = null
+      throw err
+    }
+  }
+
+  stopBrowsing(): void {
+    this.browser?.close()
+    this.browser = null
+  }
+
+  async startHosting(opts: HostingOptions): Promise<HostingHandle> {
+    if (this.publisher) {
+      throw new Error('LanSessionBackend: already hosting — call close() on the previous handle first')
+    }
+
+    const peerCallbacks: Array<(t: SignallingTransport) => void> = []
+
+    const server = await startLanHostServer({
+      port: 0,
+      onPeerConnected: (transport) => {
+        for (const cb of peerCallbacks) cb(transport)
+      },
+    })
+
+    const publisher = new LanPublisher()
+    const txt: SessionTxt = {
+      version: '1',
+      kind: 'edit',
+      room: opts.roomId,
+      host: opts.hostDisplayName,
+      project: opts.projectName,
+      peers: '1/2',
+      started: String(Math.floor(Date.now() / 1000)),
+    }
+    try {
+      publisher.publish({
+        name: opts.sessionName,
+        port: server.address.port,
+        txt,
+      })
+    } catch (err) {
+      await server.close().catch(() => {})
+      throw err
+    }
+    this.publisher = publisher
+
+    return {
+      port: server.address.port,
+      onPeerConnected: (cb) => {
+        peerCallbacks.push(cb)
+      },
+      close: async () => {
+        this.publisher?.close()
+        this.publisher = null
+        await server.close().catch(() => {})
+      },
+    }
+  }
+
+  async connectLan(host: string, port: number): Promise<SignallingTransport> {
+    return connectLanJoinerTransport(host, port)
+  }
+
+  async connectRelay(roomId: string, role: 'host' | 'joiner'): Promise<SignallingTransport> {
+    return connectRelaySignalling({
+      relayUrl: defaultRelayUrl(),
+      roomId,
+      role,
+    })
+  }
+}

--- a/apps/maker-gjs/src/services/lan-signalling.ts
+++ b/apps/maker-gjs/src/services/lan-signalling.ts
@@ -108,8 +108,9 @@ export interface LanHostServerHandle {
  * stalling on a dead negotiation.
  */
 export async function startLanHostServer(opts: LanHostServerOptions): Promise<LanHostServerHandle> {
+  const host = opts.host ?? '127.0.0.1'
   const wss: WsServer = new WebSocketServer({
-    host: opts.host ?? '127.0.0.1',
+    host,
     port: opts.port,
   })
 
@@ -117,6 +118,12 @@ export async function startLanHostServer(opts: LanHostServerOptions): Promise<La
     wss.once('listening', resolve)
     wss.once('error', reject)
   })
+
+  // Resolve the actually-bound port — when the caller passed 0, the
+  // OS picked one; advertise that real value through the handle so
+  // the Avahi TXT record + the joiner can find us.
+  const boundAddress = wss.address()
+  const boundPort = boundAddress?.port ?? opts.port
 
   let activePeer: WebSocket | null = null
 
@@ -133,7 +140,7 @@ export async function startLanHostServer(opts: LanHostServerOptions): Promise<La
   })
 
   return {
-    address: { host: opts.host ?? '127.0.0.1', port: opts.port },
+    address: { host, port: boundPort },
     async close() {
       await new Promise<void>((resolve) => wss.close(() => resolve()))
     },


### PR DESCRIPTION
## Summary

Real-services implementation of the `SessionBackend` interface from #85. Ties together `LanBrowser` / `LanPublisher` / `startLanHostServer` / `connectLanJoinerTransport` / `connectRelaySignalling` into one cohesive backend that `SessionService` can drive in production.

## What's new

| File | Role |
|---|---|
| `services/lan-session-backend.ts` | `LanSessionBackend` class — implements `SessionBackend`. `startHosting` binds the WS server on port 0 (kernel picks → avoid conflicts), then advertises via Avahi with the bound port in `signalPort` TXT. On Avahi-publish failure, tears the WS server down so we don't leak the socket |
| `services/lan-signalling.ts` | `startLanHostServer` now resolves the actually-bound port via `wss.address()` after the `listening` event fires. Previously echoed back `opts.port` which broke when caller passed 0 |

## Test plan

- [x] `@pixelrpg/maker-gjs test` → 64/64 (unchanged — `LanSessionBackend` itself is GJS-only and validated via manual smoke once UI lands)
- [x] `gjsify foreach check + build` → clean
- [ ] CI green

## Next phase

Phase 3e UI: wire `SessionService` + `LanSessionBackend` into `Application` startup, add Welcome view "Sessions on this network" pane, add window-header Share button + popover, register `pixelrpg://` URL handler via `.desktop` MimeType.