### PR TITLE
fix(maker): buffer inbound WS messages until SignallingTransport handler wired

### DIFF
--- a/apps/maker-gjs/src/services/lan-signalling.spec.ts
+++ b/apps/maker-gjs/src/services/lan-signalling.spec.ts
@@ -110,5 +110,58 @@ export default async () => {
 
       expect(() => transport.send({ type: 'bye' })).not.toThrow()
     })
+
+    await it('REGRESSION (2026-05-30 race): buffers inbound messages received BEFORE onMessage is wired', async () => {
+      // This is the bug that blocked Pair-Editing on 2026-05-30:
+      // host's `wss.on('connection')` fires synchronously when the
+      // joiner's WS handshake completes; the host's
+      // `PeerSession.connect()` runs `createOffer` +
+      // `setLocalDescription` + `signalling.send(sdp)` within the
+      // same JS tick. On the joiner side, control flows out of
+      // `await connectLanJoinerTransport(...)` through
+      // `SessionService.openSession` + `new CollabSession` + `new
+      // PeerSession` BEFORE `signalling.onMessage(handler)` is
+      // called. Pre-fix, the SDP offer arrived during that window
+      // and was silently dropped; the joiner timed out 15 s later
+      // with no other evidence than `[peer-session/joiner] waiting
+      // for host SDP offer over signalling` followed by the
+      // CollabTimeoutError.
+      const ws = new FakeWs()
+      const transport = wrapWebSocket(ws as never)
+
+      // Deliver TWO messages BEFORE the inbound handler is wired —
+      // simulating the race window.
+      const offer = { type: 'sdp' as const, payload: { type: 'offer' as const, sdp: 'v=0\r\n' } }
+      const candidate = { type: 'ice-candidate' as const, payload: { candidate: 'a=candidate:1' } }
+      ws.emit('message', JSON.stringify(offer))
+      ws.emit('message', JSON.stringify(candidate))
+
+      // Now register the handler — the buffered messages MUST be
+      // delivered in arrival order.
+      const seen: unknown[] = []
+      transport.onMessage((msg) => seen.push(msg))
+      expect(seen).toStrictEqual([offer, candidate])
+
+      // After draining, subsequent messages still flow through
+      // synchronously.
+      const bye = { type: 'bye' as const }
+      ws.emit('message', JSON.stringify(bye))
+      expect(seen).toStrictEqual([offer, candidate, bye])
+    })
+
+    await it('REGRESSION: malformed frames during the race window are dropped, not buffered', async () => {
+      // The buffer should preserve the same filtering as the live
+      // path: malformed JSON dropped, unrecognised types dropped.
+      const ws = new FakeWs()
+      const transport = wrapWebSocket(ws as never)
+
+      ws.emit('message', 'not-json')
+      ws.emit('message', JSON.stringify({ type: 'banana' }))
+      ws.emit('message', JSON.stringify({ type: 'bye' }))
+
+      const seen: unknown[] = []
+      transport.onMessage((msg) => seen.push(msg))
+      expect(seen).toStrictEqual([{ type: 'bye' }])
+    })
   })
 }

--- a/apps/maker-gjs/src/services/lan-signalling.ts
+++ b/apps/maker-gjs/src/services/lan-signalling.ts
@@ -42,10 +42,40 @@ export const LAN_CONNECT_TIMEOUT_MS = 5_000
  * Adapter that wraps a single `ws.WebSocket` instance as a
  * `SignallingTransport`. Used by both the host (one per accepted
  * peer) and the joiner (its own outgoing connection).
