### PR TITLE
fix(maker): dedup discovered LAN sessions by service name

### DIFF
--- a/apps/maker-gjs/src/widgets/welcome-view.ts
+++ b/apps/maker-gjs/src/widgets/welcome-view.ts
@@ -43,7 +43,7 @@ export class WelcomeView extends Adw.Bin {
 
   private _recentRows: Gtk.Widget[] = []
   /** `name` → row, so `service-gone` events can remove the right entry. */
-  private _sessionRows = new Map<string, Gtk.ListBoxRow>()
+  private _sessionRows = new Map<string, Adw.ActionRow>()
   private _inspectorCollapsed = false
   private _showInspector = false
 
@@ -182,8 +182,12 @@ export class WelcomeView extends Adw.Bin {
   /**
    * Add a row to the "Sessions on this network" list. Idempotent —
    * a second call with the same `service.name` updates the existing
-   * row instead of duplicating it (Avahi can re-resolve a service
-   * if its TXT or address changes mid-session).
+   * row instead of duplicating it.
+   *
+   * Avahi resolves the same service once per network interface ×
+   * protocol (e.g. lo+eth0+wlan0 × IPv4+IPv6), so a single peer
+   * normally fires 3-6 `service-discovered` events with identical
+   * `name`. Dedup-by-name collapses them to a single visible row.
    */
   addDiscoveredService(service: DiscoveredService): void {
     const existing = this._sessionRows.get(service.name)
@@ -204,10 +208,13 @@ export class WelcomeView extends Adw.Bin {
     action.connect('activated', () => this.emit('session-selected', service))
     this._sessions_list.append(action)
 
-    // Adw.ActionRow wraps itself in a Gtk.ListBoxRow when appended
-    // to a list; grab the wrapper so service-gone can remove it.
-    const wrapper = action.get_parent()
-    if (wrapper instanceof Gtk.ListBoxRow) this._sessionRows.set(service.name, wrapper)
+    // Adw.ActionRow IS a Gtk.ListBoxRow (via Adw.PreferencesRow) —
+    // no Gtk.ListBoxRow wrapper is created on append. The earlier
+    // `action.get_parent() instanceof Gtk.ListBoxRow` check returned
+    // false for that reason, so the map never got populated and the
+    // dedup at the top silently failed — every Avahi resolve event
+    // accumulated a fresh row. Store the action directly.
+    this._sessionRows.set(service.name, action)
   }
 
   /** Remove a row previously added via {@link addDiscoveredService}. */


### PR DESCRIPTION
## Summary

Welcome view's "Sessions on this network" pane was listing the same session 3-6 times — once per (network-interface × protocol) pair Avahi resolves the service on (`lo` + `eth0` + `wlan0` × IPv4 + IPv6).

The dedup-by-`service.name` logic was already in `addDiscoveredService`, but the map never got populated:

```ts
// Pre-fix
this._sessions_list.append(action)
const wrapper = action.get_parent()
if (wrapper instanceof Gtk.ListBoxRow) this._sessionRows.set(...)
```

`Adw.ActionRow` extends `Adw.PreferencesRow` extends `Gtk.ListBoxRow`, so `Gtk.ListBox.append(action)` doesn't wrap it in a fresh `Gtk.ListBoxRow` — the action's parent is the ListBox itself. The `instanceof Gtk.ListBoxRow` check returned false, `_sessionRows.set(...)` never ran, every subsequent resolve event found `existing === undefined` and appended a duplicate.

### Fix

Store the action directly. Adw.ActionRow already IS a ListBoxRow, so it's removable from the ListBox without unwrapping. Map's value type widened from `Gtk.ListBoxRow` to `Adw.ActionRow` to reflect what we actually store.

### Regression context

Surfaced in two-instance same-machine testing — the partner's published session showed up 3× in the discovery pane (one per interface × protocol Avahi resolves on).

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify foreach build -v -t` clean
- [x] `gjsify workspace @pixelrpg/maker-gjs test` 69/69 green on both runtimes
- [ ] Hand-test: two-instance same-machine (`dbus-run-session` for instance B), one publishes, the other shows exactly **1** row in the discovery pane
- [ ] CI passes on PR