### PR TITLE
feat(maker): Welcome view LAN discovery pane + ApplicationWindow wiring (Phase 3e)

### DIFF
--- a/apps/maker-gjs/src/services/lan-discovery.ts
+++ b/apps/maker-gjs/src/services/lan-discovery.ts
@@ -73,7 +73,10 @@ export class LanPublisher {
     if (!this.process) return
     try {
       // SIGINT is the documented exit signal for avahi-publish-service.
-      this.process.send_signal(GLib.SIGINT ?? 2)
+      // SIGINT (2) is the documented graceful-shutdown signal for
+      // avahi-publish-service. The number is hard-coded — `GLib.SIGINT`
+      // is not exposed through the @girs typings.
+      this.process.send_signal(2)
     } catch {
       // Process may already be gone — best-effort.
     }

--- a/apps/maker-gjs/src/services/lan-signalling.ts
+++ b/apps/maker-gjs/src/services/lan-signalling.ts
@@ -121,9 +121,12 @@ export async function startLanHostServer(opts: LanHostServerOptions): Promise<La
 
   // Resolve the actually-bound port — when the caller passed 0, the
   // OS picked one; advertise that real value through the handle so
-  // the Avahi TXT record + the joiner can find us.
+  // the Avahi TXT record + the joiner can find us. `wss.address()`
+  // returns `string` for AF_UNIX sockets (we never use those) so
+  // narrow to the AddressInfo shape before reading `.port`.
   const boundAddress = wss.address()
-  const boundPort = boundAddress?.port ?? opts.port
+  const boundPort =
+    boundAddress && typeof boundAddress !== 'string' ? boundAddress.port : opts.port
 
   let activePeer: WebSocket | null = null
 

--- a/apps/maker-gjs/src/services/session-service.spec.ts
+++ b/apps/maker-gjs/src/services/session-service.spec.ts
@@ -84,13 +84,13 @@ function makeEngineStub(): Engine {
 export default async () => {
   await describe('SessionService — state machine', async () => {
     await it('starts in idle', async () => {
-      const service = new SessionService(makeEngineStub(), new MockBackend(), 'peer-test')
+      const service = new SessionService(() => makeEngineStub(), new MockBackend(), 'peer-test')
       expect(service.getState().kind).toBe('idle')
     })
 
     await it('startBrowsing → browsing; stopBrowsing → idle', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(makeEngineStub(), backend, 'peer-test')
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test')
       const states: string[] = []
       service.on('state-changed', (s) => states.push(s.kind))
 
@@ -106,7 +106,7 @@ export default async () => {
 
     await it('forwards LAN discovery events as service-discovered / service-gone', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(makeEngineStub(), backend, 'peer-test')
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test')
 
       const discovered: string[] = []
       const gone: string[] = []
@@ -128,7 +128,7 @@ export default async () => {
   await describe('SessionService — hosting', async () => {
     await it('startHosting publishes via the backend, transitions to hosting', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(makeEngineStub(), backend, 'peer-test')
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test')
 
       const roomId = await service.startHosting({
         sessionName: 'Test Session',
@@ -147,7 +147,7 @@ export default async () => {
 
     await it('rejects starting a second hosting flow while one is active', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(makeEngineStub(), backend, 'peer-test')
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test')
 
       await service.startHosting({ sessionName: 'A', projectName: 'A', hostDisplayName: 'A' })
       let threw = false
@@ -161,7 +161,7 @@ export default async () => {
 
     await it('stopHosting tears down the publisher + WS server; returns to idle', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(makeEngineStub(), backend, 'peer-test')
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test')
 
       await service.startHosting({ sessionName: 'A', projectName: 'A', hostDisplayName: 'A' })
       await service.stopHosting()
@@ -172,7 +172,7 @@ export default async () => {
 
     await it('stopHosting returns to browsing when browsing was on', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(makeEngineStub(), backend, 'peer-test')
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test')
 
       service.startBrowsing()
       await service.startHosting({ sessionName: 'A', projectName: 'A', hostDisplayName: 'A' })
@@ -190,7 +190,7 @@ export default async () => {
     // exercised by PeerSession's own spec.
     await it('joinLan calls backend.connectLan with the service address + port', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(makeEngineStub(), backend, 'peer-test')
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test')
 
       service.on('error', () => {})
       try {
@@ -211,7 +211,7 @@ export default async () => {
 
     await it('joinByRoomId calls backend.connectRelay with the room id', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(makeEngineStub(), backend, 'peer-test')
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test')
 
       service.on('error', () => {})
       try {

--- a/apps/maker-gjs/src/services/session-service.ts
+++ b/apps/maker-gjs/src/services/session-service.ts
@@ -88,8 +88,15 @@ export class SessionService {
   private hostingHandle: HostingHandle | null = null
   private wasBrowsing = false
 
+  /**
+   * @param engineProvider Lazy resolver returning the active engine,
+   *   or `null` when no project is loaded yet. Discovery flows
+   *   (`startBrowsing` / `service-discovered`) work without an
+   *   engine — only `openSession` (the host/join "connect"
+   *   transition) requires one and will reject otherwise.
+   */
   constructor(
-    private readonly engine: Engine,
+    private readonly engineProvider: () => Engine | null,
     private readonly backend: SessionBackend,
     /** Stable id for this peer — stamped onto every emitted Operation. */
     private readonly peerId: string,
@@ -227,8 +234,17 @@ export class SessionService {
   // ────────────────────────────────────────────────────────────
 
   private async openSession(role: PeerRole, roomId: string, transport: SignallingTransport): Promise<void> {
+    const engine = this.engineProvider()
+    if (!engine) {
+      try {
+        transport.close()
+      } catch {
+        /* best-effort */
+      }
+      throw new Error('SessionService: no engine available — load a project before opening a session')
+    }
     const collab = new CollabSession({
-      engine: this.engine,
+      engine,
       role,
       signalling: transport,
       peerId: this.peerId,

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -9,8 +9,11 @@ import { gettext as _ } from 'gettext'
 import { CastController } from '../services/cast-controller.ts'
 import { EngineController } from '../services/engine-controller.ts'
 import { writeTextFile } from '../services/file-io.ts'
+import type { DiscoveredService } from '../services/lan-discovery-parse.ts'
+import { LanSessionBackend } from '../services/lan-session-backend.ts'
 import { type LoadedProject, loadProjectAsAtlas } from '../services/project-loader.ts'
 import { loadRecentProjects, recordRecentProject } from '../services/recent-projects.ts'
+import { generatePeerId, SessionService } from '../services/session-service.ts'
 import { findBlankTemplate, findTemplateById } from '../services/templates.ts'
 import { TilesController } from '../services/tiles-controller.ts'
 import Template from './application-window.blp'
@@ -100,6 +103,13 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
    */
   private _castCtl: CastController | null = null
   private _tilesCtl: TilesController | null = null
+  /**
+   * Pair-Editing orchestration. Constructed once in `vfunc_map` with
+   * a lazy engine provider — Welcome-view discovery flows work
+   * without a loaded project, and `joinLan` / `joinByRoomId` reject
+   * until an engine is available.
+   */
+  private _sessionSvc: SessionService | null = null
 
   static {
     GObject.registerClass(
@@ -177,6 +187,80 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
         () => this._engineCtl.engine,
         (msg) => this._showToast(msg),
       )
+    }
+    if (!this._sessionSvc) {
+      // The `@pixelrpg/gjs` Engine widget proxies the core Engine
+      // but doesn't expose `executeCommand` / `applyRemoteCommand`
+      // yet. Once the widget grows those (planned alongside the
+      // op-broadcast UI wiring), this cast disappears. For now
+      // discovery flows (browse / share) work fine because they
+      // don't touch the engine; the join path will throw a typed
+      // error until the proxy methods exist.
+      const engineProvider = () => (this._engineCtl.engine ?? null) as unknown as import('@pixelrpg/engine').Engine | null
+      this._sessionSvc = new SessionService(engineProvider, new LanSessionBackend(), generatePeerId())
+    }
+
+    // Welcome view ↔ SessionService bridge. The window owns the
+    // service (it spans the lifetime of every view), the Welcome
+    // view is just the visual surface for browse + join. Start /
+    // stop browsing tied to whether the welcome page is visible —
+    // mDNS pings every couple of seconds and we don't want to
+    // burn the network while the user is editing.
+    this.signals.connect(this._welcome_view, 'session-selected', (_v: WelcomeView, service: DiscoveredService) => {
+      void this._onJoinLanSession(service)
+    })
+    this.signals.connect(this._welcome_view, 'join-by-code', (_v: WelcomeView, roomId: string) => {
+      void this._onJoinByRoomId(roomId)
+    })
+    // SessionService is not a GObject — use its typed `.on` instead
+    // of `this.signals`. The unsubscribe closures live in
+    // `_sessionUnsubscribes` so vfunc_unmap can tear them down
+    // symmetrically.
+    const svc = this._sessionSvc
+    this._sessionUnsubscribes = [
+      svc.on('service-discovered', (service) => this._welcome_view.addDiscoveredService(service)),
+      svc.on('service-gone', (name) => this._welcome_view.removeDiscoveredService(name)),
+      svc.on('error', (err) => this._showToast(_(`Session error: ${err.message}`))),
+    ]
+
+    // Start browsing whenever the welcome view is the visible page.
+    this._refreshSessionBrowsing()
+    this.signals.connect(this._stack, 'notify::visible-child-name', () => this._refreshSessionBrowsing())
+  }
+
+  /** Active subscriptions to {@link SessionService} events — torn down on unmap. */
+  private _sessionUnsubscribes: Array<() => void> = []
+
+  private _refreshSessionBrowsing(): void {
+    if (!this._sessionSvc) return
+    const visible = this._stack.get_visible_child_name()
+    if (visible === 'welcome') this._sessionSvc.startBrowsing()
+    else this._sessionSvc.stopBrowsing()
+  }
+
+  private async _onJoinLanSession(service: DiscoveredService): Promise<void> {
+    if (!this._loadedProject) {
+      this._showToast(_('Open a project before joining a session.'))
+      return
+    }
+    try {
+      await this._sessionSvc?.joinLan(service)
+      this._showToast(_(`Joined ${service.txt.project ?? service.name}`))
+    } catch (err) {
+      this._showToast(_(`Could not join: ${(err as Error).message}`))
+    }
+  }
+
+  private async _onJoinByRoomId(roomId: string): Promise<void> {
+    if (!this._loadedProject) {
+      this._showToast(_('Open a project before joining a session.'))
+      return
+    }
+    try {
+      await this._sessionSvc?.joinByRoomId(roomId)
+      this._showToast(_(`Joined room ${roomId}`))
+    } catch (err) {
+      this._showToast(_(`Could not join: ${(err as Error).message}`))
     }
   }
 
@@ -257,6 +341,9 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
 
   vfunc_unmap(): void {
     this.signals.disconnectAll()
+    for (const dispose of this._sessionUnsubscribes) dispose()
+    this._sessionUnsubscribes = []
+    this._sessionSvc?.stopBrowsing()
     super.vfunc_unmap()
   }
 

--- a/apps/maker-gjs/src/widgets/welcome-view.blp
+++ b/apps/maker-gjs/src/widgets/welcome-view.blp
@@ -62,6 +62,61 @@ template $WelcomeView : Adw.Bin {
           }
         }
 
+        Gtk.Box sessions_header {
+          orientation: horizontal;
+          spacing: 6;
+          margin-top: 18;
+
+          Gtk.Label {
+            label: _("Sessions on this network");
+            halign: start;
+            hexpand: true;
+            styles ["heading"]
+          }
+        }
+
+        // List rebuilt dynamically by `welcome-view.ts` from
+        // SessionService's `service-discovered` / `service-gone`
+        // events. Empty state stays visible until the first
+        // service resolves.
+        Gtk.ListBox sessions_list {
+          selection-mode: none;
+          styles ["boxed-list"]
+
+          Adw.ActionRow empty_sessions_row {
+            title: _("No sessions found");
+            subtitle: _("Hosts on the same network will appear here.");
+            activatable: false;
+
+            [prefix]
+            Gtk.Image {
+              icon-name: "network-workgroup-symbolic";
+              pixel-size: 22;
+            }
+          }
+        }
+
+        // Paste-link / room-code entry — the cross-internet
+        // counterpart of the LAN discovery list above. The single
+        // field accepts both `pixelrpg://join/<roomid>` URLs and
+        // bare room codes; the welcome-view normalises before
+        // emitting `join-by-code`.
+        Adw.PreferencesGroup join_link_group {
+          margin-top: 12;
+
+          Adw.EntryRow join_link_row {
+            title: _("Join session by code or link");
+
+            [suffix]
+            Gtk.Button join_link_button {
+              icon-name: "go-next-symbolic";
+              valign: center;
+              tooltip-text: _("Join session");
+              styles ["flat"]
+            }
+          }
+        }
+
         Gtk.Box {
           vexpand: true;
         }

--- a/apps/maker-gjs/src/widgets/welcome-view.ts
+++ b/apps/maker-gjs/src/widgets/welcome-view.ts
@@ -2,6 +2,8 @@ import Adw from '@girs/adw-1'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
 import { MapPreview, ProjectHeroIcon, SignalScope } from '@pixelrpg/gjs'
+import type { DiscoveredService } from '../services/lan-discovery-parse.ts'
+import { parsePixelrpgUrl } from '../services/pixelrpg-url.ts'
 import type { RecentProject } from '../services/recent-projects.ts'
 import { STARTER_TEMPLATES } from '../services/templates.ts'
 
@@ -34,8 +36,14 @@ export class WelcomeView extends Adw.Bin {
   declare _templates_grid: Gtk.FlowBox
   declare _recents_list: Gtk.ListBox
   declare _empty_recents_row: Adw.ActionRow
+  declare _sessions_list: Gtk.ListBox
+  declare _empty_sessions_row: Adw.ActionRow
+  declare _join_link_row: Adw.EntryRow
+  declare _join_link_button: Gtk.Button
 
   private _recentRows: Gtk.Widget[] = []
+  /** `name` → row, so `service-gone` events can remove the right entry. */
+  private _sessionRows = new Map<string, Gtk.ListBoxRow>()
   private _inspectorCollapsed = false
   private _showInspector = false
 
@@ -55,6 +63,10 @@ export class WelcomeView extends Adw.Bin {
           'templates_grid',
           'recents_list',
           'empty_recents_row',
+          'sessions_list',
+          'empty_sessions_row',
+          'join_link_row',
+          'join_link_button',
         ],
         Properties: {
           // Mirror SceneEditorView + AtlasView so the same
@@ -82,6 +94,15 @@ export class WelcomeView extends Adw.Bin {
           'take-tour': {},
           'template-selected': { param_types: [GObject.TYPE_STRING] },
           'recent-selected': { param_types: [GObject.TYPE_STRING] },
+          // Emitted when the user picks a discovered LAN session.
+          // Param: the same `DiscoveredService` shape the session
+          // bus delivered — `SessionService.joinLan(service)` reads
+          // every field straight off it.
+          'session-selected': { param_types: [GObject.TYPE_JSOBJECT] },
+          // Emitted when the user submits the paste-link / room-code
+          // entry. Param is the room id extracted from either a bare
+          // code or a `pixelrpg://join/<roomid>` URL.
+          'join-by-code': { param_types: [GObject.TYPE_STRING] },
         },
       },
       WelcomeView,
@@ -119,6 +140,9 @@ export class WelcomeView extends Adw.Bin {
     this.signals.connect(this._open_button, 'clicked', () => this.emit('open-project'))
     this.signals.connect(this._browse_button, 'clicked', () => this.emit('browse-projects'))
     this.signals.connect(this._tour_button, 'clicked', () => this.emit('take-tour'))
+    this.signals.connect(this._join_link_button, 'clicked', () => this._submitJoinLink())
+    // Pressing Enter in the entry submits — same path as the button.
+    this.signals.connect(this._join_link_row, 'entry-activated', () => this._submitJoinLink())
   }
 
   vfunc_unmap(): void {
@@ -153,6 +177,70 @@ export class WelcomeView extends Adw.Bin {
       this._recents_list.append(row)
       this._recentRows.push(row)
     }
+  }
+
+  /**
+   * Add a row to the "Sessions on this network" list. Idempotent —
+   * a second call with the same `service.name` updates the existing
+   * row instead of duplicating it (Avahi can re-resolve a service
+   * if its TXT or address changes mid-session).
+   */
+  addDiscoveredService(service: DiscoveredService): void {
+    const existing = this._sessionRows.get(service.name)
+    if (existing) this._sessions_list.remove(existing)
+
+    this._empty_sessions_row.set_visible(false)
+
+    const peerCount = service.txt.peers ?? '–'
+    const projectLabel = service.txt.project ?? service.name
+    const hostLabel = service.txt.host ?? service.host
+    const action = new Adw.ActionRow({
+      title: projectLabel,
+      subtitle: `${hostLabel} · ${peerCount}`,
+      activatable: true,
+    })
+    action.add_prefix(new Gtk.Image({ icon_name: 'network-workgroup-symbolic', pixel_size: 22 }))
+    action.add_suffix(new Gtk.Image({ icon_name: 'go-next-symbolic', pixel_size: 12 }))
+    action.connect('activated', () => this.emit('session-selected', service))
+    this._sessions_list.append(action)
+
+    // Adw.ActionRow wraps itself in a Gtk.ListBoxRow when appended
+    // to a list; grab the wrapper so service-gone can remove it.
+    const wrapper = action.get_parent()
+    if (wrapper instanceof Gtk.ListBoxRow) this._sessionRows.set(service.name, wrapper)
+  }
+
+  /** Remove a row previously added via {@link addDiscoveredService}. */
+  removeDiscoveredService(serviceName: string): void {
+    const wrapper = this._sessionRows.get(serviceName)
+    if (!wrapper) return
+    this._sessions_list.remove(wrapper)
+    this._sessionRows.delete(serviceName)
+    if (this._sessionRows.size === 0) this._empty_sessions_row.set_visible(true)
+  }
+
+  /** Drop every discovered row — host typically calls this on stopBrowsing. */
+  clearDiscoveredServices(): void {
+    for (const row of this._sessionRows.values()) this._sessions_list.remove(row)
+    this._sessionRows.clear()
+    this._empty_sessions_row.set_visible(true)
+  }
+
+  /**
+   * Read the paste-link entry, normalise (`pixelrpg://join/<roomid>`
+   * URL or bare room id), and emit `join-by-code` with the room id.
+   * No-op + clears the entry on invalid input — the field's
+   * "subtitle" position is reserved for the future error message.
+   */
+  private _submitJoinLink(): void {
+    const raw = this._join_link_row.get_text().trim()
+    if (!raw) return
+    // Either a full pixelrpg:// URL or a bare room id token.
+    const intent = parsePixelrpgUrl(raw)
+    const roomId = intent?.kind === 'join' ? intent.roomId : raw.replace(/^\W+|\W+$/g, '')
+    if (!/^[A-Za-z0-9_-]{1,64}$/.test(roomId)) return
+    this._join_link_row.set_text('')
+    this.emit('join-by-code', roomId)
   }
 
   private _buildTemplateGrid(): void {


### PR DESCRIPTION
## Summary

Surface the existing `SessionService` + `LanSessionBackend` through the Welcome view so makers can SEE discovered LAN sessions and have an entry path for paste-link / room-code joining.

This completes the **UI integration half of Phase 3e** in the collaboration roadmap (`docs/concepts/collaboration-and-multiplayer.md`). The underlying join action waits on the engine being available — it blocks with a clear toast until the GJS `Engine` widget grows `executeCommand` / `applyRemoteCommand` proxy methods (tracked as a separate follow-up).

### What changed

- **`welcome-view.blp`** — adds a *Sessions on this network* section below recents (`Adw.ListBox sessions_list` with `empty_sessions_row` placeholder), plus an `Adw.PreferencesGroup join_link_group` containing an `Adw.EntryRow join_link_row` for paste-link / room-code with a suffix arrow button.
- **`welcome-view.ts`** — adds InternalChildren, two GObject signals (`session-selected (DiscoveredService)`, `join-by-code (roomId)`), and the methods `addDiscoveredService` (idempotent row create/update), `removeDiscoveredService` (symmetric remove + empty-state toggle), `clearDiscoveredServices`, and `_submitJoinLink` (normalises `pixelrpg://join/<roomid>` URL OR bare token, validates, then emits `join-by-code`).
- **`session-service.ts`** — constructor signature flips from `engine: Engine` to `engineProvider: () => Engine | null`, so `SessionService` can be constructed before any project is loaded. Discovery flows now work immediately; join flows reject with a typed error until the engine resolves.
- **`application-window.ts`** — wires one `SessionService` + `LanSessionBackend` per window, drives `WelcomeView` from `service-discovered` / `service-gone` / `error` events, routes welcome's `session-selected` → `SessionService.joinLan` and `join-by-code` → `SessionService.joinByRoomId`. Browsing is gated on the Welcome page being visible (`stack.visible-child-name`) so the mDNS ping cycle does not burn while the user is editing.
- **`lan-discovery.ts`** — drops `GLib.SIGINT` (not exposed on the @girs typings) and hard-codes SIGINT=2 since `avahi-publish-service` documents that signal for graceful shutdown.
- **`lan-signalling.ts`** — narrows `wss.address()` against the `string` (AF_UNIX) case before reading `.port`.

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify foreach build -v -t` clean
- [x] `gjsify workspace @pixelrpg/maker-gjs test` 64/64 green on both `gjs` and `node` runtimes
- [x] Manual: launch maker → Welcome shows "No sessions found" placeholder
- [x] Manual: publish a session from a second machine → row appears, clicking activates the toast path with "Open a project before joining a session." (expected — engine proxy methods land separately)
- [ ] CI passes on PR