### PR TITLE
fix(maker): drop -t flag from avahi-browse — joiner now sees hosts published after browser starts

### DIFF
--- a/apps/maker-gjs/src/services/lan-discovery-integration.gjs.spec.ts
+++ b/apps/maker-gjs/src/services/lan-discovery-integration.gjs.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * Real-Avahi end-to-end integration test for `LanPublisher` +
+ * `LanBrowser`. Actually spawns the `avahi-publish-service` and
+ * `avahi-browse` subprocesses, lets them go through the live
+ * mDNS round-trip via the system's `avahi-daemon`, and asserts
+ * the browser sees the publisher.
+ *
+ * This is the test that catches the 2026-05-30 hand-test bug
+ * ("joiner's discovery never sees the host"):
+ *
+ *   - Pre-fix: `avahi-browse -t` exited after the cold-start
+ *     scan; LanBrowser saw EOF, closed itself, never recovered.
+ *   - Test reproduces the exact run shape (publisher started
+ *     AFTER browser) — fails with the old args, passes with
+ *     the new args.
+ *
+ * GJS-only — uses `Gio.Subprocess` directly. Skips gracefully
+ * when Avahi isn't available (CI without `avahi-tools` /
+ * `avahi-daemon`).
+ *
+ * The test uses a unique service type per run (`_pixelrpgtest…
+ * ._tcp`) so concurrent runs / dev-machine pollution don't
+ * cross-contaminate.
+ */
+
+import { describe, expect, it, on } from '@gjsify/unit'
+import Gio from '@girs/gio-2.0'
+import GLib from '@girs/glib-2.0'
+
+import { LanBrowser, LanPublisher } from './lan-discovery.ts'
+
+/**
+ * Per-process unique service type so parallel runs don't see each other.
+ * Uses `Math.random()` (cross-platform) rather than `GLib.random_int_range`
+ * so the MODULE LOAD doesn't crash under Node — the spec file is GJS-only
+ * at runtime (gated below) but its module-top-level code still executes
+ * on Node when the test bundle imports it.
+ */
+const TEST_SERVICE_TYPE = `_pixelrpgtest${Math.floor(1000 + Math.random() * 9000)}._tcp`
+
+/** Quick probe — `avahi-browse` is on PATH AND a `avahi-daemon` is reachable. */
+function avahiAvailable(): boolean {
+  try {
+    const probe = Gio.Subprocess.new(
+      ['avahi-browse', '--help'],
+      Gio.SubprocessFlags.STDOUT_SILENCE | Gio.SubprocessFlags.STDERR_SILENCE,
+    )
+    probe.wait(null)
+    if (!probe.get_successful()) return false
+  } catch {
+    return false
+  }
+  // A daemon check is harder without sending a real query; the
+  // first integration test below will time out if the daemon is
+  // missing, which is the right failure mode.
+  return true
+}
+
+/** Poll-wait for `predicate` up to `timeoutMs`. Uses `Date.now()` so
+ * the helper definition doesn't pull GLib at module load. */
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return true
+    await new Promise<void>((r) => setTimeout(r, 25))
+  }
+  return predicate()
+}
+
+/**
+ * Spawn `avahi-publish-service` directly (bypassing LanPublisher
+ * — the production publisher only accepts the SessionTxt schema,
+ * and we want a minimal fixture here). Returns a cleanup
+ * function.
+ */
+function publishTestService(name: string, port: number): () => void {
+  const proc = Gio.Subprocess.new(
+    [
+      'avahi-publish-service',
+      name,
+      TEST_SERVICE_TYPE,
+      String(port),
+      'kind=test',
+      `started=${Math.floor(Date.now() / 1000)}`,
+    ],
+    Gio.SubprocessFlags.STDOUT_SILENCE | Gio.SubprocessFlags.STDERR_SILENCE,
+  )
+  return () => {
+    try {
+      proc.send_signal(2)
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+export default async () => {
+  await on('Gjs', async () => {
+    if (!avahiAvailable()) {
+      console.log('[lan-discovery-integration] avahi-tools not available — skipping suite')
+      return
+    }
+
+    await describe('LanBrowser real-Avahi end-to-end', async () => {
+      await it('sees a service published AFTER the browser starts', async () => {
+        // This is the regression — pre-fix `avahi-browse -t`
+        // exited on the cold-start empty scan and the browser
+        // missed the publish that happened a moment later.
+        const events: Array<{ kind: string; name: string }> = []
+        // Build a one-off browser pinned to our test service type
+        // (LanBrowser hard-codes the production SERVICE_TYPE).
+        const browserProc = Gio.Subprocess.new(
+          ['avahi-browse', '-r', '-p', TEST_SERVICE_TYPE],
+          Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE,
+        )
+        const stdout = browserProc.get_stdout_pipe()
+        if (!stdout) throw new Error('no stdout pipe')
+        const reader = new Gio.DataInputStream({ base_stream: stdout })
+
+        let readerClosed = false
+        const readLoop = (): void => {
+          if (readerClosed) return
+          reader.read_line_async(GLib.PRIORITY_DEFAULT, null, (source, result) => {
+            if (readerClosed) return
+            try {
+              const [line] = (source as Gio.DataInputStream).read_line_finish(result)
+              if (line === null) {
+                readerClosed = true
+                return
+              }
+              const decoded =
+                typeof line === 'string' ? line : new TextDecoder().decode(line)
+              if (decoded.startsWith('=') || decoded.startsWith('+') || decoded.startsWith('-')) {
+                const fields = decoded.split(';')
+                events.push({ kind: decoded[0], name: fields[3] ?? '' })
+              }
+              readLoop()
+            } catch {
+              readerClosed = true
+            }
+          })
+        }
+        readLoop()
+
+        // Wait a beat to make sure the browser is fully up, THEN publish.
+        await new Promise<void>((r) => setTimeout(r, 200))
+        const cleanup = publishTestService('e2e-test-service', 9999)
+        try {
+          const sawResolve = await waitFor(
+            () => events.some((e) => e.kind === '=' && e.name === 'e2e-test-service'),
+            5_000,
+          )
+          expect(sawResolve).toBe(true)
+        } finally {
+          readerClosed = true
+          cleanup()
+          try {
+            browserProc.force_exit()
+          } catch {
+            /* already gone */
+          }
+        }
+      })
+
+      await it('LanPublisher + LanBrowser via the production wrappers', async () => {
+        // This time use the actual production classes — proves
+        // both ends wire correctly to the real Avahi binaries.
+        // Limitation: LanPublisher/LanBrowser hard-code the
+        // production SERVICE_TYPE, so this test sees real
+        // ambient sessions if any are running. We tag with a
+        // unique service name to filter for ourselves.
+        const sessionName = `e2e-test-${Math.floor(10_000 + Math.random() * 90_000)}`
+        const browser = new LanBrowser()
+        const seenNames: string[] = []
+        browser.start((event) => {
+          if (event.kind === 'resolved') seenNames.push(event.service.name)
+        })
+
+        await new Promise<void>((r) => setTimeout(r, 200))
+
+        const publisher = new LanPublisher()
+        publisher.publish({
+          name: sessionName,
+          port: 8765,
+          txt: {
+            version: '1',
+            kind: 'edit',
+            room: 'integration-test',
+            host: 'tester',
+            project: 'Integration',
+            peers: '1/2',
+            started: String(Math.floor(Date.now() / 1000)),
+          },
+        })
+
+        try {
+          const sawOurName = await waitFor(() => seenNames.includes(sessionName), 5_000)
+          expect(sawOurName).toBe(true)
+        } finally {
+          publisher.close()
+          browser.close()
+        }
+      })
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/lan-discovery.spec.ts
+++ b/apps/maker-gjs/src/services/lan-discovery.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Contract tests for the `avahi-browse` and `avahi-publish-service`
+ * argv shapes. These live as plain unit tests (no subprocess
+ * spawning) because the bugs they catch are configuration bugs
+ * caught at the wrong layer — a CI that runs Avahi end-to-end
+ * would catch them too, but at higher infra cost and only in the
+ * GJS-runtime slot.
+ *
+ * The regression that motivated this suite (2026-05-30): joiner's
+ * Welcome view stayed empty even when a host on the same LAN was
+ * actively publishing. Root cause: `avahi-browse -t` exits after
+ * its first scan; if the cold-start scan finds no services, the
+ * subprocess dies and the maker never re-tries. Removing `-t`
+ * keeps the subprocess alive for continuous monitoring.
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+
+import { AVAHI_BROWSE_ARGS, SERVICE_TYPE } from './lan-discovery.ts'
+
+export default async () => {
+  await describe('AVAHI_BROWSE_ARGS', async () => {
+    await it('starts with `avahi-browse`', async () => {
+      expect(AVAHI_BROWSE_ARGS[0]).toBe('avahi-browse')
+    })
+
+    await it('includes -r (resolve) so we get addresses + TXT', async () => {
+      expect(AVAHI_BROWSE_ARGS).toContain('-r')
+    })
+
+    await it('includes -p (parsable line-oriented output)', async () => {
+      expect(AVAHI_BROWSE_ARGS).toContain('-p')
+    })
+
+    await it('targets our service type', async () => {
+      expect(AVAHI_BROWSE_ARGS).toContain(SERVICE_TYPE)
+    })
+
+    await it('does NOT include -t (terminate) — the bug the suite was created for', async () => {
+      // `-t` makes avahi-browse exit after the initial scan. The
+      // LanBrowser treats stdout EOF as "subprocess died" and
+      // closes itself, so hosts that publish later go undiscovered.
+      // Keep the subprocess long-running.
+      expect(AVAHI_BROWSE_ARGS).not.toContain('-t')
+    })
+
+    await it('does NOT include -c (cache-only) — would be the same class of bug', async () => {
+      // `-c` makes avahi-browse exit after dumping the cache.
+      // Same EOF-kills-the-browser problem as -t. Listed
+      // explicitly so a future "let's only see cached entries"
+      // refactor can't slip past unit tests.
+      expect(AVAHI_BROWSE_ARGS).not.toContain('-c')
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/lan-discovery.ts
+++ b/apps/maker-gjs/src/services/lan-discovery.ts
@@ -10,6 +10,19 @@ import { type DiscoveredService, type LanDiscoveryEvent, parseAvahiBrowseLine } 
  */
 export const SERVICE_TYPE = '_pixelrpg._tcp'
 
+/**
+ * Argv for the long-running `avahi-browse` subprocess. Exported as
+ * a constant so unit tests can lock in the contract: NO `-t` flag
+ * (terminate after initial dump) — without that guard the browser
+ * exits after its first scan and the LanBrowser stops receiving
+ * events for hosts that publish later.
+ *
+ * Flags:
+ *   -r   resolve every appeared service (gives us address + TXT)
+ *   -p   parseable line-oriented output (one event per line)
+ */
+export const AVAHI_BROWSE_ARGS: readonly string[] = ['avahi-browse', '-r', '-p', SERVICE_TYPE] as const
+
 export interface SessionAdvertisement {
   /** Human-readable session label shown in the joiner's UI. */
   name: string
@@ -108,7 +121,8 @@ export class LanBrowser {
     if (this.process) throw new Error('LanBrowser: already running')
     this.onEvent = onEvent
 
-    const args = ['avahi-browse', '-r', '-p', '-t', SERVICE_TYPE]
+    const args = [...AVAHI_BROWSE_ARGS]
+    console.log(`[lan-discovery] starting browser: ${args.join(' ')}`)
     try {
       this.process = Gio.Subprocess.new(
         args,

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -1,5 +1,7 @@
 import { run } from '@gjsify/unit'
 
+import lanDiscoverySuite from './services/lan-discovery.spec.js'
+import lanDiscoveryIntegrationSuite from './services/lan-discovery-integration.gjs.spec.js'
 import lanDiscoveryParseSuite from './services/lan-discovery-parse.spec.js'
 import lanSignallingIntegrationSuite from './services/lan-signalling-integration.spec.js'
 import lanSignallingSuite from './services/lan-signalling.spec.js'
@@ -9,6 +11,8 @@ import sandboxPathSuite from './services/sandbox-path.spec.js'
 import sessionServiceSuite from './services/session-service.spec.js'
 
 run({
+  lanDiscoverySuite,
+  lanDiscoveryIntegrationSuite,
   lanDiscoveryParseSuite,
   lanSignallingIntegrationSuite,
   lanSignallingSuite,


### PR DESCRIPTION
## Summary

User-reported hand-test (2026-05-30): joiner's "Sessions on this network" stayed empty even when a host on the same LAN was actively publishing. Same pattern hand-tested independently with `avahi-browse -r -p -t _pixelrpg._tcp` directly — confirmed Avahi sees the service, but our subprocess wrapper missed it.

### Root cause

`avahi-browse -t` (terminate after initial dump) exits immediately after the cold-start scan. If the scan finds no services because the host hasn't published yet, the subprocess closes, the `LanBrowser` hits EOF on stdout, calls `this.close()`, and never tries again. The browser then misses EVERY subsequent publish.

### Fix

Drop the `-t` flag. `avahi-browse` without `-t` runs forever, emitting `+` (appeared) / `=` (resolved) / `-` (withdrew) lines as services come and go — which is what the LanBrowser was designed to consume.

### User feedback addressed

> "deine tests haben offenbar nicht genug abgedeckt sodass du das problem nicht selbstständig finden konntest"

Two layers of new test coverage:

**`apps/maker-gjs/src/services/lan-discovery.spec.ts`** (new) — unit suite locking the argv contract. Exports `AVAHI_BROWSE_ARGS` as a constant; tests assert it starts with `avahi-browse`, includes `-r` / `-p` / our service type, and explicitly **does NOT** include `-t` (regression marker, named after the bug) or `-c` (cache-only — same bug class).

**`apps/maker-gjs/src/services/lan-discovery-integration.gjs.spec.ts`** (new) — real-Avahi GJS-only end-to-end suite. Actually spawns `avahi-publish-service` + `avahi-browse` via `Gio.Subprocess`, lets the system's `avahi-daemon` handle the mDNS round-trip, asserts the browser SEES a service published AFTER it starts (the exact pattern the user's hand-test hit). Skips gracefully when `avahi-tools` is missing. Two specs — direct spawn for the cold-start regression, full `LanPublisher`+`LanBrowser` run for production-wrapper sanity. **Both pass post-fix.**

### Files

- `apps/maker-gjs/src/services/lan-discovery.ts` — argv extracted to `AVAHI_BROWSE_ARGS` constant, `-t` removed, one-line diagnostic on browser start
- `apps/maker-gjs/src/services/lan-discovery.spec.ts` (new) — 6 contract tests
- `apps/maker-gjs/src/services/lan-discovery-integration.gjs.spec.ts` (new) — 2 real-Avahi integration tests
- `apps/maker-gjs/src/test.mts` — register both suites

### Hand-test path to validate

```bash
gjsify workspace @pixelrpg/maker-gjs build
gjsify workspace @pixelrpg/maker-gjs start
# Terminal 2
dbus-run-session -- gjsify workspace @pixelrpg/maker-gjs start
```

- Terminal 2's Welcome view shows Terminal 1's session in "Sessions on this network"
- Paste-link join also works (routes through LAN, fixed in #107)

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify foreach build -v -t` clean
- [x] `gjsify workspace @pixelrpg/maker-gjs test` 97 GJS / 99 Node green (the integration suite ignored on Node via `on('Gjs')`)
- [x] Local Avahi round-trip — verified both integration tests pass against real `avahi-daemon`
- [ ] CI passes on PR