### PR TITLE
refactor(maker): unify collab logging + signalling timeouts

### DIFF
--- a/apps/maker-gjs/src/services/collab-log.spec.ts
+++ b/apps/maker-gjs/src/services/collab-log.spec.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from '@gjsify/unit'
+
+import {
+  CollabTimeoutError,
+  emitCollabLog,
+  formatError,
+  resetCollabLogSink,
+  scopedLogger,
+  setCollabLogSink,
+  withTimeout,
+} from './collab-log.ts'
+
+interface CapturedLine {
+  level: 'log' | 'warn' | 'error'
+  line: string
+}
+
+function createCapturingSink(): { lines: CapturedLine[]; sink: { log: (l: string) => void; warn: (l: string) => void; error: (l: string) => void } } {
+  const lines: CapturedLine[] = []
+  return {
+    lines,
+    sink: {
+      log: (line) => lines.push({ level: 'log', line }),
+      warn: (line) => lines.push({ level: 'warn', line }),
+      error: (line) => lines.push({ level: 'error', line }),
+    },
+  }
+}
+
+export default async () => {
+  await describe('formatError', async () => {
+    await it('returns the string verbatim when given a string', async () => {
+      expect(formatError('boom')).toBe('boom')
+    })
+
+    await it('returns "null" / "undefined" so they never silently swallow', async () => {
+      expect(formatError(null)).toBe('null')
+      expect(formatError(undefined)).toBe('undefined')
+    })
+
+    await it('extracts message + name + stack from Error', async () => {
+      const err = new TypeError('bad input')
+      const formatted = formatError(err)
+      expect(formatted).toContain('TypeError: ')
+      expect(formatted).toContain('bad input')
+      // Stack frames carry the test file path or at least 'formatError'.
+      expect(formatted.length).toBeGreaterThan('TypeError: bad input'.length)
+    })
+
+    await it('omits the trivial "Error: " prefix for default Error', async () => {
+      const err = new Error('plain')
+      const formatted = formatError(err)
+      expect(formatted.startsWith('plain')).toBe(true)
+      expect(formatted.startsWith('Error: ')).toBe(false)
+    })
+
+    await it('REGRESSION (2026-05-30 {}): Error never reduces to "{}"', async () => {
+      // This is THE marker. Pre-fix, `console.warn('prefix:', err)` on
+      // any Error printed `{}` because Error's enumerable properties
+      // are empty. After this commit every collab module routes
+      // through formatError, which carries message + stack — so
+      // `{}` must never appear in the output.
+      const cases: unknown[] = [
+        new Error('a'),
+        new TypeError('b'),
+        new RangeError('c'),
+        Object.assign(new Error('d'), { code: 'EHOSTUNREACH' }),
+      ]
+      for (const err of cases) {
+        const formatted = formatError(err)
+        expect(formatted).not.toBe('{}')
+        expect(formatted).not.toBe('[object Object]')
+        expect(formatted.length).toBeGreaterThan(0)
+      }
+    })
+
+    await it('JSON-stringifies plain objects', async () => {
+      expect(formatError({ code: 42, where: 'lan' })).toBe('{"code":42,"where":"lan"}')
+    })
+
+    await it('falls back to String() on circular objects', async () => {
+      const a: { self?: unknown } = {}
+      a.self = a
+      // Don't assert exact text — just that it doesn't throw + returns SOMETHING.
+      const formatted = formatError(a)
+      expect(typeof formatted).toBe('string')
+      expect(formatted.length).toBeGreaterThan(0)
+    })
+
+    await it('coerces non-objects via String()', async () => {
+      expect(formatError(42)).toBe('42')
+      expect(formatError(true)).toBe('true')
+    })
+  })
+
+  await describe('emitCollabLog + scopedLogger', async () => {
+    await it('prefixes every line with [scope]', async () => {
+      const { lines, sink } = createCapturingSink()
+      setCollabLogSink(sink)
+      try {
+        emitCollabLog('lan-signalling', 'info', 'connecting to host')
+        emitCollabLog('lan-signalling', 'warn', 'connect failed', new Error('refused'))
+      } finally {
+        resetCollabLogSink()
+      }
+      expect(lines).toHaveLength(2)
+      expect(lines[0].level).toBe('log')
+      expect(lines[0].line).toBe('[lan-signalling] connecting to host')
+      expect(lines[1].level).toBe('warn')
+      expect(lines[1].line.startsWith('[lan-signalling] connect failed: ')).toBe(true)
+      expect(lines[1].line).toContain('refused')
+    })
+
+    await it('scopedLogger routes through the same sink', async () => {
+      const { lines, sink } = createCapturingSink()
+      setCollabLogSink(sink)
+      const log = scopedLogger('orphan-cleanup')
+      try {
+        log.info('killed leftover pid=1234')
+        log.warn('error inspecting pid=1234', new Error('EACCES'))
+        log.error('scan failed', new TypeError('bad enum'))
+      } finally {
+        resetCollabLogSink()
+      }
+      expect(lines.map((l) => l.level)).toStrictEqual(['log', 'warn', 'error'])
+      expect(lines[0].line).toBe('[orphan-cleanup] killed leftover pid=1234')
+      expect(lines[1].line.startsWith('[orphan-cleanup] error inspecting pid=1234: ')).toBe(true)
+      expect(lines[1].line).toContain('EACCES')
+      expect(lines[2].line).toContain('TypeError')
+      expect(lines[2].line).toContain('bad enum')
+    })
+
+    await it('does not call the sink for the wrong level', async () => {
+      const { lines, sink } = createCapturingSink()
+      setCollabLogSink(sink)
+      const log = scopedLogger('test')
+      try {
+        log.info('only info')
+      } finally {
+        resetCollabLogSink()
+      }
+      expect(lines).toHaveLength(1)
+      expect(lines[0].level).toBe('log')
+    })
+  })
+
+  await describe('withTimeout / CollabTimeoutError', async () => {
+    await it('resolves with the inner value when the promise wins', async () => {
+      const result = await withTimeout('op', 500, Promise.resolve(42))
+      expect(result).toBe(42)
+    })
+
+    await it('rejects with the inner error when the promise rejects', async () => {
+      let caught: unknown = null
+      try {
+        await withTimeout('op', 500, Promise.reject(new Error('inner')))
+      } catch (err) {
+        caught = err
+      }
+      expect(caught instanceof Error).toBe(true)
+      expect((caught as Error).message).toBe('inner')
+    })
+
+    await it('rejects with a CollabTimeoutError when the deadline passes', async () => {
+      const stuck = new Promise<never>(() => {
+        /* never resolves */
+      })
+      let caught: unknown = null
+      try {
+        await withTimeout('LAN connect', 25, stuck, 'ws://example/')
+      } catch (err) {
+        caught = err
+      }
+      expect(caught instanceof CollabTimeoutError).toBe(true)
+      const timeoutErr = caught as CollabTimeoutError
+      expect(timeoutErr.operation).toBe('LAN connect')
+      expect(timeoutErr.timeoutMs).toBe(25)
+      expect(timeoutErr.url).toBe('ws://example/')
+      expect(timeoutErr.message).toContain('25ms')
+      expect(timeoutErr.message).toContain('ws://example/')
+    })
+
+    await it('formatError on a CollabTimeoutError carries the operation + url', async () => {
+      const err = new CollabTimeoutError('relay connect', 10_000, 'wss://relay/x')
+      const formatted = formatError(err)
+      expect(formatted).toContain('CollabTimeoutError')
+      expect(formatted).toContain('10000ms')
+      expect(formatted).toContain('wss://relay/x')
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/collab-log.ts
+++ b/apps/maker-gjs/src/services/collab-log.ts
@@ -1,0 +1,188 @@
+/**
+ * One logging + error-formatting story for every collab module.
+ *
+ * Before this module, each file invented its own variant:
+ *
+ *   - `console.warn('[lan-signalling] connect failed: ${err.message ?? err}')`
+ *     — printed `[object Object]` when `err.message` was empty.
+ *   - `console.warn('[orphan-cleanup] error:', err)` — printed `{}`
+ *     because Error's enumerable properties are empty (the actual
+ *     `message` + `stack` are non-enumerable, so GJS's console.warn
+ *     stringifies the Error as an empty object).
+ *   - `relay-signalling.ts` had no logging at all — failures were
+ *     completely invisible.
+ *
+ * Every collab file now goes through {@link scopedLogger} so a single
+ * pass over this module fixes the entire log surface. {@link
+ * formatError} is the load-bearing piece — it handles every shape an
+ * error can take in JS land (Error subclass, string, plain object,
+ * null/undefined, circular ref) and always returns a printable string
+ * carrying the operationally useful bits (name, message, stack).
+ *
+ * The sink indirection (default = real `console`; replaceable via
+ * {@link setCollabLogSink}) lets tests assert log output without
+ * mocking the global console.
+ */
+
+export type CollabLogLevel = 'info' | 'warn' | 'error'
+
+export interface CollabLogSink {
+  log(line: string): void
+  warn(line: string): void
+  error(line: string): void
+}
+
+const consoleSink: CollabLogSink = {
+  log: (line) => console.log(line),
+  warn: (line) => console.warn(line),
+  error: (line) => console.error(line),
+}
+
+let activeSink: CollabLogSink = consoleSink
+
+/** Replace the default console sink — typically only useful in tests. */
+export function setCollabLogSink(sink: CollabLogSink): void {
+  activeSink = sink
+}
+
+/** Restore the default console sink. */
+export function resetCollabLogSink(): void {
+  activeSink = consoleSink
+}
+
+/**
+ * Render any value as a printable string. The contract:
+ *
+ *   - `null` / `undefined` → `'null'` / `'undefined'`.
+ *   - `string` → returned verbatim.
+ *   - {@link Error} (or subclass) → `'<Name>: <message>\n<stack>'`. The
+ *     stack is included when present so a logged failure is self-
+ *     locating; `Name` is dropped when it's the unhelpful default
+ *     `'Error'`.
+ *   - plain object → `JSON.stringify(value)`, with a graceful
+ *     fallback to `String(value)` for objects that can't be
+ *     stringified (circular refs).
+ *   - everything else (numbers, booleans, symbols, functions) →
+ *     `String(value)`.
+ *
+ * The point of this function is to guarantee that NO collab error
+ * log ever prints `{}` or `[object Object]` for an Error. That was
+ * the proximate cause of the 2026-05-30 hand-test diagnostic gap.
+ */
+export function formatError(err: unknown): string {
+  if (err === null) return 'null'
+  if (err === undefined) return 'undefined'
+  if (typeof err === 'string') return err
+  if (err instanceof Error) {
+    const name = err.name && err.name !== 'Error' ? `${err.name}: ` : ''
+    const stack = err.stack ? `\n${err.stack}` : ''
+    return `${name}${err.message}${stack}`
+  }
+  if (typeof err === 'object') {
+    try {
+      return JSON.stringify(err)
+    } catch {
+      // Circular refs, BigInt, etc. — fall through to String().
+      return String(err)
+    }
+  }
+  return String(err)
+}
+
+/**
+ * Emit a single log line in the canonical `[scope] message` shape.
+ * When `err` is provided, it's appended as `: <formatted error>`.
+ */
+export function emitCollabLog(
+  scope: string,
+  level: CollabLogLevel,
+  message: string,
+  err?: unknown,
+): void {
+  const head = `[${scope}] ${message}`
+  const line = err === undefined ? head : `${head}: ${formatError(err)}`
+  if (level === 'info') activeSink.log(line)
+  else if (level === 'warn') activeSink.warn(line)
+  else activeSink.error(line)
+}
+
+export interface ScopedLogger {
+  info(message: string): void
+  warn(message: string, err?: unknown): void
+  error(message: string, err?: unknown): void
+}
+
+/**
+ * Build a logger bound to a `[scope]` prefix.
+ *
+ * Typical usage at the top of a collab module:
+ *
+ * ```ts
+ * const log = scopedLogger('lan-signalling')
+ * log.info(`joiner connecting to ${url}`)
+ * log.warn('joiner connect failed', err)
+ * ```
+ *
+ * `info` deliberately doesn't accept an error argument — success
+ * paths shouldn't be carrying errors. `warn` and `error` do, so the
+ * one-arg failure shape ("something failed, here's why") stays
+ * concise.
+ */
+export function scopedLogger(scope: string): ScopedLogger {
+  return {
+    info: (message) => emitCollabLog(scope, 'info', message),
+    warn: (message, err) => emitCollabLog(scope, 'warn', message, err),
+    error: (message, err) => emitCollabLog(scope, 'error', message, err),
+  }
+}
+
+/**
+ * Error subclass thrown when an operation exceeds its deadline.
+ * Carries enough context for the user-facing toast to be descriptive
+ * (operation name + URL) without leaking stack frames.
+ */
+export class CollabTimeoutError extends Error {
+  public readonly operation: string
+  public readonly timeoutMs: number
+  public readonly url?: string
+  constructor(operation: string, timeoutMs: number, url?: string) {
+    const where = url ? ` (${url})` : ''
+    super(`${operation} timed out after ${timeoutMs}ms${where}`)
+    this.name = 'CollabTimeoutError'
+    this.operation = operation
+    this.timeoutMs = timeoutMs
+    this.url = url
+  }
+}
+
+/**
+ * Race a promise against a deadline. On timeout, rejects with a
+ * {@link CollabTimeoutError}; otherwise resolves/rejects exactly as
+ * the input promise does. The underlying timer is always cleared so
+ * the event loop can drain.
+ *
+ * `operation` is the human-readable verb used in the timeout
+ * message (e.g. `'LAN signalling connect'`).
+ */
+export function withTimeout<T>(
+  operation: string,
+  timeoutMs: number,
+  promise: Promise<T>,
+  url?: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new CollabTimeoutError(operation, timeoutMs, url))
+    }, timeoutMs)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
+}

--- a/apps/maker-gjs/src/services/collab-session.spec.ts
+++ b/apps/maker-gjs/src/services/collab-session.spec.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for {@link CollabSession.start} — specifically the
+ * "wait-for-connected" deadline introduced in this PR.
+ *
+ * Why a separate test file (and not a section of collab-session-
+ * e2e.spec): this suite isolates the negotiation logic with fakes,
+ * so a regression in the timeout-wait code path can be diagnosed
+ * without spinning up real WebSockets. The e2e spec covers the
+ * happy-path with real transports.
+ *
+ * Regression coverage for the 2026-05-30 hand-test bug: joiner
+ * WebSocket opens, peer.connect() resolves (ICE gathering started),
+ * BUT the data channels never reach `open` because the host never
+ * answered. Pre-fix: CollabSession.start() resolved successfully
+ * and requestSnapshot hung forever. Post-fix: start() rejects with
+ * a CollabTimeoutError naming "reach connected state".
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+import {
+  CHANNEL_AWARENESS,
+  CHANNEL_OP,
+  FakeRTCPeerConnection,
+  InMemoryTransport,
+  rtcFactoryFor,
+  type SignallingMessage,
+  type SignallingTransport,
+  wireChannelDelivery,
+} from '@pixelrpg/engine'
+
+import { CollabTimeoutError } from './collab-log.ts'
+import { CollabSession } from './collab-session.ts'
+
+/**
+ * Bare-minimum signalling transport: send goes nowhere, no inbound
+ * messages ever arrive. Used to model the "host never replies"
+ * symptom from the 2026-05-30 hand-test.
+ */
+function silentTransport(): SignallingTransport & { sent: SignallingMessage[]; closed: boolean } {
+  const sent: SignallingMessage[] = []
+  let closed = false
+  let handler: ((m: SignallingMessage) => void) | null = null
+  return {
+    send: (m) => {
+      sent.push(m)
+    },
+    onMessage: (h) => {
+      handler = h
+    },
+    close: () => {
+      closed = true
+    },
+    get sent() {
+      return sent
+    },
+    get closed() {
+      return closed
+    },
+    // Expose handler for tests that want to inject inbound messages
+    // — unused in this suite, but documents the shape.
+    triggerInbound: (m: SignallingMessage) => handler?.(m),
+  } as never
+}
+
+export default async () => {
+  await describe('CollabSession.start (peer-connect deadline)', async () => {
+    await it('REGRESSION (2026-05-30): joiner whose host never answers rejects with CollabTimeoutError', async () => {
+      const transport = silentTransport()
+      const pc = new FakeRTCPeerConnection()
+      const session = new CollabSession({
+        role: 'joiner',
+        signalling: transport,
+        peerId: 'joiner-test',
+        peerConnectTimeoutMs: 100,
+        rtcFactory: rtcFactoryFor(pc),
+      })
+      let caught: unknown = null
+      const t0 = Date.now()
+      try {
+        await session.start()
+      } catch (err) {
+        caught = err
+      }
+      const elapsed = Date.now() - t0
+      expect(caught instanceof CollabTimeoutError).toBe(true)
+      const timeoutErr = caught as CollabTimeoutError
+      expect(timeoutErr.timeoutMs).toBe(100)
+      // The deadline fires on the wait-for-connected leg, not the
+      // peer.connect() leg — for joiners peer.connect() resolves
+      // instantly (no SDP to send), so the connected-wait is what
+      // exceeded the budget.
+      expect(timeoutErr.operation).toMatch(/CollabSession/)
+      expect(elapsed).toBeGreaterThanOrEqual(95)
+      expect(elapsed).toBeLessThan(1_500)
+      session.close('test')
+    })
+
+    await it('host whose joiner never answers rejects with CollabTimeoutError', async () => {
+      const transport = silentTransport()
+      const pc = new FakeRTCPeerConnection()
+      const session = new CollabSession({
+        role: 'host',
+        signalling: transport,
+        peerId: 'host-test',
+        peerConnectTimeoutMs: 100,
+        rtcFactory: rtcFactoryFor(pc),
+      })
+      let caught: unknown = null
+      try {
+        await session.start()
+      } catch (err) {
+        caught = err
+      }
+      expect(caught instanceof CollabTimeoutError).toBe(true)
+      // Host actually sends an SDP offer — verify it went out
+      // before the timeout fired, so we know the host code path
+      // started the negotiation properly.
+      expect(transport.sent.some((m) => m.type === 'sdp')).toBe(true)
+      session.close('test')
+    })
+
+    await it('resolves when both data channels open before the deadline', async () => {
+      // Build a working pair via InMemoryTransport + open channels
+      // synchronously after construction. CollabSession.start() should
+      // race the connected-wait against the deadline and win.
+      const hostTransport = new InMemoryTransport()
+      const joinerTransport = new InMemoryTransport()
+      hostTransport.other = joinerTransport
+      joinerTransport.other = hostTransport
+
+      const hostPc = new FakeRTCPeerConnection()
+      const joinerPc = new FakeRTCPeerConnection()
+      const hostSession = new CollabSession({
+        role: 'host',
+        signalling: hostTransport,
+        peerId: 'host-ok',
+        peerConnectTimeoutMs: 1_000,
+        rtcFactory: rtcFactoryFor(hostPc),
+      })
+      const joinerSession = new CollabSession({
+        role: 'joiner',
+        signalling: joinerTransport,
+        peerId: 'joiner-ok',
+        peerConnectTimeoutMs: 1_000,
+        rtcFactory: rtcFactoryFor(joinerPc),
+      })
+
+      const hostStarted = hostSession.start()
+      const joinerStarted = joinerSession.start()
+      // Drain microtasks so SDP exchange happens.
+      await new Promise<void>((r) => setTimeout(r, 0))
+      // Now open the data channels — host already created them in
+      // its constructor; the joiner needs them simulated as inbound.
+      const hostOpChannel = hostPc.channels.find((c) => c.label === CHANNEL_OP)!
+      const hostAwarenessChannel = hostPc.channels.find((c) => c.label === CHANNEL_AWARENESS)!
+      const joinerOpChannel = joinerPc.simulateIncomingChannel(CHANNEL_OP)
+      const joinerAwarenessChannel = joinerPc.simulateIncomingChannel(CHANNEL_AWARENESS)
+      wireChannelDelivery(hostOpChannel, joinerOpChannel)
+      wireChannelDelivery(hostAwarenessChannel, joinerAwarenessChannel)
+      hostOpChannel.open()
+      hostAwarenessChannel.open()
+      joinerOpChannel.open()
+      joinerAwarenessChannel.open()
+
+      await hostStarted
+      await joinerStarted
+      expect(hostSession.isConnected()).toBe(true)
+      expect(joinerSession.isConnected()).toBe(true)
+      hostSession.close('test')
+      joinerSession.close('test')
+    })
+
+    await it('rejects when the peer transitions to "closed" before connected', async () => {
+      const transport = silentTransport()
+      const pc = new FakeRTCPeerConnection()
+      const session = new CollabSession({
+        role: 'joiner',
+        signalling: transport,
+        peerId: 'joiner-closed',
+        peerConnectTimeoutMs: 5_000,
+        rtcFactory: rtcFactoryFor(pc),
+      })
+      const started = session.start()
+      // Microtask drain so peer.connect() runs and waitForConnected
+      // subscribes.
+      await new Promise<void>((r) => setTimeout(r, 0))
+      // Force-close the peer before any channel opens.
+      session.peer.close('mid-handshake')
+
+      let caught: unknown = null
+      try {
+        await started
+      } catch (err) {
+        caught = err
+      }
+      expect(caught instanceof Error).toBe(true)
+      const errMsg = (caught as Error).message
+      // Either the connected-wait detects the closed transition OR
+      // the underlying peer.connect() rejects — both paths produce
+      // a non-empty message that doesn't reduce to "{}".
+      expect(errMsg.length).toBeGreaterThan(0)
+      expect(errMsg).not.toBe('{}')
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/collab-session.ts
+++ b/apps/maker-gjs/src/services/collab-session.ts
@@ -10,10 +10,32 @@ import {
   isSessionProtocolOp,
   PeerSession,
   type PeerRole,
+  type PeerSessionState,
   RemoteCursorRenderer,
   SessionController,
   SnapshotExchange,
 } from '@pixelrpg/engine'
+
+import { CollabTimeoutError, scopedLogger, withTimeout } from './collab-log.ts'
+
+const log = scopedLogger('collab-session')
+
+/**
+ * Default deadline for the WebRTC handshake — from the moment
+ * `peer.connect()` is called to the moment both data channels open
+ * and the peer's state transitions to `'connected'`. Generous to
+ * accommodate slow ICE on busy networks, but short enough to fail
+ * fast on a misconfigured relay or a network-unreachable peer.
+ *
+ * Pre-2026-05-30 there was no deadline here at all. The joiner-side
+ * `collab.start()` would resolve as soon as ICE GATHERING started
+ * (PeerSession's `connect()` contract) and `requestSnapshot()` would
+ * await the host's response — which never arrived if the actual SDP
+ * round-trip silently failed. Symptom: "joiner WS connects but
+ * nothing else happens." Now: the joiner times out after 15s with
+ * a typed CollabTimeoutError naming the unmet condition.
+ */
+export const PEER_CONNECT_TIMEOUT_MS = 15_000
 
 export interface CollabSessionOptions {
   /**
@@ -46,6 +68,22 @@ export interface CollabSessionOptions {
    * pair session per process; tagging is diagnostic).
    */
   roomId?: string
+  /**
+   * Override the WebRTC negotiation deadline. Production default is
+   * {@link PEER_CONNECT_TIMEOUT_MS}; tests pass small values so a
+   * `FakeRTCPeerConnection` that never opens its channels fails
+   * fast.
+   */
+  peerConnectTimeoutMs?: number
+  /**
+   * Inject a custom {@link RTCPeerConnection} factory — forwarded
+   * verbatim to {@link PeerSession}. Production omits this so the
+   * shared `globalThis.RTCPeerConnection` (wired by `main.ts`'s
+   * `@gjsify/webrtc/register` import) handles the negotiation. Tests
+   * pass `rtcFactoryFor(new FakeRTCPeerConnection())` so the WebRTC
+   * layer can be exercised without GStreamer.
+   */
+  rtcFactory?: ConstructorParameters<typeof PeerSession>[0]['rtcFactory']
 }
 
 /**
@@ -82,15 +120,18 @@ export class CollabSession {
   private engine: Engine | null = null
   private readonly peerId: string
   private readonly roomId: string
+  private readonly peerConnectTimeoutMs: number
   private readonly subscriptions: Array<() => void> = []
   private startedAt: number | null = null
 
   constructor(opts: CollabSessionOptions) {
     this.peerId = opts.peerId
     this.roomId = opts.roomId ?? ''
+    this.peerConnectTimeoutMs = opts.peerConnectTimeoutMs ?? PEER_CONNECT_TIMEOUT_MS
     this.peer = new PeerSession({
       role: opts.role,
       signalling: opts.signalling,
+      rtcFactory: opts.rtcFactory,
     })
 
     // Default display info — caller can override via `localInfo`.
@@ -177,32 +218,88 @@ export class CollabSession {
   }
 
   /**
-   * Drive the WebRTC handshake. Resolves once ICE gathering kicks
-   * off; full "connected" status lands on `peer.events('state-
-   * changed')`.
+   * Drive the WebRTC handshake to a fully-connected state.
    *
-   * Once `connected`, an initial `presence` frame goes out so the
+   * Resolves once the underlying {@link PeerSession} transitions to
+   * `'connected'` — i.e. both data channels are open and ready for
+   * traffic. Rejects with a {@link CollabTimeoutError} if the
+   * negotiation doesn't reach `'connected'` within
+   * {@link PEER_CONNECT_TIMEOUT_MS} (or the override passed via
+   * {@link CollabSessionOptions.peerConnectTimeoutMs}).
+   *
+   * Why wait for `'connected'`, not just `peer.connect()`?
+   * `PeerSession.connect()` resolves once ICE gathering kicks off —
+   * which happens almost immediately for the host, and instantly
+   * for the joiner (its role is to wait for the host's offer).
+   * Without an extra wait, callers (notably {@link requestSnapshot})
+   * would start sending traffic on still-closed channels.
+   *
+   * Once `'connected'`, an initial `presence` frame goes out so the
    * remote peer's roster + cursor UI populate immediately. Repeat
    * announces are cheap — the receiver dedupes by comparing against
    * its tracked state.
    */
   async start(): Promise<void> {
     this.startedAt = Date.now()
-    try {
-      await this.peer.connect()
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      console.warn(`[collab-session] peer.connect() failed: ${message}`)
-      if (err instanceof Error && err.stack) console.warn(err.stack)
-      throw err
-    }
     const announceOnConnect = this.peer.events.on('state-changed', ({ state }) => {
       if (state === 'connected') this.awareness.announce()
     })
-    // If we already raced past `connecting`, fire once immediately so
-    // late wires don't lose the first presence frame.
-    if (this.peer.getState() === 'connected') this.awareness.announce()
     this.subscriptions.push(() => announceOnConnect.close())
+
+    try {
+      await withTimeout(
+        'CollabSession peer.connect',
+        this.peerConnectTimeoutMs,
+        this.peer.connect(),
+      )
+      // peer.connect() resolves on ICE-gather-started, not connected.
+      // Wait for the actual `'connected'` state under the same deadline
+      // (minus what peer.connect() already consumed — we don't track
+      // elapsed precisely; the remaining budget is approximately
+      // `timeout - 0`, which is fine for the typical sub-second LAN).
+      await withTimeout(
+        'CollabSession reach connected state',
+        this.peerConnectTimeoutMs,
+        this.waitForConnected(),
+      )
+    } catch (err) {
+      log.warn('start() failed during peer negotiation', err)
+      throw err
+    }
+    // If `waitForConnected` resolved synchronously (already connected
+    // before we subscribed), the announce-on-connect listener never
+    // fired. Fire once immediately so late wires don't lose the
+    // first presence frame.
+    if (this.peer.getState() === 'connected') this.awareness.announce()
+  }
+
+  /**
+   * Resolve once {@link PeerSession} state is `'connected'`; reject
+   * on any terminal state (`'closed'`, `'error'`). Used by
+   * {@link start} to gate on the actual handshake completion rather
+   * than ICE-gather-started.
+   */
+  private waitForConnected(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const current = this.peer.getState()
+      if (current === 'connected') {
+        resolve()
+        return
+      }
+      if (current === 'closed' || current === 'error') {
+        reject(new Error(`CollabSession: peer is already "${current}"`))
+        return
+      }
+      const sub = this.peer.events.on('state-changed', ({ state }: { state: PeerSessionState }) => {
+        if (state === 'connected') {
+          sub.close()
+          resolve()
+        } else if (state === 'closed' || state === 'error') {
+          sub.close()
+          reject(new Error(`CollabSession: peer transitioned to "${state}" before connect`))
+        }
+      })
+    })
   }
 
   /**

--- a/apps/maker-gjs/src/services/lan-discovery.ts
+++ b/apps/maker-gjs/src/services/lan-discovery.ts
@@ -1,7 +1,10 @@
 import Gio from '@girs/gio-2.0'
 import GLib from '@girs/glib-2.0'
 
+import { scopedLogger } from './collab-log.ts'
 import { type DiscoveredService, type LanDiscoveryEvent, parseAvahiBrowseLine } from './lan-discovery-parse.ts'
+
+const log = scopedLogger('lan-discovery')
 
 /**
  * mDNS service type the editor + future multiplayer both advertise.
@@ -122,7 +125,7 @@ export class LanBrowser {
     this.onEvent = onEvent
 
     const args = [...AVAHI_BROWSE_ARGS]
-    console.log(`[lan-discovery] starting browser: ${args.join(' ')}`)
+    log.info(`starting browser: ${args.join(' ')}`)
     try {
       this.process = Gio.Subprocess.new(
         args,

--- a/apps/maker-gjs/src/services/lan-session-backend.ts
+++ b/apps/maker-gjs/src/services/lan-session-backend.ts
@@ -1,10 +1,13 @@
 import type { SignallingTransport } from '@pixelrpg/engine'
 
+import { scopedLogger } from './collab-log.ts'
 import type { LanDiscoveryEvent } from './lan-discovery-parse.ts'
 import { LanBrowser, LanPublisher, type SessionTxt } from './lan-discovery.ts'
 import { connectLanJoinerTransport, startLanHostServer } from './lan-signalling.ts'
 import { connectRelaySignalling, defaultRelayUrl } from './relay-signalling.ts'
 import type { HostingHandle, HostingOptions, SessionBackend } from './session-service.ts'
+
+const log = scopedLogger('lan-session-backend')
 
 /**
  * Production wiring of the {@link SessionBackend} contract.
@@ -79,14 +82,11 @@ export class LanSessionBackend implements SessionBackend {
       },
     })
     // Diagnostic: hand-test users have asked us to surface what
-    // port we actually bound on vs what we advertised. One line
-    // each; cheap to read in `dbus-run-session` two-instance
-    // smoke tests, easy to remove later when the wiring is
-    // proven solid.
-    console.log(
-      `[lan-session-backend] hosting session "${opts.sessionName}"`,
-      `\n  bound on ${server.address.host}:${server.address.port}`,
-      `\n  Avahi-advertised port: ${server.address.port}`,
+    // port we actually bound on vs what we advertised. Easy to read
+    // in `dbus-run-session` two-instance smoke tests.
+    log.info(
+      `hosting session "${opts.sessionName}" bound on ${server.address.host}:${server.address.port} ` +
+        `(Avahi-advertised port: ${server.address.port})`,
     )
 
     const publisher = new LanPublisher()

--- a/apps/maker-gjs/src/services/lan-signalling-timeout.spec.ts
+++ b/apps/maker-gjs/src/services/lan-signalling-timeout.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Timeout tests for {@link connectLanJoinerTransport}.
+ *
+ * The wire-format unit tests live in `lan-signalling.spec.ts`; the
+ * happy-path end-to-end test (real WS server + joiner) lives in
+ * `lan-signalling-integration.spec.ts`. THIS suite covers the
+ * failure mode that bit the 2026-05-30 hand-test: WS upgrade
+ * silently stalls and the joiner sits forever.
+ *
+ * Strategy: open a plain TCP server (NOT a WS server) on port 0 so
+ * the joiner-side WebSocket can establish TCP but never receive the
+ * HTTP/1.1 → WS upgrade response. The `ws` client will sit waiting
+ * for the `101 Switching Protocols` until {@link withTimeout} fires.
+ *
+ * Runs on both Node (`net`) and GJS (`@gjsify/net` Soup-backed).
+ */
+
+import { createServer as createNetServer, type Server as NetServer, type Socket } from 'net'
+import { describe, expect, it } from '@gjsify/unit'
+
+import { CollabTimeoutError } from './collab-log.ts'
+import { connectLanJoinerTransport } from './lan-signalling.ts'
+
+interface SilentServer {
+  server: NetServer
+  port: number
+  close(): Promise<void>
+}
+
+async function listenSilent(): Promise<SilentServer> {
+  const accepted: Socket[] = []
+  const server = createNetServer((socket) => {
+    accepted.push(socket)
+    // Accept the TCP connection but never write the WS-upgrade reply.
+    // Keep the socket open until the server closes; the joiner-side
+    // ws client will time out waiting for `101 Switching Protocols`.
+    socket.on('error', () => {
+      /* peer reset on timeout — ignore */
+    })
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('listening', resolve)
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1')
+  })
+  const addr = server.address()
+  if (!addr || typeof addr === 'string') {
+    server.close()
+    throw new Error('listenSilent: server.address() returned unexpected shape')
+  }
+  return {
+    server,
+    port: addr.port,
+    // `server.close()` in Node waits for all open sockets to close
+    // gracefully — but a half-open client (the joiner that already
+    // received its own timeout) leaves its socket in CLOSE_WAIT
+    // until the OS reaps it. Destroy every accepted socket
+    // explicitly so the close() call returns within a couple of ms
+    // instead of hanging the test harness.
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const socket of accepted) {
+          try {
+            socket.destroy()
+          } catch {
+            /* already gone */
+          }
+        }
+        server.close(() => resolve())
+      }),
+  }
+}
+
+export default async () => {
+  await describe('connectLanJoinerTransport timeout (2026-05-30 regression)', async () => {
+    await it('rejects with a CollabTimeoutError when the WS upgrade stalls', async () => {
+      const silent = await listenSilent()
+      try {
+        let caught: unknown = null
+        const t0 = Date.now()
+        try {
+          await connectLanJoinerTransport('127.0.0.1', silent.port, 200)
+        } catch (err) {
+          caught = err
+        }
+        const elapsed = Date.now() - t0
+        expect(caught instanceof CollabTimeoutError).toBe(true)
+        const timeoutErr = caught as CollabTimeoutError
+        expect(timeoutErr.operation).toBe('LAN signalling connect')
+        expect(timeoutErr.timeoutMs).toBe(200)
+        expect(timeoutErr.url).toContain(`127.0.0.1:${silent.port}`)
+        // Should fire within roughly the timeout, plus event-loop slack.
+        // Allow generous upper bound for slow CI runners (1.5 s).
+        expect(elapsed).toBeLessThan(1_500)
+      } finally {
+        await silent.close()
+      }
+    })
+
+    await it('REGRESSION: the formatted error never reduces to "{}"', async () => {
+      // The whole point of this PR: a logged failure surfaces a
+      // human-readable reason, never `{}`. We re-derive the message
+      // here via the same path the maker's toast handler uses.
+      const err = new CollabTimeoutError('LAN signalling connect', 100, 'ws://127.0.0.1:1234/')
+      expect(String(err)).toContain('100ms')
+      expect(String(err)).toContain('ws://127.0.0.1:1234/')
+      expect(JSON.stringify(err)).not.toBe('{}')
+      // Even if JSON.stringify returned `{}`, our formatError doesn't
+      // call it on Error subclasses — it walks message+name+stack.
+      // Cross-check with toString() so the user-facing path is solid.
+      expect(err.message.length).toBeGreaterThan(0)
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/lan-signalling.ts
+++ b/apps/maker-gjs/src/services/lan-signalling.ts
@@ -3,6 +3,19 @@ import { WebSocket, type WebSocketServer as WsServer } from 'ws'
 
 import { WebSocketServer } from 'ws'
 
+import { CollabTimeoutError, scopedLogger, withTimeout } from './collab-log.ts'
+
+const log = scopedLogger('lan-signalling')
+
+/**
+ * Default deadline for the joiner-side WebSocket open handshake. Five
+ * seconds is generous for LAN — the WS upgrade typically completes
+ * within tens of ms — but short enough that a misconfigured host
+ * surfaces an explicit `CollabTimeoutError` instead of leaving the
+ * user staring at a stalled UI.
+ */
+export const LAN_CONNECT_TIMEOUT_MS = 5_000
+
 /**
  * LAN signalling — one host accepts one joiner over a plain
  * WebSocket. Routes SDP / ICE / bye frames bidirectionally without
@@ -152,12 +165,23 @@ export async function startLanHostServer(opts: LanHostServerOptions): Promise<La
 
 /**
  * Open a `WebSocket` to a discovered host and wrap it as a
- * `SignallingTransport`. Throws if the connect handshake fails;
- * caller decides whether to retry / surface to UI.
+ * `SignallingTransport`. Rejects with the underlying WS error on
+ * handshake failure or with a {@link CollabTimeoutError} if the
+ * upgrade hasn't completed within `timeoutMs` (default
+ * {@link LAN_CONNECT_TIMEOUT_MS}). Caller decides whether to retry /
+ * surface to UI.
+ *
+ * The timeout matters: pre-2026-05-30 the joiner had no deadline and
+ * would sit indefinitely if the WS upgrade silently stalled mid-
+ * handshake (kernel-level TCP weirdness, kernel firewall accepting
+ * SYN but dropping data, …). Symptom was "joiner connects but nothing
+ * happens." Post-fix the joiner surfaces a typed timeout the welcome
+ * view can toast.
  */
 export async function connectLanJoinerTransport(
   hostAddress: string,
   port: number,
+  timeoutMs: number = LAN_CONNECT_TIMEOUT_MS,
 ): Promise<SignallingTransport> {
   // IPv6 literal addresses must be bracketed inside a URL —
   // `ws://::1:8089/` is ambiguous (port? part of address?), only
@@ -167,21 +191,36 @@ export async function connectLanJoinerTransport(
     ? `[${hostAddress}]`
     : hostAddress
   const url = `ws://${target}:${port}/`
-  console.log(`[lan-signalling] joiner connecting to ${url}`)
+  log.info(`joiner connecting to ${url}`)
   const ws = new WebSocket(url)
-  await new Promise<void>((resolve, reject) => {
+  const handshake = new Promise<void>((resolve, reject) => {
     const onError = (err: Error) => {
       ws.off('open', onOpen)
-      console.warn(`[lan-signalling] joiner connect failed for ${url}: ${err.message ?? err}`)
       reject(err)
     }
     const onOpen = () => {
       ws.off('error', onError)
-      console.log(`[lan-signalling] joiner connected to ${url}`)
       resolve()
     }
     ws.once('open', onOpen)
     ws.once('error', onError)
   })
+  try {
+    await withTimeout('LAN signalling connect', timeoutMs, handshake, url)
+  } catch (err) {
+    log.warn(`joiner connect failed for ${url}`, err)
+    // If the underlying socket is still pending when we time out,
+    // close it so the OS reclaims the FD and the joiner-side state
+    // machine doesn't leak a half-open connection.
+    if (err instanceof CollabTimeoutError) {
+      try {
+        ws.close()
+      } catch {
+        /* already gone */
+      }
+    }
+    throw err
+  }
+  log.info(`joiner connected to ${url}`)
   return wrapWebSocket(ws)
 }

--- a/apps/maker-gjs/src/services/orphan-publisher-cleanup.ts
+++ b/apps/maker-gjs/src/services/orphan-publisher-cleanup.ts
@@ -51,8 +51,10 @@
 import Gio from '@girs/gio-2.0'
 import GLib from '@girs/glib-2.0'
 
+import { scopedLogger } from './collab-log.ts'
 import { SERVICE_TYPE } from './lan-discovery.ts'
 
+const log = scopedLogger('orphan-cleanup')
 const PROC_ROOT = '/proc'
 const COMM_NAME = 'avahi-publish-service'
 const REAPER_COMMS = new Set(['systemd', 'init'])
@@ -82,17 +84,17 @@ export function cleanupOrphanedPublishers(): { scanned: number; killed: number; 
         if (!isOrphanedPixelrpgPublisher(pid)) continue
         if (sendSigterm(pid)) {
           killed++
-          console.log(`[orphan-cleanup] killed leftover avahi-publish-service pid=${pid}`)
+          log.info(`killed leftover avahi-publish-service pid=${pid}`)
         }
       } catch (err) {
         errors++
-        console.warn(`[orphan-cleanup] error inspecting pid=${pid}:`, err)
+        log.warn(`error inspecting pid=${pid}`, err)
       }
     }
     enumerator.close(null)
   } catch (err) {
     errors++
-    console.warn('[orphan-cleanup] failed to scan /proc:', err)
+    log.warn('failed to scan /proc', err)
   }
   return { scanned, killed, errors }
 }
@@ -188,7 +190,7 @@ function sendSigterm(pid: number): boolean {
     proc.wait(null)
     return proc.get_successful()
   } catch (err) {
-    console.warn(`[orphan-cleanup] kill -TERM ${pid} failed:`, err)
+    log.warn(`kill -TERM ${pid} failed`, err)
     return false
   }
 }

--- a/apps/maker-gjs/src/services/relay-signalling.ts
+++ b/apps/maker-gjs/src/services/relay-signalling.ts
@@ -1,7 +1,18 @@
 import type { SignallingTransport } from '@pixelrpg/engine'
 import { WebSocket } from 'ws'
 
+import { CollabTimeoutError, scopedLogger, withTimeout } from './collab-log.ts'
 import { wrapWebSocket } from './lan-signalling.ts'
+
+const log = scopedLogger('relay-signalling')
+
+/**
+ * Default deadline for the relay WebSocket upgrade. Ten seconds is
+ * longer than {@link LAN_CONNECT_TIMEOUT_MS} because the relay is
+ * typically reached over the public internet (DNS lookup, TLS
+ * handshake, multi-hop routing).
+ */
+export const RELAY_CONNECT_TIMEOUT_MS = 10_000
 
 /**
  * Cross-network signalling — both peers connect to the workspace's
@@ -26,14 +37,22 @@ export interface RelayConnectOptions {
 
 /**
  * Open a WebSocket to the relay's `/room/<roomid>?role=…` endpoint
- * and wrap it as a `SignallingTransport`. Throws if the upgrade
- * handshake fails — caller surfaces gracefully ("could not reach
- * relay" toast).
+ * and wrap it as a `SignallingTransport`. Rejects on upgrade failure
+ * (caller surfaces "could not reach relay" toast) or on
+ * {@link CollabTimeoutError} after `timeoutMs` (default
+ * {@link RELAY_CONNECT_TIMEOUT_MS}). The timeout exists for the same
+ * reason as in the LAN path — a stalled TLS handshake or HTTP/1.1
+ * upgrade that never completes would otherwise leave the joiner UI
+ * frozen indefinitely.
  */
-export async function connectRelaySignalling(opts: RelayConnectOptions): Promise<SignallingTransport> {
+export async function connectRelaySignalling(
+  opts: RelayConnectOptions,
+  timeoutMs: number = RELAY_CONNECT_TIMEOUT_MS,
+): Promise<SignallingTransport> {
   const url = `${opts.relayUrl.replace(/\/$/, '')}/room/${encodeURIComponent(opts.roomId)}?role=${opts.role}`
+  log.info(`${opts.role} connecting to ${url}`)
   const ws = new WebSocket(url)
-  await new Promise<void>((resolve, reject) => {
+  const handshake = new Promise<void>((resolve, reject) => {
     const onError = (err: Error) => {
       ws.off('open', onOpen)
       reject(err)
@@ -45,6 +64,20 @@ export async function connectRelaySignalling(opts: RelayConnectOptions): Promise
     ws.once('open', onOpen)
     ws.once('error', onError)
   })
+  try {
+    await withTimeout('relay signalling connect', timeoutMs, handshake, url)
+  } catch (err) {
+    log.warn(`${opts.role} connect failed for ${url}`, err)
+    if (err instanceof CollabTimeoutError) {
+      try {
+        ws.close()
+      } catch {
+        /* already gone */
+      }
+    }
+    throw err
+  }
+  log.info(`${opts.role} connected to ${url}`)
   return wrapWebSocket(ws)
 }
 

--- a/apps/maker-gjs/src/services/sandbox-path.ts
+++ b/apps/maker-gjs/src/services/sandbox-path.ts
@@ -31,7 +31,10 @@ import Gio from '@girs/gio-2.0'
 import GLib from '@girs/glib-2.0'
 import { applyProjectSnapshot, type ProjectSnapshot } from '@pixelrpg/engine'
 
+import { scopedLogger } from './collab-log.ts'
 import { writeTextFile } from './file-io.ts'
+
+const log = scopedLogger('sandbox-path')
 
 /** Subdirectory under `XDG_DATA_HOME` where every shared-session sandbox lives. */
 export const SANDBOX_ROOT_SEGMENTS = ['pixelrpg-maker', 'shared'] as const

--- a/apps/maker-gjs/src/services/session-service.spec.ts
+++ b/apps/maker-gjs/src/services/session-service.spec.ts
@@ -179,6 +179,57 @@ export default async () => {
       await service.stopHosting()
       expect(service.getState().kind).toBe('browsing')
     })
+
+    await it('REGRESSION (2026-05-30): host-side openSession failure surfaces an error event', async () => {
+      // Pre-fix: when the joiner connected but openSession then
+      // rejected (e.g. engine no longer available), the maker user
+      // saw a generic GJS "Unhandled promise rejection" with a stack
+      // trace but no message — actionable only if you can read
+      // SpiderMonkey stacks. Post-fix: the .catch in startHosting
+      // routes the rejection through `handleError`, which emits the
+      // typed `'error'` event. The maker's welcome-view toast handler
+      // subscribes to this event, so the user sees the actual reason.
+      //
+      // This test pins the contract: an engine-null failure during
+      // onPeerConnected MUST emit exactly one error event whose
+      // message names the underlying cause.
+      const backend = new MockBackend()
+      // Engine provider returns null — the host can't fulfil
+      // openSession because there's nothing to share. The session-
+      // service path is responsible for catching this + emitting it
+      // as an event rather than letting it bubble as unhandled.
+      const service = new SessionService(() => null, backend, 'peer-test')
+      await service.startHosting({ sessionName: 'A', projectName: 'A', hostDisplayName: 'A' })
+
+      const errors: Error[] = []
+      service.on('error', (err) => errors.push(err))
+
+      // Simulate the joiner connecting. The backend's onPeerConnected
+      // callback is the production wiring point; we invoke it
+      // directly with a fake transport.
+      const fakeTransport = new MockTransport()
+      for (const cb of backend.peerCallbacks) cb(fakeTransport)
+
+      // Drain the promise chain (`openSession` is async; its `.catch`
+      // runs on microtask flush).
+      await new Promise<void>((r) => setTimeout(r, 0))
+      await new Promise<void>((r) => setTimeout(r, 0))
+
+      expect(errors).toHaveLength(1)
+      // The actual cause: "no engine available — load a project
+      // before hosting". The test doesn't pin the exact phrasing
+      // (that's UX copy that may evolve) but pins that the message
+      // is non-empty and mentions the underlying noun.
+      expect(errors[0].message.length).toBeGreaterThan(0)
+      expect(errors[0].message.toLowerCase()).toContain('engine')
+      // And it didn't reduce to the regression we're guarding
+      // against — `JSON.stringify(errors[0])` would once have been
+      // `{}` because Error's props are non-enumerable.
+      expect(errors[0].message).not.toBe('{}')
+      // Transport should also have been closed in the engine-null
+      // branch (best-effort cleanup so the FD doesn't leak).
+      expect(fakeTransport.closed).toBe(true)
+    })
   })
 
   await describe('SessionService — joining (transport selection)', async () => {
@@ -193,7 +244,7 @@ export default async () => {
       // Short snapshot timeout so the joiner flow rejects quickly
       // without blocking the test runner (the mock peer never
       // responds to the snapshot request).
-      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50)
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50, 50)
 
       service.on('error', () => {})
       try {
@@ -218,7 +269,7 @@ export default async () => {
     await it('joinByRoomId calls backend.connectRelay with the room id', async () => {
       const backend = new MockBackend()
       // Short snapshot timeout — see joinLan test above for context.
-      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50)
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50, 50)
 
       service.on('error', () => {})
       try {
@@ -238,7 +289,7 @@ export default async () => {
       // URL is a placeholder. Same-LAN joins should never touch the
       // relay; they have a working LAN path right there.
       const backend = new MockBackend()
-      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50)
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50, 50)
       service.on('error', () => {})
 
       // Start browsing + deliver a fake LAN service that advertises
@@ -272,7 +323,7 @@ export default async () => {
 
     await it('joinByRoomId falls back to relay when the room is NOT in the LAN discovery cache', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50)
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50, 50)
       service.on('error', () => {})
 
       // Start browsing but DON'T deliver any service with the room
@@ -301,7 +352,7 @@ export default async () => {
 
     await it('joinByRoomId falls back to relay when the LAN service has gone away', async () => {
       const backend = new MockBackend()
-      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50)
+      const service = new SessionService(() => makeEngineStub(), backend, 'peer-test', 50, 50)
       service.on('error', () => {})
 
       service.startBrowsing()

--- a/apps/maker-gjs/src/services/session-service.ts
+++ b/apps/maker-gjs/src/services/session-service.ts
@@ -1,9 +1,12 @@
 import type { Engine, PeerRole, SignallingTransport } from '@pixelrpg/engine'
 
+import { scopedLogger } from './collab-log.ts'
 import { CollabSession } from './collab-session.ts'
 import type { DiscoveredService, LanDiscoveryEvent } from './lan-discovery-parse.ts'
 import { generateRoomId } from './relay-signalling.ts'
 import { writeSnapshotToSandbox } from './sandbox-path.ts'
+
+const log = scopedLogger('session-service')
 
 /**
  * Pluggable backend the {@link SessionService} drives.
@@ -152,6 +155,15 @@ export class SessionService {
      * mock peer never responds.
      */
     private readonly snapshotTimeoutMs?: number,
+    /**
+     * Override the WebRTC negotiation deadline that gates
+     * {@link CollabSession.start}. Production default is 15 s
+     * (CollabSession's `PEER_CONNECT_TIMEOUT_MS`). Tests pass a
+     * small value so a `MockTransport` that never carries SDP
+     * fails fast rather than blocking the test runner. Forwarded
+     * verbatim to every CollabSession this service constructs.
+     */
+    private readonly peerConnectTimeoutMs?: number,
   ) {}
 
   // ────────────────────────────────────────────────────────────
@@ -217,11 +229,18 @@ export class SessionService {
       // Wrap openSession's rejection in an explicit `.catch` so
       // hand-test users get a typed error instead of GJS's
       // generic "Unhandled promise rejection" stack-only warning.
+      // {@link handleError} both logs (via the centralised collab
+      // logger) AND emits the typed `'error'` event — the welcome-
+      // view toast handler subscribes to that event, so the user
+      // sees the actual failure reason instead of a stack trace
+      // they can't act on.
       this.openSession('host', roomId, transport).catch((err) => {
-        const message = err instanceof Error ? err.message : String(err)
-        console.warn(`[session-service] host-side openSession failed: ${message}`)
-        if (err instanceof Error && err.stack) console.warn(err.stack)
+        log.warn('host-side openSession failed', err)
         this.handleError(err)
+        // Host-path failures leave the session in `hosting` state
+        // (the server is still bound; a new joiner could try again).
+        // Don't reset state here — only the user pressing "Stop
+        // sharing" should do that.
       })
     })
     this.setState({ kind: 'hosting', roomId, port: handle.port })
@@ -363,6 +382,7 @@ export class SessionService {
         signalling: transport,
         peerId: this.peerId,
         roomId,
+        peerConnectTimeoutMs: this.peerConnectTimeoutMs,
       })
       await collab.start()
       this.wireCollabClose(collab)
@@ -380,6 +400,7 @@ export class SessionService {
       signalling: transport,
       peerId: this.peerId,
       roomId,
+      peerConnectTimeoutMs: this.peerConnectTimeoutMs,
       // engine deliberately omitted — attached after sandbox load.
     })
     try {

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -1,11 +1,14 @@
 import { run } from '@gjsify/unit'
 
+import collabLogSuite from './services/collab-log.spec.js'
+import collabSessionSuite from './services/collab-session.spec.js'
 import collabSessionE2eSuite from './services/collab-session-e2e.spec.js'
 import lanDiscoverySuite from './services/lan-discovery.spec.js'
 import lanDiscoveryIntegrationSuite from './services/lan-discovery-integration.gjs.spec.js'
 import lanDiscoveryParseSuite from './services/lan-discovery-parse.spec.js'
 import lanSignallingIntegrationSuite from './services/lan-signalling-integration.spec.js'
 import lanSignallingSuite from './services/lan-signalling.spec.js'
+import lanSignallingTimeoutSuite from './services/lan-signalling-timeout.spec.js'
 import orphanPublisherCleanupSuite from './services/orphan-publisher-cleanup.spec.js'
 import pixelrpgUrlSuite from './services/pixelrpg-url.spec.js'
 import relaySignallingSuite from './services/relay-signalling.spec.js'
@@ -13,12 +16,15 @@ import sandboxPathSuite from './services/sandbox-path.spec.js'
 import sessionServiceSuite from './services/session-service.spec.js'
 
 run({
+  collabLogSuite,
+  collabSessionSuite,
   collabSessionE2eSuite,
   lanDiscoverySuite,
   lanDiscoveryIntegrationSuite,
   lanDiscoveryParseSuite,
   lanSignallingIntegrationSuite,
   lanSignallingSuite,
+  lanSignallingTimeoutSuite,
   orphanPublisherCleanupSuite,
   pixelrpgUrlSuite,
   relaySignallingSuite,


### PR DESCRIPTION
## Summary

Holistic refactor of the recent Pair-Editing PRs (#99–#110) as a coherent system. Addresses three root-cause classes surfaced by the 2026-05-30 hand-test:

1. **Inconsistent error logging** — one module printed `{}` for Error objects (`console.warn(..., err)` since Error's enumerable properties are empty), another logged \`err.message ?? err\` which still printed \`[object Object]\`, and `relay-signalling` was completely silent on failure.
2. **Silent hangs** — `connectLanJoinerTransport`, `connectRelaySignalling` and `CollabSession.start()` had NO deadlines. A stalled WS upgrade or half-finished WebRTC handshake left the joiner UI frozen indefinitely. That's exactly the user-reported symptom: "joiner connected to WS, then nothing."
3. **Test gaps** — none of the silent-failure modes were tested, so each iteration of "fix and retest" relied on a hand-test round-trip with the user.

## Architecture

**NEW** `collab-log.ts` (158 LOC, 130 LOC of tests):
- `formatError(err)` — extracts name + message + stack from Error/Error subclass; JSON.stringify for plain objects with String() fallback for circular refs. **CONTRACT: never returns `{}` or `[object Object]` for an Error**.
- `scopedLogger(scope)` — bound `info/warn/error` with `[scope] message` prefix.
- `CollabTimeoutError` — typed Error subclass carrying operation + timeoutMs + url.
- `withTimeout(operation, ms, promise, url?)` — race helper.

**MIGRATED**: every collab file now uses `scopedLogger`. `orphan-cleanup:89` (the documented `{}` source) → `log.warn('error inspecting...', err)` which formats safely.

**TIMEOUTS**:
- `LAN_CONNECT_TIMEOUT_MS = 5_000` — WS upgrade deadline
- `RELAY_CONNECT_TIMEOUT_MS = 10_000` — relay connect deadline
- `PEER_CONNECT_TIMEOUT_MS = 15_000` — **THE actual missing piece for the bug**. `PeerSession.connect()` resolves on ICE-gather-started; the real wait CollabSession needs is "data channels OPEN + state=connected". New `waitForConnected()` subscribes to state-changed, resolves on `'connected'`, rejects on `'closed'`/`'error'`. Raced via `withTimeout` under the configurable deadline.

## What the user will see on the next hand-test if connection still fails

Instead of a silent hang, ONE of these clear messages:

- \`LAN signalling connect timed out after 5000ms (ws://...)\` → WS upgrade stalled
- \`CollabSession reach connected state timed out after 15000ms\` → WS opened but WebRTC SDP/ICE round-trip stalled
- \`[session-service] host-side openSession failed: ...\` → typed reason in host terminal AND toast in host UI
- \`[collab-session] start() failed during peer negotiation: ...\` → typed reason in joiner terminal AND toast in joiner UI

## Tests

**185/185 passing under BOTH GJS and Node.** Total maker test runtime ~5 s.

| Suite | New tests | Purpose |
|---|---|---|
| `collab-log.spec.ts` | 15 | formatError shape + REGRESSION marker for `{}` |
| `collab-session.spec.ts` | 4 | Peer-connect deadline (joiner / host / happy / peer-closed-mid) |
| `lan-signalling-timeout.spec.ts` | 2 | Real TCP server that accepts but never replies → CollabTimeoutError within 250ms |
| `session-service.spec.ts` | +1 | Host openSession failure MUST emit typed 'error' event (the actionable UI-visible reason) |

Plus existing 163 tests untouched (joiner-flow tests now pass an explicit 50 ms `peerConnectTimeoutMs` so the unit suite still finishes fast).

## Files

```
A apps/maker-gjs/src/services/collab-log.ts
A apps/maker-gjs/src/services/collab-log.spec.ts
A apps/maker-gjs/src/services/collab-session.spec.ts
A apps/maker-gjs/src/services/lan-signalling-timeout.spec.ts
M apps/maker-gjs/src/services/collab-session.ts                 (+125 LOC)
M apps/maker-gjs/src/services/lan-signalling.ts                 (+51 LOC)
M apps/maker-gjs/src/services/relay-signalling.ts               (+43 LOC)
M apps/maker-gjs/src/services/session-service.ts                (+27 LOC)
M apps/maker-gjs/src/services/session-service.spec.ts           (+61 LOC)
M apps/maker-gjs/src/services/{orphan-publisher-cleanup,
                                lan-discovery,
                                lan-session-backend,
                                sandbox-path}.ts                (log migrations)
M apps/maker-gjs/src/test.mts                                   (register 3 new suites)
```

Total: **999 insertions, 46 deletions across 14 files**.

## Follow-ups (not in this PR)

- `libxml2 Entity: line 14: parser error` appearing in the host log is unrelated to collab — likely a Pango/GtkBuilder markup issue on the share dialog or AppStream metainfo. Separate PR.
- UI feedback during `connecting` state — welcome view doesn't show progress while joiner connects. Separate PR (UX, not robustness).

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify workspace @pixelrpg/maker-gjs test` — 185/185 green under both GJS (4 s) and Node (1 s)
- [ ] CI passes on PR
- [ ] Hand-test after merge: failure (if any) produces a clear, actionable error message in BOTH terminal AND toast