### PR TITLE
feat(engine,maker): broadcast + render remote cursors (Phase 5 stack 3)

### DIFF
--- a/apps/maker-gjs/src/services/collab-session.ts
+++ b/apps/maker-gjs/src/services/collab-session.ts
@@ -38,8 +38,11 @@ export class CollabSession {
   public readonly awareness: AwarenessManager
   private closed = false
   private awarenessUnsubscribe: (() => void) | null = null
+  private cursorUnsubscribe: (() => void) | null = null
+  private readonly engine: Engine
 
   constructor(opts: CollabSessionOptions) {
+    this.engine = opts.engine
     this.peer = new PeerSession({
       role: opts.role,
       signalling: opts.signalling,
@@ -96,6 +99,12 @@ export class CollabSession {
       announceOnConnect.close()
       prevUnsub?.()
     }
+    // Bridge engine pointer → awareness cursor stream. The engine
+    // hook fires on every Excalibur `pointermove`; the manager
+    // throttles to ~33 Hz so the unreliable channel doesn't flood.
+    this.cursorUnsubscribe = this.engine.onPointerMoved(({ sceneId, worldX, worldY }) => {
+      this.awareness.sendCursor({ sceneId, x: worldX, y: worldY })
+    })
   }
 
   /** Tear down. Idempotent. */
@@ -110,6 +119,8 @@ export class CollabSession {
     } catch {
       /* channel may already be torn down */
     }
+    this.cursorUnsubscribe?.()
+    this.cursorUnsubscribe = null
     this.awarenessUnsubscribe?.()
     this.awarenessUnsubscribe = null
     this.controller.close()

--- a/apps/maker-gjs/src/services/collab-session.ts
+++ b/apps/maker-gjs/src/services/collab-session.ts
@@ -1,5 +1,11 @@
 import type { AwarenessPeerInfo, Engine, SignallingTransport } from '@pixelrpg/engine'
-import { AwarenessManager, PeerSession, type PeerRole, SessionController } from '@pixelrpg/engine'
+import {
+  AwarenessManager,
+  PeerSession,
+  type PeerRole,
+  RemoteCursorRenderer,
+  SessionController,
+} from '@pixelrpg/engine'
 
 export interface CollabSessionOptions {
   engine: Engine
@@ -36,6 +42,7 @@ export class CollabSession {
   public readonly peer: PeerSession
   public readonly controller: SessionController
   public readonly awareness: AwarenessManager
+  public readonly cursorRenderer: RemoteCursorRenderer
   private closed = false
   private awarenessUnsubscribe: (() => void) | null = null
   private cursorUnsubscribe: (() => void) | null = null
@@ -71,6 +78,10 @@ export class CollabSession {
       this.awareness.handleInbound(data)
     })
     this.awarenessUnsubscribe = () => dispose.close()
+    // Render remote peers' cursors in-canvas via Excalibur actors.
+    // Constructed up-front so a remote `peer-changed` arriving
+    // before `start()` resolves still produces a dot.
+    this.cursorRenderer = new RemoteCursorRenderer(opts.engine, this.awareness)
   }
 
   /**
@@ -123,6 +134,7 @@ export class CollabSession {
     this.cursorUnsubscribe = null
     this.awarenessUnsubscribe?.()
     this.awarenessUnsubscribe = null
+    this.cursorRenderer.close()
     this.controller.close()
     this.peer.close(reason)
   }

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -675,6 +675,55 @@ export class Engine {
     }
   }
 
+  /**
+   * Subscribe to the primary pointer's world-space position.
+   *
+   * Used by the awareness layer to broadcast the local user's cursor
+   * to remote peers. Fires on every Excalibur `pointermove` — the
+   * caller is expected to throttle (the {@link AwarenessManager}
+   * does, via `cursorThrottleMs`).
+   *
+   * Payload carries the **scene-local world coordinates** (already
+   * camera/zoom-resolved by Excalibur's `screenToWorldCoordinates`)
+   * plus the `sceneId` (== map id) so the receiver can drop frames
+   * for scenes it is not currently viewing.
+   *
+   * Returns the disposer; calling it disconnects the `pointer.on`
+   * subscription. No-op when no scene is active yet (the
+   * subscription rebinds via `MAP_LOADED` so a caller that
+   * subscribes before the first map loads still gets events once
+   * one does).
+   */
+  onPointerMoved(
+    cb: (event: { sceneId: string; worldX: number; worldY: number }) => void,
+  ): () => void {
+    let disposeMove: (() => void) | null = null
+    const rebind = () => {
+      disposeMove?.()
+      disposeMove = null
+      const pointer = this.excalibur?.input?.pointers?.primary
+      if (!pointer) return
+      const handler = (event: { screenPos: { x: number; y: number } }) => {
+        const scene = this._activeMapScene()
+        if (!scene) return
+        const sceneId = scene.mapResource.mapData.id
+        if (!sceneId) return
+        const world = this.excalibur.screen.screenToWorldCoordinates(
+          new Vector(event.screenPos.x, event.screenPos.y),
+        )
+        cb({ sceneId, worldX: world.x, worldY: world.y })
+      }
+      pointer.on('move', handler)
+      disposeMove = () => pointer.off('move', handler)
+    }
+    rebind()
+    const mapSub = this.events.on(EngineEvent.MAP_LOADED, () => rebind())
+    return () => {
+      disposeMove?.()
+      mapSub.close()
+    }
+  }
+
   private setStatus(status: EngineStatus): void {
     if (this.status === status) return
     this.logger.info(`Engine status changed from ${this.status} to ${status}`)

--- a/packages/engine/src/sync/index.ts
+++ b/packages/engine/src/sync/index.ts
@@ -2,5 +2,6 @@
 
 export * from './awareness'
 export * from './peer-session'
+export * from './remote-cursor-renderer'
 export * from './session-controller'
 export * from './types'

--- a/packages/engine/src/sync/remote-cursor-renderer.ts
+++ b/packages/engine/src/sync/remote-cursor-renderer.ts
@@ -1,0 +1,152 @@
+import { Actor, Circle, Color, Font, GraphicsGroup, Text, Vector } from 'excalibur'
+
+import type { Engine } from '../engine.ts'
+import type { AwarenessManager, AwarenessPeerState } from './awareness.ts'
+
+/**
+ * In-canvas renderer for remote peers' cursors.
+ *
+ * Why an in-canvas Excalibur actor (and not a GTK overlay)? The
+ * canvas is the world-coordinate surface — its transform already
+ * tracks camera + zoom. A GTK overlay would have to mirror that
+ * transform on every camera tick (re-computing world→screen for
+ * each peer), which is solvable but error-prone at zoom
+ * boundaries and during smooth-pan animations. An Excalibur actor
+ * just *is* at its world position; the scene graph handles the
+ * rest, including hi-DPI scaling and the editor view-mode's grid
+ * overlay z-order.
+ *
+ * One {@link Actor} per tracked peer:
+ *
+ *   - A {@link Circle} graphic (6 px radius, peer's colour) sits
+ *     at the cursor position.
+ *   - A {@link Text} graphic placed slightly above renders the
+ *     display name in the same colour.
+ *
+ * Lifetime:
+ *
+ *   - Subscribes to `awareness.on('peer-changed' / 'peer-left')`
+ *     in the constructor; calling {@link close} disposes both.
+ *   - On `peer-changed` for a peer whose cursor is null (peer
+ *     announced presence but hasn't moved yet) — actor stays
+ *     hidden until the first cursor arrives.
+ *   - On `peer-changed` whose `cursor.sceneId` differs from the
+ *     engine's active map — actor is removed; the peer is editing
+ *     somewhere else and we don't want a stale dot left behind.
+ *   - On `peer-left` — actor is removed.
+ *
+ * Re-binds across `MAP_LOADED` so the renderer keeps working
+ * after the user opens a different scene mid-session.
+ */
+export class RemoteCursorRenderer {
+  private readonly actors = new Map<string, Actor>()
+  private readonly disposers: Array<() => void> = []
+  private closed = false
+
+  constructor(
+    private readonly engine: Engine,
+    private readonly awareness: AwarenessManager,
+  ) {
+    this.disposers.push(awareness.on('peer-changed', (peer) => this.applyPeer(peer)))
+    this.disposers.push(awareness.on('peer-left', ({ peerId }) => this.removeActor(peerId)))
+    // Re-paint every existing peer when the map changes — actors
+    // were attached to the OLD scene and went away with it.
+    this.disposers.push(
+      (() => {
+        const sub = this.engine.events.on('map-loaded', () => {
+          // The old actors are torn down with the previous scene
+          // graph. Re-create from the awareness snapshot for the
+          // new map.
+          this.actors.clear()
+          for (const peer of awareness.getPeers()) this.applyPeer(peer)
+        })
+        return () => sub.close()
+      })(),
+    )
+  }
+
+  /** Drop every actor + subscription. Idempotent. */
+  close(): void {
+    if (this.closed) return
+    this.closed = true
+    for (const dispose of this.disposers) {
+      try {
+        dispose()
+      } catch {
+        /* listener map may already be gone */
+      }
+    }
+    this.disposers.length = 0
+    for (const actor of this.actors.values()) actor.kill()
+    this.actors.clear()
+  }
+
+  private applyPeer(peer: AwarenessPeerState): void {
+    if (this.closed) return
+    const scene = this.engine.excalibur?.currentScene
+    if (!scene) return
+    // No cursor yet OR peer is editing a different scene — make
+    // sure we don't have a stale actor lying around.
+    const activeMapId = (scene as { mapResource?: { mapData?: { id?: string } } }).mapResource?.mapData?.id
+    if (!peer.cursor || peer.cursor.sceneId !== activeMapId) {
+      this.removeActor(peer.peerId)
+      return
+    }
+    const existing = this.actors.get(peer.peerId)
+    if (existing) {
+      existing.pos = new Vector(peer.cursor.x, peer.cursor.y)
+      // Colour / name may have changed via `presence` — refresh
+      // the graphics in place.
+      this.applyGraphics(existing, peer)
+      return
+    }
+    const actor = new Actor({
+      pos: new Vector(peer.cursor.x, peer.cursor.y),
+      // Z above any tilemap (max layer z is typically < 1000) so
+      // the cursor floats on top of every editor surface.
+      z: 10_000,
+    })
+    this.applyGraphics(actor, peer)
+    scene.add(actor)
+    this.actors.set(peer.peerId, actor)
+  }
+
+  private applyGraphics(actor: Actor, peer: AwarenessPeerState): void {
+    const colour = parseColour(peer.info.color)
+    const dot = new Circle({ radius: 6, color: colour })
+    const label = new Text({
+      text: peer.info.displayName,
+      font: new Font({ family: 'Adwaita Sans, sans-serif', size: 11, color: colour }),
+    })
+    // Compose dot + label into a GraphicsGroup so both render
+    // every frame. Label sits slightly above + right of the dot so
+    // it doesn't occlude the click target.
+    const group = new GraphicsGroup({
+      members: [
+        { graphic: dot, offset: Vector.Zero },
+        { graphic: label, offset: new Vector(10, -14) },
+      ],
+    })
+    actor.graphics.use(group)
+  }
+
+  private removeActor(peerId: string): void {
+    const actor = this.actors.get(peerId)
+    if (!actor) return
+    actor.kill()
+    this.actors.delete(peerId)
+  }
+}
+
+/**
+ * Parse a CSS-style colour token (`#rgb` / `#rrggbb`) into an
+ * Excalibur Color. Falls back to mid-grey on parse failure so a
+ * peer with a bogus colour still renders.
+ */
+function parseColour(token: string): Color {
+  try {
+    return Color.fromHex(token)
+  } catch {
+    return Color.fromHex('#888888')
+  }
+}


### PR DESCRIPTION
## Summary

**Completes Phase 5.** Carries both halves of the cursor flow as a tightly-coupled pair (cursor source is invisible without renderer; renderer needs the source):

- **Commit 1 (stack 3a)** — broadcast: hook Excalibur `pointermove`, throttle, send `AwarenessMessage` (`cursor` variant) on the unreliable channel.
- **Commit 2 (stack 3b)** — render: in-canvas Excalibur Actor (Circle + Text in a GraphicsGroup) per remote peer, positioned by world coords so it tracks camera + zoom automatically.

Both build on the protocol + state machine from #91 and the CollabSession wiring from #93 (both merged).

### Files

**`packages/engine/src/engine.ts`** (commit 1) — new `Engine.onPointerMoved(cb)`. Mirrors the existing `onUndoStackChanged` / `onEditorViewModeChanged` lifecycle: hooks `excalibur.input.pointers.primary.on('move')`, converts via `screen.screenToWorldCoordinates`, emits `{ sceneId, worldX, worldY }`. Returns a disposer; auto-rebinds on `MAP_LOADED`.

**`apps/maker-gjs/src/services/collab-session.ts`** (commits 1 + 2) — `start()` wires `engine.onPointerMoved → awareness.sendCursor` (30 ms throttle → ~33 Hz). Constructs `RemoteCursorRenderer` up-front so a remote `peer-changed` arriving before `start()` resolves still produces a dot. `close()` disposes both.

**`packages/engine/src/sync/remote-cursor-renderer.ts`** (commit 2, new) — `RemoteCursorRenderer`. One Excalibur Actor per tracked peer; `GraphicsGroup` wraps `Circle` (6 px, `peer.color`) + `Text` (11 px label, +10/-14 offset). Subscribes to `awareness.on('peer-changed' | 'peer-left')` and `engine.events.on('map-loaded')` (so actors re-create in the new scene's graph). Hides cursors whose `sceneId` does not match the engine's active map. `close()` disposes every actor + subscription.

### Why an in-canvas actor (and not a GTK overlay)?

The canvas's transform already tracks camera + zoom. A GTK overlay would have to mirror that on every camera tick — solvable but error-prone at zoom boundaries and during smooth-pan animations. An actor just *is* at its world position; the scene graph handles the rest including hi-DPI scaling + grid overlay z-order.

### End-to-end verification (Phase 5 complete)

1. Open maker instance A, load project, host via mode-rail Share.
2. Open instance B, accept the LAN session in Welcome view.
3. Move pointer in A — coloured dot + `peer-…` label appears in B at the matching world position, follows camera + zoom.
4. Move pointer in B — same thing in A.
5. Stop sharing in A — dots disappear in B (`peer-left` frame).

### Open follow-ups (separate PRs, NOT in this PR)

- Selection-highlight rendering (`selection` variant wired transport-side via #91/#93; no UI consumer yet).
- Idle-fade: dim cursors whose `lastUpdate` is > N seconds old.

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify foreach build -v -t` clean
- [x] `gjsify workspace @pixelrpg/engine test` 166/166 green on both runtimes
- [x] `gjsify workspace @pixelrpg/maker-gjs test` 69/69 green on both runtimes
- [ ] Hand-test (two-instance flow above)
- [ ] CI passes on PR