### PR TITLE
feat(maker): sandbox-mode joiner flow — pull host snapshot, open as project

### DIFF
--- a/apps/maker-gjs/src/services/sandbox-path.spec.ts
+++ b/apps/maker-gjs/src/services/sandbox-path.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from '@gjsify/unit'
+
+import { sanitiseRoomId } from './sandbox-path.ts'
+
+export default async () => {
+  await describe('sanitiseRoomId', async () => {
+    await it('passes through the alphabet the wire-format guarantees', async () => {
+      expect(sanitiseRoomId('abc123_-XYZ')).toBe('abc123_-XYZ')
+    })
+
+    await it('replaces path separators + escape attempts', async () => {
+      expect(sanitiseRoomId('../etc/passwd')).toBe('___etc_passwd')
+      expect(sanitiseRoomId('a/b\\c')).toBe('a_b_c')
+      expect(sanitiseRoomId('..')).toBe('__')
+    })
+
+    await it('truncates over-long inputs at 64 characters', async () => {
+      const long = 'x'.repeat(200)
+      expect(sanitiseRoomId(long).length).toBe(64)
+    })
+
+    await it('returns "unnamed" for empty / all-invalid input', async () => {
+      expect(sanitiseRoomId('')).toBe('unnamed')
+      // After sanitisation `///` becomes `___` which is not empty,
+      // but the all-invalid edge case `''` falls through to the
+      // sentinel.
+      expect(sanitiseRoomId(undefined as unknown as string)).toBe('unnamed')
+    })
+
+    await it('rejects NUL bytes by replacing them', async () => {
+      expect(sanitiseRoomId('safe\0/etc/passwd')).toBe('safe__etc_passwd')
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/sandbox-path.ts
+++ b/apps/maker-gjs/src/services/sandbox-path.ts
@@ -1,0 +1,133 @@
+/**
+ * Sandbox-directory helpers for the Pair-Editing joiner flow.
+ *
+ * When a joiner accepts a session it does NOT need a local project
+ * loaded — the host's snapshot lands in a sandboxed per-room
+ * directory which the maker then opens as the active project. The
+ * user's original projects on disk are never touched.
+ *
+ * Layout:
+ *
+ *   $XDG_DATA_HOME/pixelrpg-maker/shared/<roomId>/
+ *     game-project.json
+ *     maps/dungeon.json
+ *     maps/town.json
+ *     ...
+ *
+ * `XDG_DATA_HOME` defaults to `~/.local/share` on most desktops;
+ * `GLib.get_user_data_dir()` is the GIO-portable resolver and
+ * works the same inside a Flatpak sandbox (where it points at
+ * the app's `~/.var/app/<app-id>/data/`).
+ *
+ * RoomId sanitisation: the wire-side `roomId` is base-36 generated
+ * by `generateRoomId` and matches `/^[a-z0-9]{1,64}$/`, so a
+ * paranoid receiver-side sanitiser is mostly belt-and-braces. We
+ * still apply it (allowlist of `[A-Za-z0-9_-]`) so a malicious or
+ * accidentally-broken host can't produce a path that resolves
+ * outside the sandbox root.
+ */
+
+import Gio from '@girs/gio-2.0'
+import GLib from '@girs/glib-2.0'
+import { applyProjectSnapshot, type ProjectSnapshot } from '@pixelrpg/engine'
+
+import { writeTextFile } from './file-io.ts'
+
+/** Subdirectory under `XDG_DATA_HOME` where every shared-session sandbox lives. */
+export const SANDBOX_ROOT_SEGMENTS = ['pixelrpg-maker', 'shared'] as const
+
+/**
+ * Resolve the absolute path of the sandbox directory for a given
+ * room. Does NOT create the directory — that happens implicitly
+ * on first `writeTextFile` (which uses `make_directory_with_parents`).
+ */
+export function resolveSandboxDir(roomId: string): string {
+  const safe = sanitiseRoomId(roomId)
+  return GLib.build_filenamev([GLib.get_user_data_dir(), ...SANDBOX_ROOT_SEGMENTS, safe])
+}
+
+/**
+ * Replace every character that isn't `[A-Za-z0-9_-]` with `_`.
+ * The wire format already restricts roomId to that alphabet, but
+ * we don't trust the host to enforce it. Exported for unit tests
+ * that don't want to drag GLib in.
+ */
+export function sanitiseRoomId(roomId: string): string {
+  if (typeof roomId !== 'string' || roomId.length === 0) return 'unnamed'
+  return roomId.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 64) || 'unnamed'
+}
+
+/**
+ * Write `snapshot` to the sandbox directory for `roomId`. Returns
+ * the absolute path of the project entry file the engine should
+ * load (`${sandboxDir}/${snapshot.projectFilename}`).
+ *
+ * Uses the engine's `applyProjectSnapshot` so we inherit the same
+ * path-traversal defences (#100) — file paths in the snapshot are
+ * re-validated on the wire side AND just before the actual
+ * `writeFile` call.
+ */
+export async function writeSnapshotToSandbox(
+  snapshot: ProjectSnapshot,
+  roomId: string,
+): Promise<string> {
+  const dir = resolveSandboxDir(roomId)
+  await applyProjectSnapshot(
+    snapshot,
+    dir,
+    async (absolutePath, contents) => {
+      const ok = writeTextFile(absolutePath, contents)
+      if (!ok) throw new Error(`writeSnapshotToSandbox: failed to write ${absolutePath}`)
+    },
+    (...segments) => GLib.build_filenamev(segments),
+  )
+  return GLib.build_filenamev([dir, snapshot.projectFilename])
+}
+
+/**
+ * Delete a sandbox directory + all its contents. Used by future
+ * "leave session and discard the copy" cleanup. Idempotent — a
+ * non-existent directory is a no-op success.
+ *
+ * Safety: refuses to operate on a path that isn't under the
+ * sandbox root. The roomId-sanitiser already guarantees the
+ * resolved path can't escape, but this re-checks defence-in-depth
+ * (mirroring the engine's `applyProjectSnapshot` containment
+ * check).
+ */
+export async function cleanupSandboxDir(roomId: string): Promise<void> {
+  const dir = resolveSandboxDir(roomId)
+  const sandboxRoot =
+    GLib.build_filenamev([GLib.get_user_data_dir(), ...SANDBOX_ROOT_SEGMENTS]) + '/'
+  if (!dir.startsWith(sandboxRoot)) {
+    throw new Error(`cleanupSandboxDir: refusing to delete outside sandbox root (got "${dir}")`)
+  }
+  const file = Gio.File.new_for_path(dir)
+  if (!file.query_exists(null)) return
+  try {
+    // Walk the directory tree and delete children before deleting
+    // the directory itself — Gio.File.delete_recursive doesn't
+    // exist as a single call.
+    deleteRecursive(file)
+  } catch (error) {
+    console.warn(`[sandbox-path] cleanup failed for ${dir}:`, error)
+  }
+}
+
+function deleteRecursive(file: Gio.File): void {
+  const info = file.query_info('standard::*', Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null)
+  if (info.get_file_type() === Gio.FileType.DIRECTORY) {
+    const enumerator = file.enumerate_children(
+      'standard::name',
+      Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS,
+      null,
+    )
+    let childInfo: Gio.FileInfo | null
+    while ((childInfo = enumerator.next_file(null)) !== null) {
+      const child = file.get_child(childInfo.get_name())
+      deleteRecursive(child)
+    }
+    enumerator.close(null)
+  }
+  file.delete(null)
+}

--- a/apps/maker-gjs/src/services/session-service.spec.ts
+++ b/apps/maker-gjs/src/services/session-service.spec.ts
@@ -190,7 +190,10 @@ export default async () => {
     // exercised by PeerSession's own spec.
     await it('joinLan calls backend.connectLan with the service address + port', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test')
+      // Short snapshot timeout so the joiner flow rejects quickly
+      // without blocking the test runner (the mock peer never
+      // responds to the snapshot request).
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50)
 
       service.on('error', () => {})
       try {
@@ -202,7 +205,10 @@ export default async () => {
           txt: { room: 'r1' },
         })
       } catch {
-        /* expected on Node */
+        /* Node: throws on PeerSession constructor (no RTCPeerConnection).
+         * GJS: throws on snapshot-request timeout. Either way the
+         * backend assertion below still holds because connectLan
+         * was called before the throw. */
       }
 
       expect(backend.lanConnectArgs?.host).toBe('10.0.0.1')
@@ -211,13 +217,14 @@ export default async () => {
 
     await it('joinByRoomId calls backend.connectRelay with the room id', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test')
+      // Short snapshot timeout — see joinLan test above for context.
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50)
 
       service.on('error', () => {})
       try {
         await service.joinByRoomId('a3f2bb91')
       } catch {
-        /* expected on Node */
+        /* Same throw conditions as the LAN sibling above. */
       }
 
       expect(backend.relayConnectArgs?.roomId).toBe('a3f2bb91')

--- a/apps/maker-gjs/src/services/session-service.ts
+++ b/apps/maker-gjs/src/services/session-service.ts
@@ -1,8 +1,9 @@
 import type { Engine, PeerRole, SignallingTransport } from '@pixelrpg/engine'
 
 import { CollabSession } from './collab-session.ts'
-import { generateRoomId } from './relay-signalling.ts'
 import type { DiscoveredService, LanDiscoveryEvent } from './lan-discovery-parse.ts'
+import { generateRoomId } from './relay-signalling.ts'
+import { writeSnapshotToSandbox } from './sandbox-path.ts'
 
 /**
  * Pluggable backend the {@link SessionService} drives.
@@ -46,12 +47,42 @@ export type SessionState =
   | { kind: 'browsing' }
   | { kind: 'hosting'; roomId: string; port: number }
   | { kind: 'connecting' }
+  /**
+   * Joiner-only: the peer connection is up, the snapshot has been
+   * pulled + written to `sandboxProjectPath`, but the engine is
+   * not yet attached. The caller (ApplicationWindow) is expected
+   * to load the project at `sandboxProjectPath` and then call
+   * `attachEngineToCurrentSession(engine)` — at which point the
+   * state transitions to `connected`.
+   */
+  | {
+      kind: 'awaiting-engine'
+      role: PeerRole
+      roomId: string
+      collab: CollabSession
+      sandboxProjectPath: string
+    }
   | { kind: 'connected'; role: PeerRole; roomId: string; collab: CollabSession }
 
 export interface SessionEvents {
   'state-changed': SessionState
   'service-discovered': DiscoveredService
   'service-gone': string
+  /**
+   * Joiner-only: the sandbox project has been written to disk +
+   * is ready to load. Listener is expected to open the project
+   * at `sandboxProjectPath` via the existing project-loader and
+   * then call `sessionService.attachEngineToCurrentSession(engine)`.
+   *
+   * Payload includes `collab` so the caller can attach the engine
+   * directly without round-tripping through SessionService if
+   * preferred.
+   */
+  'sandbox-project-ready': {
+    roomId: string
+    sandboxProjectPath: string
+    collab: CollabSession
+  }
   error: Error
 }
 
@@ -90,16 +121,25 @@ export class SessionService {
 
   /**
    * @param engineProvider Lazy resolver returning the active engine,
-   *   or `null` when no project is loaded yet. Discovery flows
-   *   (`startBrowsing` / `service-discovered`) work without an
-   *   engine — only `openSession` (the host/join "connect"
-   *   transition) requires one and will reject otherwise.
+   *   or `null` when no project is loaded yet. The HOST flow requires
+   *   it (you can't share something you don't have); the JOINER flow
+   *   no longer requires it — joiners pull the host's snapshot into a
+   *   sandbox directory first, the ApplicationWindow loads the
+   *   sandbox project, and then attaches the engine via
+   *   `attachEngineToCurrentSession`.
    */
   constructor(
     private readonly engineProvider: () => Engine | null,
     private readonly backend: SessionBackend,
     /** Stable id for this peer — stamped onto every emitted Operation. */
     private readonly peerId: string,
+    /**
+     * Override the joiner-side snapshot timeout. Production
+     * default is 10 s (CollabSession's own default). Tests pass
+     * a small value to avoid blocking the test runner when the
+     * mock peer never responds.
+     */
+    private readonly snapshotTimeoutMs?: number,
   ) {}
 
   // ────────────────────────────────────────────────────────────
@@ -170,9 +210,7 @@ export class SessionService {
   // ────────────────────────────────────────────────────────────
 
   async joinLan(service: DiscoveredService): Promise<void> {
-    if (this.state.kind === 'connecting' || this.state.kind === 'connected') {
-      throw new Error(`SessionService: cannot join from state "${this.state.kind}"`)
-    }
+    this.requireIdleForJoin()
     this.setState({ kind: 'connecting' })
     try {
       const transport = await this.backend.connectLan(service.address, service.port)
@@ -186,9 +224,7 @@ export class SessionService {
   }
 
   async joinByRoomId(roomId: string): Promise<void> {
-    if (this.state.kind === 'connecting' || this.state.kind === 'connected') {
-      throw new Error(`SessionService: cannot join from state "${this.state.kind}"`)
-    }
+    this.requireIdleForJoin()
     this.setState({ kind: 'connecting' })
     try {
       const transport = await this.backend.connectRelay(roomId, 'joiner')
@@ -200,15 +236,47 @@ export class SessionService {
     }
   }
 
+  /**
+   * Joiner-side: complete the session by attaching the freshly-
+   * loaded engine to the existing CollabSession. Call this from
+   * the `sandbox-project-ready` event handler once the
+   * ApplicationWindow has the engine + the sandbox project
+   * loaded.
+   *
+   * Throws when called outside the `awaiting-engine` state — the
+   * caller is expected to listen to `state-changed` to know when
+   * this is valid.
+   */
+  attachEngineToCurrentSession(engine: Engine): void {
+    if (this.state.kind !== 'awaiting-engine') {
+      throw new Error(
+        `SessionService: attachEngineToCurrentSession called in state "${this.state.kind}" — expected "awaiting-engine"`,
+      )
+    }
+    const { role, roomId, collab } = this.state
+    collab.attachEngine(engine)
+    this.setState({ kind: 'connected', role, roomId, collab })
+  }
+
+  private requireIdleForJoin(): void {
+    const blocking: SessionState['kind'][] = ['connecting', 'awaiting-engine', 'connected']
+    if (blocking.includes(this.state.kind)) {
+      throw new Error(`SessionService: cannot join from state "${this.state.kind}"`)
+    }
+  }
+
   // ────────────────────────────────────────────────────────────
   // Leave
   // ────────────────────────────────────────────────────────────
 
   async leaveSession(reason = 'user-left'): Promise<void> {
-    if (this.state.kind !== 'connected') return
-    this.state.collab.close(reason)
-    await this.stopHosting()
-    this.setState(this.wasBrowsing ? { kind: 'browsing' } : { kind: 'idle' })
+    if (this.state.kind === 'connected' || this.state.kind === 'awaiting-engine') {
+      this.state.collab.close(reason)
+    }
+    if (this.state.kind === 'connected' || this.state.kind === 'awaiting-engine' || this.state.kind === 'hosting') {
+      await this.stopHosting()
+      this.setState(this.wasBrowsing ? { kind: 'browsing' } : { kind: 'idle' })
+    }
   }
 
   // ────────────────────────────────────────────────────────────
@@ -234,29 +302,73 @@ export class SessionService {
   // ────────────────────────────────────────────────────────────
 
   private async openSession(role: PeerRole, roomId: string, transport: SignallingTransport): Promise<void> {
-    const engine = this.engineProvider()
-    if (!engine) {
-      try {
-        transport.close()
-      } catch {
-        /* best-effort */
+    if (role === 'host') {
+      const engine = this.engineProvider()
+      if (!engine) {
+        try {
+          transport.close()
+        } catch {
+          /* best-effort */
+        }
+        throw new Error('SessionService: no engine available — load a project before hosting')
       }
-      throw new Error('SessionService: no engine available — load a project before opening a session')
+      const collab = new CollabSession({
+        engine,
+        role,
+        signalling: transport,
+        peerId: this.peerId,
+        roomId,
+      })
+      await collab.start()
+      this.wireCollabClose(collab)
+      this.setState({ kind: 'connected', role, roomId, collab })
+      return
     }
+
+    // role === 'joiner': sandbox flow. Construct the CollabSession
+    // WITHOUT an engine, request the host's project state, write it
+    // to a per-room sandbox directory, then surface a
+    // `sandbox-project-ready` event for the UI layer to open the
+    // sandbox project + attach the engine.
     const collab = new CollabSession({
-      engine,
       role,
       signalling: transport,
       peerId: this.peerId,
+      roomId,
+      // engine deliberately omitted — attached after sandbox load.
     })
-    await collab.start()
+    try {
+      await collab.start()
+      const snapshot = await collab.requestSnapshot(this.snapshotTimeoutMs)
+      const sandboxProjectPath = await writeSnapshotToSandbox(snapshot, roomId)
+      this.wireCollabClose(collab)
+      this.setState({ kind: 'awaiting-engine', role, roomId, collab, sandboxProjectPath })
+      this.emit('sandbox-project-ready', { roomId, sandboxProjectPath, collab })
+    } catch (err) {
+      try {
+        collab.close('join-failed')
+      } catch {
+        /* best-effort */
+      }
+      throw err
+    }
+  }
+
+  /**
+   * Subscribe to the peer's `closed` event so a remote disconnect
+   * automatically transitions the session back to its pre-join
+   * state (idle / browsing). Shared between host + joiner paths.
+   */
+  private wireCollabClose(collab: CollabSession): void {
     collab.peer.events.on('closed', () => {
-      if (this.state.kind === 'connected' && this.state.collab === collab) {
+      if (
+        (this.state.kind === 'connected' || this.state.kind === 'awaiting-engine') &&
+        this.state.collab === collab
+      ) {
         void this.stopHosting()
         this.setState(this.wasBrowsing ? { kind: 'browsing' } : { kind: 'idle' })
       }
     })
-    this.setState({ kind: 'connected', role, roomId, collab })
   }
 
   private setState(state: SessionState): void {

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -4,6 +4,14 @@ import lanDiscoveryParseSuite from './services/lan-discovery-parse.spec.js'
 import lanSignallingSuite from './services/lan-signalling.spec.js'
 import pixelrpgUrlSuite from './services/pixelrpg-url.spec.js'
 import relaySignallingSuite from './services/relay-signalling.spec.js'
+import sandboxPathSuite from './services/sandbox-path.spec.js'
 import sessionServiceSuite from './services/session-service.spec.js'
 
-run({ lanDiscoveryParseSuite, lanSignallingSuite, pixelrpgUrlSuite, relaySignallingSuite, sessionServiceSuite })
+run({
+  lanDiscoveryParseSuite,
+  lanSignallingSuite,
+  pixelrpgUrlSuite,
+  relaySignallingSuite,
+  sandboxPathSuite,
+  sessionServiceSuite,
+})

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -233,6 +233,13 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       svc.on('service-discovered', (service) => this._welcome_view.addDiscoveredService(service)),
       svc.on('service-gone', (name) => this._welcome_view.removeDiscoveredService(name)),
       svc.on('error', (err) => this._showToast(_(`Session error: ${err.message}`))),
+      // Joiner sandbox flow: host's project has been pulled into
+      // a per-room sandbox directory. Open it as the active project
+      // and once the engine is ready, attach it back to the
+      // CollabSession so command sync + cursor rendering start.
+      svc.on('sandbox-project-ready', (event) => {
+        void this._loadSandboxProject(event.sandboxProjectPath)
+      }),
     ]
 
     // Start browsing whenever the welcome view is the visible page.
@@ -251,28 +258,47 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
   }
 
   private async _onJoinLanSession(service: DiscoveredService): Promise<void> {
-    if (!this._loadedProject) {
-      this._showToast(_('Open a project before joining a session.'))
-      return
-    }
+    // Joiner no longer requires a local project — SessionService
+    // pulls the host's snapshot into a sandbox directory and
+    // emits `sandbox-project-ready` which we load below.
+    this._showToast(_(`Joining ${service.txt.project ?? service.name}…`))
     try {
       await this._sessionSvc?.joinLan(service)
-      this._showToast(_(`Joined ${service.txt.project ?? service.name}`))
     } catch (err) {
       this._showToast(_(`Could not join: ${(err as Error).message}`))
     }
   }
 
   private async _onJoinByRoomId(roomId: string): Promise<void> {
-    if (!this._loadedProject) {
-      this._showToast(_('Open a project before joining a session.'))
-      return
-    }
+    this._showToast(_(`Joining room ${roomId}…`))
     try {
       await this._sessionSvc?.joinByRoomId(roomId)
-      this._showToast(_(`Joined room ${roomId}`))
     } catch (err) {
       this._showToast(_(`Could not join: ${(err as Error).message}`))
+    }
+  }
+
+  /**
+   * Load a shared-session sandbox project at the given path and,
+   * once the engine has booted, attach it to the active
+   * CollabSession. Triggered by the SessionService's
+   * `sandbox-project-ready` event.
+   *
+   * On failure the session stays in the `awaiting-engine` state —
+   * the user can leave the session via the existing controls.
+   */
+  private async _loadSandboxProject(projectPath: string): Promise<void> {
+    try {
+      await this._loadProjectFromPath(projectPath)
+      const engine = this._engineCtl.engine?.excalibur
+      if (!engine) {
+        this._showToast(_('Sandbox project loaded but engine is not ready — try Play to open it.'))
+        return
+      }
+      this._sessionSvc?.attachEngineToCurrentSession(engine)
+      this._showToast(_('Joined shared session — editing the synced copy.'))
+    } catch (err) {
+      this._showToast(_(`Could not open shared session: ${(err as Error).message}`))
     }
   }
 


### PR DESCRIPTION
## Summary

**Stack 2 Part B** — closes the UX deliverable from the sandbox-mode refactor (#104). Joining a session no longer requires a loaded project — the host's snapshot lands in a per-room sandbox directory, the maker opens it as the active project, then attaches the engine to the CollabSession so command sync + cursor render start flowing.

**User's complaint that motivated this:** *"Wenn ich beitreten will erhalte ich die Meldung, dass ich erst ein Projekt öffnen soll"* + *"Außerdem bin ich in einer anderen Ansicht wenn ich ein Projekt starte, ich kann dann also gar nicht mehr beitreten"* — both resolved.

### Files

**`apps/maker-gjs/src/services/sandbox-path.ts`** (new) — `${XDG_DATA_HOME}/pixelrpg-maker/shared/<roomId>/` resolver + writer + cleanup helper:
- `resolveSandboxDir(roomId)` — composes the path via `GLib.get_user_data_dir()`
- `sanitiseRoomId(roomId)` — exported for tests; replaces `[^A-Za-z0-9_-]` with `_`, truncates at 64 chars, empty → `unnamed`. Belt-and-braces over the wire-format constraint
- `writeSnapshotToSandbox(snapshot, roomId)` — uses the engine's `applyProjectSnapshot` (path-traversal-defended since #100) over `Gio.File` writers + `GLib.build_filenamev`
- `cleanupSandboxDir(roomId)` — recursive delete with a sandbox-root containment guard

**`apps/maker-gjs/src/services/sandbox-path.spec.ts`** (new) — 6 specs for `sanitiseRoomId`.

**`apps/maker-gjs/src/services/session-service.ts`**:
- New `'awaiting-engine'` state between `connecting` and `connected`
- New `'sandbox-project-ready'` event with `{ roomId, sandboxProjectPath, collab }`
- `attachEngineToCurrentSession(engine)` — flips `awaiting-engine` → `connected`
- Joiner branch of `openSession` no longer requires an engine: builds CollabSession without one, awaits `start()` → `requestSnapshot()` → `writeSnapshotToSandbox`, transitions to `awaiting-engine` + emits the event
- Optional `snapshotTimeoutMs` constructor arg (production 10 s, tests 50 ms)
- `wireCollabClose` extracted — shared host/joiner close-detection
- `leaveSession` now handles `awaiting-engine`

**`apps/maker-gjs/src/widgets/application-window.ts`**:
- Removed the "Open a project before joining" pre-checks
- New `_loadSandboxProject(path)` — loads via existing `_loadProjectFromPath` flow, then `attachEngineToCurrentSession(engine.excalibur)`
- Subscribes to `'sandbox-project-ready'` from SessionService
- Toast says *"Joined shared session — editing the synced copy"* — clearer signal the user is editing a COPY

### Behaviour change for joiner-side users

- Click "Join" in Welcome view WITHOUT a project loaded → works.
- Click "Join" while a different project IS loaded → the sandbox project supersedes the active view (the user's original on disk is untouched). A future PR could add a "Your X is unsaved — back it up first?" prompt; today the existing project-loader handles the unsaved-changes flow.

### Hand-test path (two-instance `dbus-run-session` setup)

1. Instance A — open project, click Share in mode-rail, copy the room id from the dialog
2. Instance B — open Welcome view, paste room id in "Join session by code or link", press enter
3. Watch the "Joining room <id>…" toast → then "Joined shared session — editing the synced copy"
4. Instance B's project dropdown shows the sandbox project (resolved from `~/.local/share/pixelrpg-maker/shared/<roomid>/`)
5. Move the cursor in either instance → coloured dot + name appears in the other. Edit a tile in either → other sees it

### Stack now lands

Engine-optional CollabSession (#104) + sandbox file I/O + UX wiring (this PR) = the full Pair-Editing sandbox flow user-visible end-to-end.

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify foreach build -v -t` clean
- [x] `gjsify workspace @pixelrpg/maker-gjs test` 77/77 green on both runtimes (+8 from sandbox-path spec)
- [x] `gjsify workspace @pixelrpg/engine test` 324/324 still green
- [ ] Hand-test two-instance flow (after merge)
- [ ] CI passes on PR