### PR TITLE
debug(maker): instrument wrapWebSocket + reportError shim — surface real listener errors

### DIFF
--- a/apps/maker-gjs/src/main.ts
+++ b/apps/maker-gjs/src/main.ts
@@ -19,6 +19,32 @@ if (debugPeerEnv !== '0' && debugPeerEnv !== 'false') {
   ;(globalThis as { __PIXELRPG_PEER_DEBUG?: boolean }).__PIXELRPG_PEER_DEBUG = true
 }
 
+// TEMPORARY SHIM — install `globalThis.reportError` so EventTarget's
+// listener-exception catch (in @gjsify/dom-events) delegates here
+// instead of falling back to `console.error(err)`. The fallback
+// path renders Error objects as `{}` via `@gjsify/console`'s
+// `_formatArgs` JSON.stringify pass (Error's enumerable property
+// set is empty), which is why hand-test logs showed mysterious
+// bare `{}` lines with no message + no stack — see PR gjsify#426
+// for the root-cause fix in @gjsify/dom-events itself.
+//
+// Once @gjsify ≥0.4.36 lands and this app bumps its dep, the
+// shim becomes redundant (the upstream fix delegates to reportError
+// natively when wired) and this block can be deleted.
+//
+// SpiderMonkey's `Error.stack` is frames-only — no name+message
+// embedded at the top — so the formatter always prepends them.
+if (typeof (globalThis as { reportError?: unknown }).reportError !== 'function') {
+  ;(globalThis as { reportError: (err: unknown) => void }).reportError = (err) => {
+    if (err instanceof Error) {
+      const head = `${err.name}: ${err.message}`
+      console.warn(`[unhandled listener exception] ${err.stack ? `${head}\n${err.stack}` : head}`)
+    } else {
+      console.warn(`[unhandled listener exception] ${String(err)}`)
+    }
+  }
+}
+
 export function main(argv: string[]) {
   const application = new Application()
   return application.runAsync(argv)

--- a/apps/maker-gjs/src/services/lan-signalling.ts
+++ b/apps/maker-gjs/src/services/lan-signalling.ts
@@ -8,6 +8,25 @@ import { CollabTimeoutError, scopedLogger, withTimeout } from './collab-log.ts'
 const log = scopedLogger('lan-signalling')
 
 /**
+ * Mirror of the engine's `__PIXELRPG_PEER_DEBUG` gate so wire-
+ * level diagnostics (every raw WS frame in/out, every send error)
+ * land in the same hand-test log stream as the SDP/ICE traces. Off
+ * by default; the maker's main.ts flips it on for the v1 cycle.
+ */
+function wireDebugEnabled(): boolean {
+  const g = globalThis as { __PIXELRPG_PEER_DEBUG?: unknown }
+  return Boolean(g.__PIXELRPG_PEER_DEBUG)
+}
+
+function wlog(role: string, message: string): void {
+  if (wireDebugEnabled()) {
+    console.log(`[lan-signalling/${role}] ${message}`)
+  }
+}
+
+let wrapCounter = 0
+
+/**
  * Default deadline for the joiner-side WebSocket open handshake. Five
  * seconds is generous for LAN — the WS upgrade typically completes
  * within tens of ms — but short enough that a misconfigured host
@@ -76,43 +95,71 @@ export function wrapWebSocket(ws: Pick<WebSocket, 'send' | 'close' | 'on'>): Sig
   let inboundHandler: ((msg: SignallingMessage) => void) | null = null
   let closed = false
   const pendingInbound: SignallingMessage[] = []
+  const wrapId = `#${++wrapCounter}`
+  let rawFrameCount = 0
+  let sendCount = 0
+
+  wlog(wrapId, 'wrapped (handler-null; buffering)')
 
   ws.on('message', (raw: Buffer | string, isBinary?: boolean) => {
+    rawFrameCount++
+    // Pre-filter raw log: surfaces EVERY frame that hits the WS,
+    // regardless of binary/JSON-validity/type. If the user sees
+    // this line, the WS layer IS delivering frames; if not, the
+    // problem is at the @gjsify/ws or libsoup level (and we'd
+    // hand the regression off to @gjsify/ws).
+    if (wireDebugEnabled()) {
+      const head = typeof raw === 'string' ? raw : Buffer.isBuffer(raw) ? raw.toString('utf-8') : String(raw)
+      console.log(
+        `[lan-signalling/${wrapId}] raw frame #${rawFrameCount} ` +
+          `(binary=${isBinary === true}, len=${head.length}): ${head.slice(0, 200)}${head.length > 200 ? '…' : ''}`,
+      )
+    }
     if (isBinary === true) return
     const text = typeof raw === 'string' ? raw : raw.toString()
     let parsed: unknown
     try {
       parsed = JSON.parse(text)
-    } catch {
-      // Drop malformed frames silently — the relay drops them too.
+    } catch (err) {
+      wlog(wrapId, `dropped malformed JSON frame: ${err instanceof Error ? err.message : String(err)}`)
       return
     }
-    if (!isSignallingMessage(parsed)) return
+    if (!isSignallingMessage(parsed)) {
+      wlog(wrapId, `dropped non-signalling frame: type=${(parsed as { type?: unknown })?.type}`)
+      return
+    }
     if (inboundHandler) {
+      wlog(wrapId, `→ deliver to handler (type=${parsed.type})`)
       inboundHandler(parsed)
     } else {
-      // Race-window buffering — see invariant in the doc comment.
+      wlog(wrapId, `→ buffer (handler not wired yet, type=${parsed.type})`)
       pendingInbound.push(parsed)
     }
   })
 
   ws.on('close', () => {
+    wlog(wrapId, `ws closed (delivered ${rawFrameCount} frames, sent ${sendCount}, ${pendingInbound.length} unflushed in buffer)`)
     closed = true
   })
 
   return {
     send(message: SignallingMessage): void {
-      if (closed) return
+      if (closed) {
+        wlog(wrapId, `send(${message.type}) called after close — dropped`)
+        return
+      }
+      sendCount++
       try {
-        ws.send(JSON.stringify(message))
-      } catch {
-        /* peer may have closed mid-send — best-effort */
+        const json = JSON.stringify(message)
+        wlog(wrapId, `send #${sendCount} (type=${message.type}, len=${json.length})`)
+        ws.send(json)
+      } catch (err) {
+        wlog(wrapId, `send(${message.type}) THREW: ${err instanceof Error ? err.message : String(err)}`)
       }
     },
     onMessage(handler: (message: SignallingMessage) => void): void {
+      wlog(wrapId, `onMessage handler installed (draining ${pendingInbound.length} buffered)`)
       inboundHandler = handler
-      // Drain anything that arrived during the race window. The
-      // queue is FIFO so SDP/ICE ordering is preserved.
       if (pendingInbound.length > 0) {
         const drain = pendingInbound.splice(0)
         for (const message of drain) handler(message)
@@ -121,6 +168,7 @@ export function wrapWebSocket(ws: Pick<WebSocket, 'send' | 'close' | 'on'>): Sig
     close(): void {
       if (closed) return
       closed = true
+      wlog(wrapId, `close() called`)
       try {
         ws.close(1000, 'closed-by-host')
       } catch {


### PR DESCRIPTION
## Why this PR exists

The buffering fix (PR #113) didn't unblock the joiner. Diagnostic logs after that PR still show:

\`\`\`
[peer-session/joiner] waiting for host SDP offer over signalling
{}        ← mysterious bare line
[collab-session] start() failed during peer negotiation: CollabTimeoutError
\`\`\`

The host's \`[peer-session/host] sending SDP offer (sdp.length=1437)\` confirms the SDP was sent. The buffering would catch it if it arrived. But the joiner never logs \`received SDP offer\` — so EITHER the frame isn't reaching the joiner WS at all OR a filter is dropping it before our buffer.

Plus the \`{}\` mystery — I tracked it back to \`@gjsify/dom-events\`'s \`EventTarget.dispatchEvent\` catch: \`console.error(err)\` for an Error reduces to \`{}\` under \`@gjsify/console\`'s \`_formatArgs\` JSON.stringify pass (Error props are non-enumerable). So every \`{}\` line means a WS event listener is throwing an Error that's getting silently swallowed.

## Fix in two places

### \`apps/maker-gjs/src/services/lan-signalling.ts\`

\`wrapWebSocket\` now logs (gated by \`__PIXELRPG_PEER_DEBUG\`):
- wrap creation with sequential \`#N\` id
- **EVERY raw frame received PRE-filter** (binary flag, length, first 200 chars) — surfaces frames regardless of JSON-validity or type-filter outcome
- dropped-malformed-JSON / dropped-non-signalling with reason
- deliver-to-handler / buffer-while-handler-not-wired
- send call (type + length), send-after-close, send-threw
- close event with frame-counts + unflushed buffer size

If the next hand-test STILL shows no \`received SDP offer\` on the joiner, these tell us EXACTLY whether the WS frame is arriving at all or being dropped by a filter — pinpointing the regression to either \`@gjsify/ws\` (no frame) or our own filter (wrong type).

### \`apps/maker-gjs/src/main.ts\`

TEMPORARY shim — install \`globalThis.reportError\` so \`EventTarget.dispatchEvent\`'s listener-exception catch (in @gjsify/dom-events) delegates here instead of falling back to \`console.error(err)\`. Upstream root-cause fix is in **gjsify PR #426** (delegates to \`globalThis.reportError\` natively when wired, falls back to safely-formatted stack otherwise). This shim is removable once map-editor bumps to @gjsify ≥0.4.36 that includes #426.

SpiderMonkey's \`Error.stack\` is frames-only (no name+message embedded) — the formatter always prepends \`\${name}: \${message}\` so the operator sees the cause.

## What the user will see on the next hand-test

Joiner-side logs should now contain:

\`\`\`
[lan-signalling/#1] wrapped (handler-null; buffering)
[lan-signalling/#1] raw frame #1 (binary=false, len=1437): {"type":"sdp","payload":{…
[lan-signalling/#1] → buffer (handler not wired yet, type=sdp)
[lan-signalling/#1] onMessage handler installed (draining 1 buffered)
[peer-session/joiner] received SDP offer (sdp.length=1437)
[peer-session/joiner] createAnswer OK
…
\`\`\`

OR if there's still a problem:

\`\`\`
[lan-signalling/#1] wrapped (handler-null; buffering)
[unhandled listener exception] TypeError: <real error message>
  at <stack frames>
\`\`\`

Which collectively answer: (a) does the SDP frame arrive at the joiner WS at all, (b) does our filter pass it, (c) does any listener throw, and (d) what is it actually throwing.

## Tests

- maker-gjs **188/188** green under both GJS + Node
- gjsify PR #426 has **283/283** green for the upstream root-cause fix

## Test plan

- [x] \`gjsify foreach check -v -t\` clean
- [x] \`gjsify workspace @pixelrpg/maker-gjs test\` green both runtimes
- [ ] CI passes on PR
- [ ] Hand-test after merge: pinpoint exact WS-layer state, surface real listener error
- [ ] Bump @gjsify dependency when 0.4.36 lands → delete the \`reportError\` shim