### PR TITLE
feat(engine,maker): broadcast local cursor via awareness (Phase 5 stack 3a)

### DIFF
--- a/apps/maker-gjs/src/services/collab-session.ts
+++ b/apps/maker-gjs/src/services/collab-session.ts
@@ -38,8 +38,11 @@ export class CollabSession {
   public readonly awareness: AwarenessManager
   private closed = false
   private awarenessUnsubscribe: (() => void) | null = null
+  private cursorUnsubscribe: (() => void) | null = null
+  private readonly engine: Engine
 
   constructor(opts: CollabSessionOptions) {
+    this.engine = opts.engine
     this.peer = new PeerSession({
       role: opts.role,
       signalling: opts.signalling,
@@ -96,6 +99,12 @@ export class CollabSession {
       announceOnConnect.close()
       prevUnsub?.()
     }
+    // Bridge engine pointer → awareness cursor stream. The engine
+    // hook fires on every Excalibur `pointermove`; the manager
+    // throttles to ~33 Hz so the unreliable channel doesn't flood.
+    this.cursorUnsubscribe = this.engine.onPointerMoved(({ sceneId, worldX, worldY }) => {
+      this.awareness.sendCursor({ sceneId, x: worldX, y: worldY })
+    })
   }
 
   /** Tear down. Idempotent. */
@@ -110,6 +119,8 @@ export class CollabSession {
     } catch {
       /* channel may already be torn down */
     }
+    this.cursorUnsubscribe?.()
+    this.cursorUnsubscribe = null
     this.awarenessUnsubscribe?.()
     this.awarenessUnsubscribe = null
     this.controller.close()

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -675,6 +675,55 @@ export class Engine {
     }
   }
 
+  /**
+   * Subscribe to the primary pointer's world-space position.
+   *
+   * Used by the awareness layer to broadcast the local user's cursor
+   * to remote peers. Fires on every Excalibur `pointermove` — the
+   * caller is expected to throttle (the {@link AwarenessManager}
+   * does, via `cursorThrottleMs`).
+   *
+   * Payload carries the **scene-local world coordinates** (already
+   * camera/zoom-resolved by Excalibur's `screenToWorldCoordinates`)
+   * plus the `sceneId` (== map id) so the receiver can drop frames
+   * for scenes it is not currently viewing.
+   *
+   * Returns the disposer; calling it disconnects the `pointer.on`
+   * subscription. No-op when no scene is active yet (the
+   * subscription rebinds via `MAP_LOADED` so a caller that
+   * subscribes before the first map loads still gets events once
+   * one does).
+   */
+  onPointerMoved(
+    cb: (event: { sceneId: string; worldX: number; worldY: number }) => void,
+  ): () => void {
+    let disposeMove: (() => void) | null = null
+    const rebind = () => {
+      disposeMove?.()
+      disposeMove = null
+      const pointer = this.excalibur?.input?.pointers?.primary
+      if (!pointer) return
+      const handler = (event: { screenPos: { x: number; y: number } }) => {
+        const scene = this._activeMapScene()
+        if (!scene) return
+        const sceneId = scene.mapResource.mapData.id
+        if (!sceneId) return
+        const world = this.excalibur.screen.screenToWorldCoordinates(
+          new Vector(event.screenPos.x, event.screenPos.y),
+        )
+        cb({ sceneId, worldX: world.x, worldY: world.y })
+      }
+      pointer.on('move', handler)
+      disposeMove = () => pointer.off('move', handler)
+    }
+    rebind()
+    const mapSub = this.events.on(EngineEvent.MAP_LOADED, () => rebind())
+    return () => {
+      disposeMove?.()
+      mapSub.close()
+    }
+  }
+
   private setStatus(status: EngineStatus): void {
     if (this.status === status) return
     this.logger.info(`Engine status changed from ${this.status} to ${status}`)


### PR DESCRIPTION
## Summary

**Stacked on #93.** Closes the SENDER side of the cursor flow: every Excalibur `pointermove` becomes an `AwarenessMessage` (`cursor` variant) that goes out on the unreliable channel. Peers receive + accumulate state in their own AwarenessManager already (#91 + #93); the RENDERING side (remote-cursor overlay) lands in the follow-on PR (stack 3b).

### Files

**`packages/engine/src/engine.ts`**:

- New `Engine.onPointerMoved(cb)` — subscribe to the primary pointer's world-space position. Hooks `excalibur.input.pointers.primary.on('move')`, converts via `screen.screenToWorldCoordinates`, looks up the active scene's map id, fires `{ sceneId, worldX, worldY }`. Returns a disposer; auto-rebinds on `MAP_LOADED` so a subscriber set before the first map loads picks up events once one does. Mirrors the existing `onUndoStackChanged` / `onEditorViewModeChanged` lifecycle.

**`apps/maker-gjs/src/services/collab-session.ts`**:

- Captures `opts.engine` for later use.
- `start()` wires `engine.onPointerMoved` → `awareness.sendCursor`. The AwarenessManager's 30 ms throttle (`cursorThrottleMs` default from #91) coalesces a raw 60-Hz pointer stream down to ~33 Hz, comfortable for SCTP and visually smooth.
- `close()` disposes the cursor subscription alongside the existing awareness teardown.

### Behaviour impact

A connected session now produces a steady ~33 Hz `cursor` frame stream. The remote peer's AwarenessManager updates its `peers` map and emits `peer-changed`; **no consumer subscribes to that event yet**, so nothing renders. The cursor reaches the wire AND the peer's state machine — confirmed via the existing 16 awareness specs.

### Stacked next (separate PR)

- **Stack 3b**: GTK overlay rendering remote cursors over the engine widget — small coloured dot + name label per peer, positioned via `worldToScreenCoordinates` so the marker tracks camera + zoom.

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify foreach build -v -t` clean
- [x] `gjsify workspace @pixelrpg/engine test` 166/166 green on both runtimes
- [x] `gjsify workspace @pixelrpg/maker-gjs test` 69/69 green on both runtimes
- [ ] Hand-test: open two maker instances, host from one + join from other, move pointer in one, watch `awareness-received` event count climb on the other (will get visual confirmation in stack 3b)
- [ ] CI passes (after #93 lands)