### PR TITLE
refactor(engine,maker): engine-optional CollabSession + decoupled SnapshotExchange

### DIFF
--- a/apps/maker-gjs/src/services/collab-session.ts
+++ b/apps/maker-gjs/src/services/collab-session.ts
@@ -7,6 +7,7 @@ import type {
 import {
   AwarenessManager,
   captureProjectSnapshot,
+  isSessionProtocolOp,
   PeerSession,
   type PeerRole,
   RemoteCursorRenderer,
@@ -15,7 +16,19 @@ import {
 } from '@pixelrpg/engine'
 
 export interface CollabSessionOptions {
-  engine: Engine
+  /**
+   * Optional — when omitted the session starts in an "engine-
+   * less" state: handshake + awareness work, snapshot requests
+   * work, but op-sync + cursor render don't until
+   * {@link CollabSession.attachEngine} is called. The sandbox
+   * joiner flow uses this: connect first, pull the host's
+   * snapshot, write it to a sandbox directory, load the engine,
+   * THEN attach.
+   *
+   * Host paths always pass it up-front; joiner paths attach
+   * after the sandbox project loads.
+   */
+  engine?: Engine
   role: PeerRole
   signalling: SignallingTransport
   /** Stable id for this peer — stamped onto every emitted Operation. */
@@ -38,12 +51,19 @@ export interface CollabSessionOptions {
 /**
  * Top-level glue holding the active Pair-Editing session together.
  *
- * Owns one `PeerSession` (raw WebRTC + signalling) plus the
- * `SessionController` that bridges it to the local `Engine`. The
- * caller supplies the `SignallingTransport` — `LanHostServer` /
- * `connectLanJoinerTransport` cover LAN today; the cross-internet
- * relay client (Phase 3e) plugs in here without touching the
- * collab class itself.
+ * Owns one `PeerSession` (raw WebRTC + signalling) and lazily
+ * builds the engine-dependent pieces (`SessionController`,
+ * `RemoteCursorRenderer`, engine pointer-source) when an `Engine`
+ * is provided — either via the constructor option or via
+ * {@link attachEngine} after construction.
+ *
+ * Three lifetimes coexist:
+ *
+ *   - **Always**: `PeerSession`, `AwarenessManager`,
+ *     `SnapshotExchange`. These work without an engine.
+ *   - **Once engine attached**: `SessionController` (commands
+ *     in/out), `RemoteCursorRenderer` (paints peers' cursors in
+ *     the canvas), local pointer-source (broadcasts our cursor).
  *
  * Side-effect: the maker's entrypoint (`src/main.ts`) is responsible
  * for importing `@gjsify/webrtc/register` so `globalThis.RTCPeerConnection`
@@ -53,43 +73,26 @@ export interface CollabSessionOptions {
  */
 export class CollabSession {
   public readonly peer: PeerSession
-  public readonly controller: SessionController
   public readonly awareness: AwarenessManager
-  public readonly cursorRenderer: RemoteCursorRenderer
   public readonly snapshotExchange: SnapshotExchange
+  /** Set once {@link attachEngine} runs. `null` in the joiner-pre-snapshot phase. */
+  public controller: SessionController | null = null
+  public cursorRenderer: RemoteCursorRenderer | null = null
   private closed = false
-  private awarenessUnsubscribe: (() => void) | null = null
-  private cursorUnsubscribe: (() => void) | null = null
-  private readonly engine: Engine
+  private engine: Engine | null = null
+  private readonly peerId: string
   private readonly roomId: string
+  private readonly subscriptions: Array<() => void> = []
+  private startedAt: number | null = null
 
   constructor(opts: CollabSessionOptions) {
-    this.engine = opts.engine
+    this.peerId = opts.peerId
     this.roomId = opts.roomId ?? ''
     this.peer = new PeerSession({
       role: opts.role,
       signalling: opts.signalling,
     })
-    this.controller = new SessionController({
-      engine: opts.engine,
-      session: this.peer,
-      peerId: opts.peerId,
-      onSessionProtocol: (op) => this.snapshotExchange.handle(op),
-    })
-    // Snapshot exchange — host responds to joiner requests by
-    // capturing its current project state; joiner uses
-    // `requestSnapshot()` to pull it. Constructed after the
-    // controller so the `onSessionProtocol` hook above resolves
-    // to a fully-initialised exchange by the time the first
-    // protocol message arrives.
-    this.snapshotExchange = new SnapshotExchange({
-      controller: this.controller,
-      // Returns null when the engine hasn't loaded a project yet
-      // (host hasn't opened anything) — the requester sees a
-      // timeout, which the UI surfaces as "host has no project to
-      // share yet".
-      captureSnapshot: () => captureProjectSnapshot(this.engine),
-    })
+
     // Default display info — caller can override via `localInfo`.
     // The placeholder colour matches the Adwaita "blue-3" accent so
     // a default-styled peer still sits cleanly on either the light
@@ -103,16 +106,74 @@ export class CollabSession {
       localInfo,
       send: (message) => this.peer.sendAwareness(message),
     })
-    // Inbound awareness frames arrive via the unreliable channel and
-    // are dispatched through the typed peer-events bus.
-    const dispose = this.peer.events.on('awareness-received', ({ data }) => {
+    // Inbound awareness frames arrive via the unreliable channel.
+    const awarenessSub = this.peer.events.on('awareness-received', ({ data }) => {
       this.awareness.handleInbound(data)
     })
-    this.awarenessUnsubscribe = () => dispose.close()
-    // Render remote peers' cursors in-canvas via Excalibur actors.
-    // Constructed up-front so a remote `peer-changed` arriving
-    // before `start()` resolves still produces a dot.
-    this.cursorRenderer = new RemoteCursorRenderer(opts.engine, this.awareness)
+    this.subscriptions.push(() => awarenessSub.close())
+
+    // Snapshot exchange is engine-independent — uses raw `sendOp`
+    // for the protocol frames + a captureSnapshot closure that
+    // returns null when no engine is attached. CollabSession
+    // routes inbound session-protocol ops here directly (the
+    // command-path filter in SessionController also skips them,
+    // but works even when the controller hasn't been built yet).
+    this.snapshotExchange = new SnapshotExchange({
+      peerId: opts.peerId,
+      send: (op) => this.peer.sendOp(op),
+      captureSnapshot: () => (this.engine ? captureProjectSnapshot(this.engine) : null),
+    })
+    const opSub = this.peer.events.on('op-received', ({ op }) => {
+      if (isSessionProtocolOp(op)) this.snapshotExchange.handle(op)
+    })
+    this.subscriptions.push(() => opSub.close())
+
+    if (opts.engine) this.attachEngine(opts.engine)
+  }
+
+  /**
+   * Wire the engine-dependent layers — command sync via
+   * SessionController, remote-cursor rendering, local cursor
+   * pointer-source. Call EXACTLY once; throws on second attach.
+   *
+   * Typical sandbox-joiner flow:
+   *
+   *   1. `new CollabSession({ engine: undefined, ... })`
+   *   2. `await session.start()`            ← handshake + presence
+   *   3. `await session.requestSnapshot()`  ← pull host's state
+   *   4. write snapshot to sandbox dir; load engine from there
+   *   5. `session.attachEngine(engine)`     ← commands + cursors start flowing
+   *
+   * Host flow remains unchanged: pass `engine` in the constructor;
+   * attach happens implicitly.
+   *
+   * NOTE: ops received between `start()` and `attachEngine()` are
+   * dropped (no command target). For the sandbox window this is
+   * acceptable — the host typically isn't editing while it
+   * services a snapshot request — but a future PR could add a
+   * pre-attach buffer for stricter consistency.
+   */
+  attachEngine(engine: Engine): void {
+    if (this.closed) throw new Error('CollabSession: attachEngine called after close()')
+    if (this.engine) throw new Error('CollabSession: engine already attached')
+    this.engine = engine
+    this.controller = new SessionController({
+      engine,
+      session: this.peer,
+      peerId: this.peerId,
+      // CollabSession already routes session-protocol ops to the
+      // exchange (see `op-received` subscription in the constructor).
+      // SessionController's own filter drops them via the no-hook
+      // path; we deliberately don't double-route through here.
+    })
+    this.cursorRenderer = new RemoteCursorRenderer(engine, this.awareness)
+    // Bridge engine pointer → awareness cursor stream. The engine
+    // hook fires on every Excalibur `pointermove`; the manager
+    // throttles to ~33 Hz so the unreliable channel doesn't flood.
+    const cursorDispose = engine.onPointerMoved(({ sceneId, worldX, worldY }) => {
+      this.awareness.sendCursor({ sceneId, x: worldX, y: worldY })
+    })
+    this.subscriptions.push(() => cursorDispose())
   }
 
   /**
@@ -126,6 +187,7 @@ export class CollabSession {
    * its tracked state.
    */
   async start(): Promise<void> {
+    this.startedAt = Date.now()
     await this.peer.connect()
     const announceOnConnect = this.peer.events.on('state-changed', ({ state }) => {
       if (state === 'connected') this.awareness.announce()
@@ -133,20 +195,7 @@ export class CollabSession {
     // If we already raced past `connecting`, fire once immediately so
     // late wires don't lose the first presence frame.
     if (this.peer.getState() === 'connected') this.awareness.announce()
-    // The handle is dropped on close — wrap the existing tear-down so
-    // we don't leak the listener if connect() resolved before any
-    // state transition fired.
-    const prevUnsub = this.awarenessUnsubscribe
-    this.awarenessUnsubscribe = () => {
-      announceOnConnect.close()
-      prevUnsub?.()
-    }
-    // Bridge engine pointer → awareness cursor stream. The engine
-    // hook fires on every Excalibur `pointermove`; the manager
-    // throttles to ~33 Hz so the unreliable channel doesn't flood.
-    this.cursorUnsubscribe = this.engine.onPointerMoved(({ sceneId, worldX, worldY }) => {
-      this.awareness.sendCursor({ sceneId, x: worldX, y: worldY })
-    })
+    this.subscriptions.push(() => announceOnConnect.close())
   }
 
   /**
@@ -158,9 +207,23 @@ export class CollabSession {
    * Times out after `timeoutMs` (default 10 s) — long enough for
    * a fat snapshot over a slow LAN, short enough to surface a
    * stalled host before the user gives up.
+   *
+   * Engine-independent: works in the pre-attach phase. The host
+   * peer responds from its own captureProjectSnapshot regardless
+   * of whether the joiner has an engine yet.
    */
   requestSnapshot(timeoutMs?: number): Promise<ProjectSnapshot> {
     return this.snapshotExchange.request(this.roomId, timeoutMs)
+  }
+
+  /** Whether `attachEngine` has been called yet. */
+  hasEngine(): boolean {
+    return this.engine !== null
+  }
+
+  /** Whether the underlying peer connection is currently connected. */
+  isConnected(): boolean {
+    return this.peer.getState() === 'connected'
   }
 
   /** Tear down. Idempotent. */
@@ -175,18 +238,20 @@ export class CollabSession {
     } catch {
       /* channel may already be torn down */
     }
-    this.cursorUnsubscribe?.()
-    this.cursorUnsubscribe = null
-    this.awarenessUnsubscribe?.()
-    this.awarenessUnsubscribe = null
-    this.cursorRenderer.close()
+    for (const dispose of this.subscriptions) {
+      try {
+        dispose()
+      } catch {
+        /* best-effort */
+      }
+    }
+    this.subscriptions.length = 0
+    this.cursorRenderer?.close()
+    this.cursorRenderer = null
     this.snapshotExchange.dispose()
-    this.controller.close()
+    this.controller?.close()
+    this.controller = null
     this.peer.close(reason)
-  }
-
-  /** Whether the underlying peer connection is currently connected. */
-  isConnected(): boolean {
-    return this.peer.getState() === 'connected'
+    void this.startedAt
   }
 }

--- a/packages/engine/src/sync/snapshot-exchange.spec.ts
+++ b/packages/engine/src/sync/snapshot-exchange.spec.ts
@@ -3,26 +3,26 @@
  *
  * Drives the full path against `createConnectedSessionPair`:
  *
- *    host SessionController + SnapshotExchange ↔ FakeRTCPeerConnection
+ *    host PeerSession + SnapshotExchange ↔ FakeRTCPeerConnection
  *      ↑ ↓ wire (cross-wired data channels)
- *    joiner SessionController + SnapshotExchange ↔ FakeRTCPeerConnection
+ *    joiner PeerSession + SnapshotExchange ↔ FakeRTCPeerConnection
  *
- * The actual `Engine` is replaced with a tiny duck-typed stub so
- * the test doesn't need to boot Excalibur (heavy + irrelevant to
- * the protocol). The protocol primitives (request/response
- * envelopes, controller filter, exchange state machine) are all
- * real.
+ * No `SessionController` (and therefore no Engine) needed — the
+ * exchange takes raw `send` + `captureSnapshot` callbacks, which
+ * is exactly what enables the joiner sandbox flow: connect →
+ * requestSnapshot → write-to-disk → THEN load engine.
+ *
+ * Production CollabSession wires `send` to `peer.sendOp` and
+ * inbound routing via `peer.events.on('op-received')` filtered by
+ * `isSessionProtocolOp`. This spec mirrors that wiring directly.
  */
 
 import { describe, expect, it } from '@gjsify/unit'
 
-import type { Engine } from '../engine.ts'
-import { EngineEvent, type EngineEventMap } from '../types/index.ts'
-import { EventEmitter } from 'excalibur'
-
 import { createConnectedSessionPair, flushMicrotasks } from './in-memory-transport.ts'
-import { PROJECT_SNAPSHOT_VERSION, type ProjectSnapshot } from './project-snapshot.ts'
-import { SessionController } from './session-controller.ts'
+import type { ProjectSnapshot } from './project-snapshot.ts'
+import { PROJECT_SNAPSHOT_VERSION } from './project-snapshot.ts'
+import { isSessionProtocolOp } from './session-protocol.ts'
 import { SnapshotExchange } from './snapshot-exchange.ts'
 
 const FAKE_SNAPSHOT: ProjectSnapshot = {
@@ -55,15 +55,25 @@ const FAKE_SNAPSHOT: ProjectSnapshot = {
 }
 
 /**
- * Minimal Engine stand-in. SessionController only touches
- * `events.on(EngineEvent.COMMAND_EXECUTED)` + `applyRemoteCommand`
- * — and for this protocol test neither path fires.
+ * Build a SnapshotExchange wired to one side of a connected
+ * peer pair — inbound routing via the peer's `op-received` event
+ * (filtered to session-protocol kinds), outbound via `peer.sendOp`.
+ * Mirrors how `CollabSession` composes the exchange in production.
  */
-function makeFakeEngine(): Engine {
-  return {
-    events: new EventEmitter<EngineEventMap>(),
-    applyRemoteCommand: () => {},
-  } as unknown as Engine
+function exchangeFor(
+  peer: import('./peer-session.ts').PeerSession,
+  peerId: string,
+  captureSnapshot: () => ProjectSnapshot | null,
+): SnapshotExchange {
+  const exchange = new SnapshotExchange({
+    peerId,
+    send: (op) => peer.sendOp(op),
+    captureSnapshot,
+  })
+  peer.events.on('op-received', ({ op }) => {
+    if (isSessionProtocolOp(op)) exchange.handle(op)
+  })
+  return exchange
 }
 
 export default async () => {
@@ -71,34 +81,12 @@ export default async () => {
     await it('host receives the joiner request and sends back its captured snapshot', async () => {
       const sessions = await createConnectedSessionPair()
       try {
-        const hostEngine = makeFakeEngine()
-        const joinerEngine = makeFakeEngine()
-
         let captureCount = 0
-        const hostController = new SessionController({
-          engine: hostEngine,
-          session: sessions.host,
-          peerId: 'host-1',
-          onSessionProtocol: (op) => hostExchange.handle(op),
+        const hostExchange = exchangeFor(sessions.host, 'host-1', () => {
+          captureCount++
+          return FAKE_SNAPSHOT
         })
-        const hostExchange = new SnapshotExchange({
-          controller: hostController,
-          captureSnapshot: () => {
-            captureCount++
-            return FAKE_SNAPSHOT
-          },
-        })
-
-        const joinerController = new SessionController({
-          engine: joinerEngine,
-          session: sessions.joiner,
-          peerId: 'joiner-1',
-          onSessionProtocol: (op) => joinerExchange.handle(op),
-        })
-        const joinerExchange = new SnapshotExchange({
-          controller: joinerController,
-          captureSnapshot: () => null, // joiner doesn't host its own snapshot
-        })
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-1', () => null)
 
         const received = await joinerExchange.request('room-abc', 2_000)
 
@@ -110,8 +98,6 @@ export default async () => {
 
         hostExchange.dispose()
         joinerExchange.dispose()
-        hostController.close()
-        joinerController.close()
       } finally {
         sessions.close()
       }
@@ -120,30 +106,8 @@ export default async () => {
     await it('joiner times out when the host refuses (captureSnapshot returns null)', async () => {
       const sessions = await createConnectedSessionPair()
       try {
-        const hostEngine = makeFakeEngine()
-        const joinerEngine = makeFakeEngine()
-
-        const hostController = new SessionController({
-          engine: hostEngine,
-          session: sessions.host,
-          peerId: 'host-2',
-          onSessionProtocol: (op) => hostExchange.handle(op),
-        })
-        const hostExchange = new SnapshotExchange({
-          controller: hostController,
-          captureSnapshot: () => null,
-        })
-
-        const joinerController = new SessionController({
-          engine: joinerEngine,
-          session: sessions.joiner,
-          peerId: 'joiner-2',
-          onSessionProtocol: (op) => joinerExchange.handle(op),
-        })
-        const joinerExchange = new SnapshotExchange({
-          controller: joinerController,
-          captureSnapshot: () => null,
-        })
+        const hostExchange = exchangeFor(sessions.host, 'host-2', () => null)
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-2', () => null)
 
         // 50 ms timeout — keeps the test fast.
         let thrown: Error | null = null
@@ -157,8 +121,6 @@ export default async () => {
 
         hostExchange.dispose()
         joinerExchange.dispose()
-        hostController.close()
-        joinerController.close()
       } finally {
         sessions.close()
       }
@@ -167,22 +129,9 @@ export default async () => {
     await it('rejects a second request while the first is in flight', async () => {
       const sessions = await createConnectedSessionPair()
       try {
-        const hostController = new SessionController({
-          engine: makeFakeEngine(),
-          session: sessions.host,
-          peerId: 'host-3',
-        })
-        // No-op host exchange so the joiner request never resolves.
-        const joinerController = new SessionController({
-          engine: makeFakeEngine(),
-          session: sessions.joiner,
-          peerId: 'joiner-3',
-          onSessionProtocol: (op) => joinerExchange.handle(op),
-        })
-        const joinerExchange = new SnapshotExchange({
-          controller: joinerController,
-          captureSnapshot: () => null,
-        })
+        // Host doesn't respond — so the first request never resolves.
+        const hostExchange = exchangeFor(sessions.host, 'host-3', () => null)
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-3', () => null)
 
         const first = joinerExchange.request('room-1', 2_000)
         let secondError: Error | null = null
@@ -205,8 +154,7 @@ export default async () => {
         }
         expect(firstError?.message).toContain('disposed')
 
-        hostController.close()
-        joinerController.close()
+        hostExchange.dispose()
       } finally {
         sessions.close()
       }
@@ -215,21 +163,8 @@ export default async () => {
     await it('dispose cancels in-flight requests', async () => {
       const sessions = await createConnectedSessionPair()
       try {
-        const hostController = new SessionController({
-          engine: makeFakeEngine(),
-          session: sessions.host,
-          peerId: 'host-4',
-        })
-        const joinerController = new SessionController({
-          engine: makeFakeEngine(),
-          session: sessions.joiner,
-          peerId: 'joiner-4',
-          onSessionProtocol: (op) => joinerExchange.handle(op),
-        })
-        const joinerExchange = new SnapshotExchange({
-          controller: joinerController,
-          captureSnapshot: () => null,
-        })
+        const hostExchange = exchangeFor(sessions.host, 'host-4', () => null)
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-4', () => null)
 
         const pending = joinerExchange.request('room-x', 2_000)
         joinerExchange.dispose()
@@ -244,50 +179,37 @@ export default async () => {
         // Idempotent: second dispose is a no-op.
         joinerExchange.dispose()
 
-        hostController.close()
-        joinerController.close()
+        hostExchange.dispose()
       } finally {
         sessions.close()
       }
     })
-  })
 
-  await describe('SessionController.onSessionProtocol — protocol routing', async () => {
-    await it('routes a session-protocol op to the hook instead of the command registry', async () => {
+    await it('stamps each outgoing envelope with the configured peerId + monotonic seq', async () => {
       const sessions = await createConnectedSessionPair()
       try {
-        const hostEngine = makeFakeEngine()
-        let commandsApplied = 0
-        // Spy: count command apply calls so we can prove the protocol hook DIDN'T trigger one.
-        hostEngine.applyRemoteCommand = () => {
-          commandsApplied++
-        }
-        const protocolReceived: unknown[] = []
-        const hostController = new SessionController({
-          engine: hostEngine,
-          session: sessions.host,
-          peerId: 'host-5',
-          onSessionProtocol: (op) => protocolReceived.push(op),
-        })
-        // Joiner-side controller exists only as a sender.
-        const joinerController = new SessionController({
-          engine: makeFakeEngine(),
-          session: sessions.joiner,
-          peerId: 'joiner-5',
-        })
+        const hostExchange = exchangeFor(sessions.host, 'host-5', () => FAKE_SNAPSHOT)
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-5', () => null)
 
-        joinerController.sendSessionProtocol({
-          kind: '__session/snapshot-request',
-          payload: { roomId: 'room' },
-        } as unknown as Parameters<typeof joinerController.sendSessionProtocol>[0])
-
+        await joinerExchange.request('room-stamp', 2_000)
         await flushMicrotasks()
 
-        expect(protocolReceived.length).toBe(1)
-        expect(commandsApplied).toBe(0)
+        // The joiner sent one request — assert peerId + seq stamping.
+        // The host's first sentFrames entry on the op channel is the request that arrived.
+        const joinerSentFrames = sessions.joinerOpChannel.sentFrames
+        expect(joinerSentFrames.length).toBeGreaterThan(0)
+        const joinerSent = joinerSentFrames.map((f) => JSON.parse(f) as { peerId?: string; seq?: number })
+        expect(joinerSent[0].peerId).toBe('joiner-5')
+        expect(joinerSent[0].seq).toBe(0)
 
-        hostController.close()
-        joinerController.close()
+        const hostSentFrames = sessions.hostOpChannel.sentFrames
+        const hostSent = hostSentFrames.map((f) => JSON.parse(f) as { peerId?: string; seq?: number })
+        // Host's first response is the snapshot reply.
+        expect(hostSent[0].peerId).toBe('host-5')
+        expect(hostSent[0].seq).toBe(0)
+
+        hostExchange.dispose()
+        joinerExchange.dispose()
       } finally {
         sessions.close()
       }

--- a/packages/engine/src/sync/snapshot-exchange.ts
+++ b/packages/engine/src/sync/snapshot-exchange.ts
@@ -24,7 +24,6 @@
  */
 
 import type { ProjectSnapshot } from './project-snapshot.ts'
-import type { SessionController } from './session-controller.ts'
 import {
   createSnapshotRequestOp,
   createSnapshotResponseOp,
@@ -34,13 +33,28 @@ import {
 } from './session-protocol.ts'
 
 export interface SnapshotExchangeOptions {
-  /** The SessionController to bind to — provides send + receive. */
-  controller: SessionController
+  /**
+   * Stable id stamped onto every outgoing protocol envelope.
+   * Receivers don't use it for routing (single pending request at
+   * a time) but it shows up in wire-level diagnostics.
+   */
+  peerId: string
+  /**
+   * Transport callback. The exchange hands fully-stamped session-
+   * protocol ops; the callback's only job is "put this on the
+   * reliable channel" — typically `(op) => peerSession.sendOp(op)`.
+   *
+   * Decoupled from `SessionController` so the snapshot flow works
+   * even before an engine is attached (joiner sandbox flow: connect
+   * → request snapshot → write to disk → THEN load engine).
+   */
+  send: (op: SessionProtocolOp) => void
   /**
    * Producer for the local project state. Called when the peer
    * sends a snapshot-request. Return `null` to refuse (the
-   * requester will see a timeout). v1 always returns the current
-   * `engine.captureProjectSnapshot()`.
+   * requester will see a timeout). Hosts pass
+   * `() => captureProjectSnapshot(engine)`; joiners typically
+   * return null (they don't host their own state).
    */
   captureSnapshot: () => ProjectSnapshot | null
   /**
@@ -58,16 +72,23 @@ interface PendingRequest {
 }
 
 export class SnapshotExchange {
-  private readonly controller: SessionController
+  private readonly peerId: string
+  private readonly send: (op: SessionProtocolOp) => void
   private readonly captureSnapshot: () => ProjectSnapshot | null
   private readonly defaultTimeoutMs: number
   private pending: PendingRequest | null = null
+  private localSeq = 0
   private disposed = false
 
   constructor(opts: SnapshotExchangeOptions) {
-    this.controller = opts.controller
+    this.peerId = opts.peerId
+    this.send = opts.send
     this.captureSnapshot = opts.captureSnapshot
     this.defaultTimeoutMs = opts.defaultTimeoutMs ?? 10_000
+  }
+
+  private nextSeq(): number {
+    return this.localSeq++
   }
 
   /**
@@ -122,8 +143,8 @@ export class SnapshotExchange {
       // synchronous-handler test scenario (where the response
       // arrives before sendOp returns) can't race past the
       // assignment.
-      this.controller.sendSessionProtocol(
-        createSnapshotRequestOp({ peerId: '', seq: 0, roomId }),
+      this.send(
+        createSnapshotRequestOp({ peerId: this.peerId, seq: this.nextSeq(), roomId }),
       )
     })
   }
@@ -152,11 +173,10 @@ export class SnapshotExchange {
       // layer via the awareness presence channel.
       return
     }
-    // Tag roomId for symmetry / diagnostics — the controller
-    // overwrites peerId+seq anyway.
+    // roomId echoed for diagnostics; not load-bearing in v1.
     void roomId
-    this.controller.sendSessionProtocol(
-      createSnapshotResponseOp({ peerId: '', seq: 0, snapshot }),
+    this.send(
+      createSnapshotResponseOp({ peerId: this.peerId, seq: this.nextSeq(), snapshot }),
     )
   }
 


### PR DESCRIPTION
## Summary

Foundation for the sandbox-mode UX (joiner connects + pulls host's snapshot BEFORE having an engine, writes it to a sandbox dir, then attaches the engine). The engine-side primitives all work without an engine; `CollabSession` composes them lazily and exposes `attachEngine()` for the post-snapshot wire-up step.

### Files

**`packages/engine/src/sync/snapshot-exchange.ts`** — decouples from SessionController. Options change:

```diff
- controller: SessionController
+ peerId: string
+ send: (op: SessionProtocolOp) => void
```

Sequence numbers now stamped internally (`localSeq++`). Same wire semantics.

**`packages/engine/src/sync/snapshot-exchange.spec.ts`** — mirrors the new API. New `exchangeFor(peer, peerId, capture)` helper wires inbound via `peer.events.on('op-received')` filtered with `isSessionProtocolOp` — matches how `CollabSession` composes it. New assertion: outgoing envelopes carry the configured `peerId` + monotonic `seq` (0 for the first frame on each side).

**`apps/maker-gjs/src/services/collab-session.ts`** — substantial restructure:
- `engine?` becomes OPTIONAL
- `attachEngine(engine)` is the new wire-up entry point; called from the constructor when `opts.engine` is present (host path), or by the maker after sandbox-load (joiner path)
- `controller` + `cursorRenderer` become nullable + lazy
- Snapshot exchange wired with raw `peer.sendOp` + a `captureSnapshot` closure that returns null when no engine is attached
- Inbound session-protocol routing moves into CollabSession itself (subscribes + filters with `isSessionProtocolOp`)
- All subscriptions tracked in a `subscriptions[]` array for symmetric teardown
- `hasEngine()` helper for callers that want to gate UI on wire-up state

### Behaviour impact

**Host path (existing ApplicationWindow wiring):** constructor signature still accepts the `{ engine, ... }` shape; public fields `controller` / `cursorRenderer` are now nullable typed, existing call sites read via optional chaining.

**Joiner sandbox path (NEW):**
1. Construct with `engine` omitted
2. `start()` — handshake + presence frame
3. `requestSnapshot()` — pulls host's project state
4. `attachEngine(engine)` — wires command sync + cursor rendering once the sandbox project has loaded

Ops received during the pre-attach window are dropped (documented limitation; a pre-attach op buffer is a possible future PR).

### Stacked next (separate PR — actual UX delivery)

- `sandbox-path.ts` in maker: resolve `${XDG_DATA_HOME}/pixelrpg-maker/shared/<roomId>/`, write snapshot via `applyProjectSnapshot` + `Gio.File`.
- `SessionService.joinLan` / `joinByRoomId`: drop the "engine required" pre-check; instead request snapshot, write to sandbox, emit a new `sandbox-project-ready` event.
- `ApplicationWindow`: on `sandbox-project-ready`, load the project via the existing project-loader, then call `sessionSvc.attachEngineToCurrentSession(engine)`.

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify foreach build -v -t` clean
- [x] `gjsify workspace @pixelrpg/engine test` 324/324 green on both runtimes (+3 from refactored spec)
- [x] `gjsify workspace @pixelrpg/maker-gjs test` 69/69 green
- [ ] CI passes on PR