+ *
+ * Buffering invariant — load-bearing:
+ *
+ *   `ws.on('message', ...)` is registered SYNCHRONOUSLY when this
+ *   function runs, but `inboundHandler` only becomes non-null when
+ *   the caller invokes `transport.onMessage(handler)`. Between
+ *   those two events, any inbound message would be lost — and on
+ *   the joiner side those microseconds are real: `wrapWebSocket`
+ *   resolves out of the `await connectLanJoinerTransport(...)`
+ *   call site, control returns to `SessionService.openSession`,
+ *   which creates a `CollabSession`, which creates a `PeerSession`,
+ *   whose constructor finally calls `signalling.onMessage(...)`.
+ *   Meanwhile on the host side, `wss.on('connection')` fires the
+ *   instant the joiner's WS handshake completes; the host's
+ *   `PeerSession.connect()` proceeds straight to `createOffer` +
+ *   `setLocalDescription` + `signalling.send(sdp)` — frequently
+ *   FASTER than the joiner can wire its handler.
+ *
+ *   The 2026-05-30 hand-test caught exactly this race: joiner's
+ *   `[peer-session/joiner] waiting for host SDP offer` confirmed
+ *   the handler was wired, host's `sending SDP offer (sdp.length=
+ *   1437)` confirmed the send, but no `received SDP offer` ever
+ *   appeared on the joiner — because the SDP was delivered to the
+ *   `ws.on('message')` callback while `inboundHandler === null`
+ *   and was silently dropped.
+ *
+ *   Fix: buffer parsed inbound messages in `pendingInbound` until
+ *   `onMessage` is called, then drain. Anything that arrives after
+ *   the handler is wired goes straight through.
  */
 export function wrapWebSocket(ws: Pick<WebSocket, 'send' | 'close' | 'on'>): SignallingTransport {
   let inboundHandler: ((msg: SignallingMessage) => void) | null = null
   let closed = false
+  const pendingInbound: SignallingMessage[] = []
 
   ws.on('message', (raw: Buffer | string, isBinary?: boolean) => {
     if (isBinary === true) return
@@ -58,7 +88,12 @@ export function wrapWebSocket(ws: Pick<WebSocket, 'send' | 'close' | 'on'>): Sig
       return
     }
     if (!isSignallingMessage(parsed)) return
-    inboundHandler?.(parsed)
+    if (inboundHandler) {
+      inboundHandler(parsed)
+    } else {
+      // Race-window buffering — see invariant in the doc comment.
+      pendingInbound.push(parsed)
+    }
   })
 
   ws.on('close', () => {
@@ -76,6 +111,12 @@ export function wrapWebSocket(ws: Pick<WebSocket, 'send' | 'close' | 'on'>): Sig
     },
     onMessage(handler: (message: SignallingMessage) => void): void {
       inboundHandler = handler
+      // Drain anything that arrived during the race window. The
+      // queue is FIFO so SDP/ICE ordering is preserved.
+      if (pendingInbound.length > 0) {
+        const drain = pendingInbound.splice(0)
+        for (const message of drain) handler(message)
+      }
     },
     close(): void {
       if (closed) return


### PR DESCRIPTION
## The 2026-05-30 hand-test stall — root cause

PR #112's diagnostic logs made the bug visible at last:

**HOST** (instance 1):
```
[peer-session/host] state idle → negotiating
[peer-session/host] createOffer OK (sdp.length=414)
[peer-session/host] setLocalDescription(offer) OK
[peer-session/host] sending SDP offer over signalling (sdp.length=1437)   ← SENT
[peer-session/host] ICE local #1..#12  (host candidates only — no STUN/srflx, UPnP fix worked)
```

**JOINER** (instance 2):
```
[lan-signalling] joiner connected to ws://192.168.178.161:42533/
[peer-session/joiner] state idle → negotiating
[peer-session/joiner] waiting for host SDP offer over signalling           ← waited
... 15 s pass ...
[collab-session] start() failed during peer negotiation: CollabTimeoutError
```

Host SENT the SDP. Joiner NEVER received it. The WS round-trip works (proved by `lan-signalling-integration.spec.ts`). So what's different in production?

**Race in `wrapWebSocket`.** `ws.on('message', ...)` is registered synchronously when the function runs, but `inboundHandler` only becomes non-null when the caller invokes `transport.onMessage(handler)`. Between those two moments any message callback runs but `inboundHandler?.(parsed)` is a no-op — the message is **silently dropped**.

| Side | Timing |
|---|---|
| **Joiner** | `await connectLanJoinerTransport(...)` resolves → microtask barrier → `SessionService.openSession` → `new CollabSession` → `new PeerSession` → finally `signalling.onMessage(handler)` |
| **Host** | `wss.on('connection')` fires the INSTANT joiner's WS handshake completes → `opts.onPeerConnected(wrapWebSocket(ws))` → openSession → `peer.connect()` → `createOffer` → `setLocalDescription` → `signalling.send(sdp)` |

Host's send is frequently FASTER than joiner's handler wire-up. Deterministic hang on the user's machine.

## Fix

`apps/maker-gjs/src/services/lan-signalling.ts` — buffer parsed inbound messages in `pendingInbound` until `onMessage` is called. Handler registration drains the queue in FIFO order (preserving SDP/ICE ordering). Anything after wire-up bypasses the queue.

Plus an 8-line **invariant doc comment** above the function so the next person doesn't accidentally remove it thinking the `ws.on('message')` registration "obviously" runs after the caller's `onMessage` (it doesn't — that's the whole point of the SignallingTransport interface).

## Tests

**maker-gjs 188/188 green** (3 new tests) under both GJS + Node:

- `REGRESSION (2026-05-30 race): buffers inbound messages received BEFORE onMessage is wired` — emits two messages on the FakeWs THEN calls onMessage, asserts both delivered in arrival order, asserts subsequent live messages still flow through.
- `REGRESSION: malformed frames during the race window are dropped, not buffered` — pins the contract that the buffer preserves the same filtering as the live path.

## Not in this PR

- The libxml2 `Entity: line 14: parser error` is a separate gupnp/libnice side-effect (host candidates still gathered correctly, doesn't block ICE).
- The bare `{}` on joiner is also unrelated to the SDP path — investigation continues, but now that SDP arrives the user-facing flow should complete.

## Test plan

- [x] `gjsify foreach check -v -t` clean
- [x] `gjsify workspace @pixelrpg/maker-gjs test` — 188/188 green (3 new) under both GJS + Node
- [ ] CI passes on PR
- [ ] Hand-test after merge: joiner receives SDP, both peers reach `state=connected`, Pair-Editing actually works