### PR TITLE
refactor(maker): drop SessionService engine-cast — unwrap widget.excalibur

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -202,14 +202,13 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       )
     }
     if (!this._sessionSvc) {
-      // The `@pixelrpg/gjs` Engine widget proxies the core Engine
-      // but doesn't expose `executeCommand` / `applyRemoteCommand`
-      // yet. Once the widget grows those (planned alongside the
-      // op-broadcast UI wiring), this cast disappears. For now
-      // discovery flows (browse / share) work fine because they
-      // don't touch the engine; the join path will throw a typed
-      // error until the proxy methods exist.
-      const engineProvider = () => (this._engineCtl.engine ?? null) as unknown as import('@pixelrpg/engine').Engine | null
+      // Resolve the core `@pixelrpg/engine` instance through the GJS
+      // Engine widget — `widget.excalibur` is the same Engine class
+      // (`executeCommand` / `applyRemoteCommand` / op-log etc.) that
+      // CollabSession expects, so this is just an unwrap, not a
+      // cross-API cast. Returns `null` until a project is loaded;
+      // discovery flows work regardless.
+      const engineProvider = () => this._engineCtl.engine?.excalibur ?? null
       this._sessionSvc = new SessionService(engineProvider, new LanSessionBackend(), generatePeerId())
     }
 


### PR DESCRIPTION
## Summary

The `SessionService` construction in `ApplicationWindow` was casting the `@pixelrpg/gjs` Engine widget to the core `@pixelrpg/engine` Engine type with a fat comment explaining the cast was temporary *until the widget grows `executeCommand` / `applyRemoteCommand` proxies*. That refactor is unnecessary: the GJS Engine widget already exposes the core Engine instance directly through its `excalibur` getter (named for historical reasons — `_excalibur` is the `@pixelrpg/engine` `Engine` class, which itself wraps the Excalibur engine).

Unwrapping at the `engineProvider` site is the smaller, type-safe fix:

```ts
const engineProvider = () => this._engineCtl.engine?.excalibur ?? null
```

The cast disappears. `CollabSession` receives the very `Engine` the core sync layer was designed to drive, with `executeCommand` / `applyRemoteCommand` already in place. No widget-side proxy work needed.

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify foreach build -v -t` clean
- [x] `gjsify workspace @pixelrpg/maker-gjs test` still green
- [x] Manual: hand-tested join path — `CollabSession.start()` now wires through (project loaded + room joined → ops apply)
- [ ] CI passes on PR