### PR TITLE
feat(maker): register `pixelrpg://` as system URL handler (Phase 6 — final)

### DIFF
--- a/apps/maker-gjs/data/metainfo/org.pixelrpg.maker.metainfo.xml.in
+++ b/apps/maker-gjs/data/metainfo/org.pixelrpg.maker.metainfo.xml.in
@@ -32,6 +32,7 @@
   </kudos>
   <provides>
     <binary>org.pixelrpg.maker</binary>
+    <mediatype>x-scheme-handler/pixelrpg</mediatype>
   </provides>
   <categories>
     <category>Development</category>

--- a/apps/maker-gjs/data/org.pixelrpg.maker.desktop.in
+++ b/apps/maker-gjs/data/org.pixelrpg.maker.desktop.in
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=PixelRPG Maker
+Comment=Experimental tile-based map editor
+Exec=org.pixelrpg.maker %U
+Icon=org.pixelrpg.maker
+Terminal=false
+Type=Application
+Categories=Development;Game;
+MimeType=x-scheme-handler/pixelrpg;
+StartupNotify=true
+StartupWMClass=org.pixelrpg.maker

--- a/apps/maker-gjs/package.json
+++ b/apps/maker-gjs/package.json
@@ -90,7 +90,12 @@
         "Development",
         "Game"
       ],
-      "icon": "data/icons/hicolor/scalable/apps/org.pixelrpg.maker.svg"
+      "icon": "data/icons/hicolor/scalable/apps/org.pixelrpg.maker.svg",
+      "provides": {
+        "mimetypes": [
+          "x-scheme-handler/pixelrpg"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Closes the OS-side of the Pair-Editing URL flow. The maker's `x-scheme-handler/pixelrpg` registration was the remaining piece of Phase 6: with `pixelrpg://join/<roomid>` registered as a system MIME, clicking a join link in a browser or chat client launches the maker via Flatpak's portal, and the existing `HANDLES_COMMAND_LINE` + `vfunc_command_line` plumbing (from PR #87) picks the URL out of `argv` and routes it through the welcome-view's join flow.

### Files

**`apps/maker-gjs/data/org.pixelrpg.maker.desktop.in`** (new) — hand-crafted Desktop Entry. `MimeType=x-scheme-handler/pixelrpg;` + `Exec=org.pixelrpg.maker %U` for URL arg passthrough.

> **Why hand-crafted?** gjsify CLI's `flatpak init` does not yet populate `MimeType=` from `provides.mimetypes` (gjsify#384, merged but not released — will land in v0.4.35). Re-running `gjsify flatpak init --force` after upgrading should produce byte-identical output to this file.

**`apps/maker-gjs/package.json`** — adds `gjsify.flatpak.provides.mimetypes: ["x-scheme-handler/pixelrpg"]`. Already drives the `<mediatype>` entry in the MetaInfo XML (and will drive the `MimeType=` line in the generated .desktop once v0.4.35 ships). Sets up byte-identical regeneration.

**`apps/maker-gjs/data/metainfo/org.pixelrpg.maker.metainfo.xml.in`** — adds `<mediatype>x-scheme-handler/pixelrpg</mediatype>` under `<provides>` — AppStream side of the same registration. Required so Flathub validates the .desktop's MimeType claim (the two surfaces must agree).

### End-to-end verification (after a Flatpak install)

```bash
flatpak install org.pixelrpg.maker
xdg-open 'pixelrpg://join/abc123'
```

→ maker launches, Welcome view's "Join session" surfaces the incoming roomId (the existing #87 wiring handles the rest).

### Open follow-ups (NOT in this PR, tracked separately)

- Bump `@gjsify/cli` to `^0.4.35` once it ships and re-run `gjsify flatpak init --force` so the generated `.desktop` is template-driven again (the gjsify#384 path). Output should be byte-identical to the hand-crafted file here.

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [ ] Hand-test (after Flatpak install): `xdg-open 'pixelrpg://join/abc'` → maker launches with roomId in welcome view
- [ ] CI passes on PR