### PR TITLE
feat(maker): wire AwarenessManager into CollabSession (Phase 5 stack 2/3)

### DIFF
--- a/apps/maker-gjs/src/services/collab-session.ts
+++ b/apps/maker-gjs/src/services/collab-session.ts
@@ -1,5 +1,5 @@
-import type { Engine, SignallingTransport } from '@pixelrpg/engine'
-import { PeerSession, type PeerRole, SessionController } from '@pixelrpg/engine'
+import type { AwarenessPeerInfo, Engine, SignallingTransport } from '@pixelrpg/engine'
+import { AwarenessManager, PeerSession, type PeerRole, SessionController } from '@pixelrpg/engine'
 
 export interface CollabSessionOptions {
   engine: Engine
@@ -7,6 +7,13 @@ export interface CollabSessionOptions {
   signalling: SignallingTransport
   /** Stable id for this peer — stamped onto every emitted Operation. */
   peerId: string
+  /**
+   * Display info broadcast on session start so the peer's UI can
+   * render our cursor + name. Default colours are picked from the
+   * Adwaita accent palette so peers without explicit config still
+   * land on a recognisable hue.
+   */
+  localInfo?: AwarenessPeerInfo
 }
 
 /**
@@ -28,7 +35,9 @@ export interface CollabSessionOptions {
 export class CollabSession {
   public readonly peer: PeerSession
   public readonly controller: SessionController
+  public readonly awareness: AwarenessManager
   private closed = false
+  private awarenessUnsubscribe: (() => void) | null = null
 
   constructor(opts: CollabSessionOptions) {
     this.peer = new PeerSession({
@@ -40,21 +49,69 @@ export class CollabSession {
       session: this.peer,
       peerId: opts.peerId,
     })
+    // Default display info — caller can override via `localInfo`.
+    // The placeholder colour matches the Adwaita "blue-3" accent so
+    // a default-styled peer still sits cleanly on either the light
+    // or dark scratchpad backdrop.
+    const localInfo: AwarenessPeerInfo = opts.localInfo ?? {
+      displayName: opts.peerId,
+      color: '#1c71d8',
+    }
+    this.awareness = new AwarenessManager({
+      localPeerId: opts.peerId,
+      localInfo,
+      send: (message) => this.peer.sendAwareness(message),
+    })
+    // Inbound awareness frames arrive via the unreliable channel and
+    // are dispatched through the typed peer-events bus.
+    const dispose = this.peer.events.on('awareness-received', ({ data }) => {
+      this.awareness.handleInbound(data)
+    })
+    this.awarenessUnsubscribe = () => dispose.close()
   }
 
   /**
    * Drive the WebRTC handshake. Resolves once ICE gathering kicks
    * off; full "connected" status lands on `peer.events('state-
    * changed')`.
+   *
+   * Once `connected`, an initial `presence` frame goes out so the
+   * remote peer's roster + cursor UI populate immediately. Repeat
+   * announces are cheap — the receiver dedupes by comparing against
+   * its tracked state.
    */
   async start(): Promise<void> {
     await this.peer.connect()
+    const announceOnConnect = this.peer.events.on('state-changed', ({ state }) => {
+      if (state === 'connected') this.awareness.announce()
+    })
+    // If we already raced past `connecting`, fire once immediately so
+    // late wires don't lose the first presence frame.
+    if (this.peer.getState() === 'connected') this.awareness.announce()
+    // The handle is dropped on close — wrap the existing tear-down so
+    // we don't leak the listener if connect() resolved before any
+    // state transition fired.
+    const prevUnsub = this.awarenessUnsubscribe
+    this.awarenessUnsubscribe = () => {
+      announceOnConnect.close()
+      prevUnsub?.()
+    }
   }
 
   /** Tear down. Idempotent. */
   close(reason = 'closed'): void {
     if (this.closed) return
     this.closed = true
+    // Best-effort leave — if the channel is still open the peer
+    // drops our cursor immediately; otherwise PeerSession's 'closed'
+    // event is the fallback.
+    try {
+      this.awareness.leave()
+    } catch {
+      /* channel may already be torn down */
+    }
+    this.awarenessUnsubscribe?.()
+    this.awarenessUnsubscribe = null
     this.controller.close()
     this.peer.close(reason)
   }


### PR DESCRIPTION
## Summary

**Stacked on #91.** Connects the application-layer `AwarenessManager` (introduced in #91) to the existing `PeerSession` unreliable channel so engine + UI code can drive cursor / selection / presence updates through the session object without touching the WebRTC plumbing.

### Files

**`apps/maker-gjs/src/services/collab-session.ts`**:

- `CollabSessionOptions.localInfo?` — optional display-name + colour. Defaults to `{ displayName: peerId, color: '#1c71d8' }` (Adwaita `blue-3` accent — sits cleanly on either backdrop).
- `public readonly awareness: AwarenessManager` — constructed once per session, wired bidirectionally:
  - outbound: `awareness.send → peer.sendAwareness`
  - inbound: `peer.events.on('awareness-received') → awareness.handleInbound`
- On `start()`: subscribes to `state-changed`; sends initial `presence` frame the moment `state === 'connected'` so the remote peer's roster + cursor UI populate immediately. If we already raced past `connected` between `peer.connect()` returning and the listener attaching, fire once synchronously so the first announce is never dropped.
- On `close()`: best-effort `awareness.leave()` so the remote drops our cursor without waiting for the channel timeout; both subscriptions disposed via the existing `awarenessUnsubscribe` slot.

### Behaviour impact

Wiring-only. No consumer calls `session.awareness.sendCursor` yet, so behaviour is identical to v1 except a `presence` frame goes out on connect (silently absorbed by peers that don't render awareness yet).

### Stacked next (separate PR)

- **Stack 3/3**: engine-side cursor source — translate Excalibur pointer events into `AwarenessManager.sendCursor`, and GTK rendering — small coloured dot + name label per remote peer via the engine widget overlay.

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify foreach build -v -t` clean
- [x] `gjsify workspace @pixelrpg/maker-gjs test` 69/69 green on both runtimes
- [x] `gjsify workspace @pixelrpg/engine test` 166/166 still green (includes 16 awareness specs from #91)
- [ ] CI passes on PR (after #91 lands)