### PR TITLE
debug(maker): WS close code+reason + peer-error subscription

### DIFF
--- a/apps/maker-gjs/src/services/collab-session.ts
+++ b/apps/maker-gjs/src/services/collab-session.ts
@@ -153,6 +153,20 @@ export class CollabSession {
     })
     this.subscriptions.push(() => awarenessSub.close())
 
+    // Subscribe to peer error events so any failure inside
+    // PeerSession (malformed JSON on wire, channel-send while not
+    // open, sdp/ice processing throw, RTC connectionState 'failed')
+    // lands in the operator-visible log AS A TYPED MESSAGE instead
+    // of going through the upstream @gjsify/dom-events EventTarget
+    // catch and rendering as `{}`. Adding the subscription also
+    // satisfies the standard "error events should have a listener"
+    // invariant — PeerSession's emitter is silent when no listener
+    // is registered (no implicit fallback to console).
+    const peerErrorSub = this.peer.events.on('error', ({ error }) => {
+      log.warn('peer emitted error', error)
+    })
+    this.subscriptions.push(() => peerErrorSub.close())
+
     // Snapshot exchange is engine-independent — uses raw `sendOp`
     // for the protocol frames + a captureSnapshot closure that
     // returns null when no engine is attached. CollabSession

--- a/apps/maker-gjs/src/services/lan-signalling.ts
+++ b/apps/maker-gjs/src/services/lan-signalling.ts
@@ -137,9 +137,35 @@ export function wrapWebSocket(ws: Pick<WebSocket, 'send' | 'close' | 'on'>): Sig
     }
   })
 
-  ws.on('close', () => {
-    wlog(wrapId, `ws closed (delivered ${rawFrameCount} frames, sent ${sendCount}, ${pendingInbound.length} unflushed in buffer)`)
+  // @gjsify/ws's `ws.on('close', cb)` callback signature is
+  // `cb(code: number, reason: Buffer)` per node `ws` semantics —
+  // surface them so we can distinguish "normal 1000 close" from
+  // "abnormal 1006 / protocol error 1002 / message-too-big 1009 /
+  // policy 1008". The 2026-05-31 hand-test showed the host-side WS
+  // closing immediately after a 1534-byte SDP frame was sent (12
+  // ICE candidates went through cleanly first), with no close-code
+  // surfaced.
+  ws.on('close', (code?: number, reason?: Buffer | string) => {
+    const reasonText =
+      reason && typeof reason !== 'number'
+        ? Buffer.isBuffer(reason)
+          ? reason.toString('utf-8') || '<empty>'
+          : String(reason) || '<empty>'
+        : '<no reason>'
+    wlog(
+      wrapId,
+      `ws closed (code=${code ?? '<none>'}, reason="${reasonText}", ` +
+        `delivered ${rawFrameCount} frames, sent ${sendCount}, ${pendingInbound.length} unflushed in buffer)`,
+    )
     closed = true
+  })
+
+  // The ws library exposes 'error' as a separate event from 'close'.
+  // On @gjsify/ws over Soup, an error before / during the close
+  // sequence (e.g. SoupWebsocketConnection emitted its `error`
+  // signal with a GError) lands here.
+  ws.on('error', (err: Error) => {
+    wlog(wrapId, `ws error: ${err instanceof Error ? `${err.name}: ${err.message}` : String(err)}`)
   })
 
   return {


### PR DESCRIPTION
## Next diagnostic layer

After PR #114's WS frame instrumentation, the hand-test surfaced:
- Host sends 13 frames (12 ICE candidates + 1 SDP), all small (< 2 KiB)
- WS closes IMMEDIATELY after send #13 (the 1534-byte SDP frame)
- Joiner shows \`delivered 0 frames\` — NONE of the 13 frames crossed the WS

But we still don't see WHY the WS closed. This PR adds:

### \`apps/maker-gjs/src/services/lan-signalling.ts\`

\`ws.on('close', cb)\` now logs the actual \`(code, reason)\` surfaced by node-ws / @gjsify/ws — distinguishing:
- **1000** normal close
- **1002** protocol error
- **1006** abnormal (no close frame received)
- **1008** policy violation
- **1009** message too big
- **1011** internal error

Subscribed to \`ws.on('error', cb)\` too — Soup emits its \`SoupWebsocketConnection.error\` signal here. Pre-fix we silently dropped it.

### \`apps/maker-gjs/src/services/collab-session.ts\`

Subscribed to PeerSession's \`'error'\` event with the centralised scopedLogger. Without this listener, errors from inside PeerSession (malformed wire JSON, channel-send while not open, sdp/ice processing throws, connectionState=failed) either fired into a void OR bubbled through the upstream @gjsify/dom-events EventTarget catch which logs them as \`{}\` (fixed in gjsify PR #426 but not yet published).

## Parallel work: gjsify-side fix-with-test

I'm also writing a TDD reproducer in @gjsify/ws that mimics the maker's "12 small + 1 larger frame in rapid succession server→client" scenario. If the test fails (= bug in @gjsify/ws or @gjsify/websocket), I'll fix it there per gjsify's root-cause governance rule.

## What user will see on next hand-test

One of these will name the actual cause:

\`\`\`
ws closed (code=1009, reason="message too big", ...)        ← payload-size bug
ws closed (code=1002, reason="protocol error", ...)         ← frame encoding broken
ws closed (code=1011, reason="internal error", ...)         ← Soup internal
ws closed (code=1006, reason="<no reason>", ...)
ws error: GError: <actual gerror>                           ← TCP/socket fail
peer emitted error: <typed error>                           ← PeerSession-layer fail
\`\`\`

Test counts: maker-gjs 188/188 green on both GJS + Node.

## Test plan

- [x] check + test green
- [ ] CI passes
- [ ] User retests, surfaces the actual close code