### PR TITLE
chore: bump @gjsify/* to ^0.4.36 + drop interim reportError shim

### DIFF
--- a/apps/game-browser/package.json
+++ b/apps/game-browser/package.json
@@ -17,7 +17,7 @@
     "excalibur": "^0.32.0"
   },
   "devDependencies": {
-    "@gjsify/cli": "^0.4.35",
+    "@gjsify/cli": "^0.4.36",
     "http-server": "^14.1.1",
     "typescript": "^6.0.3"
   }

--- a/apps/maker-gjs/package.json
+++ b/apps/maker-gjs/package.json
@@ -29,8 +29,8 @@
   "author": "Pascal Garber <pascal@artandcode.studio>",
   "license": "GPL-3.0",
   "devDependencies": {
-    "@gjsify/cli": "^0.4.35",
-    "@gjsify/unit": "^0.4.35",
+    "@gjsify/cli": "^0.4.36",
+    "@gjsify/unit": "^0.4.36",
     "typescript": "^6.0.3"
   },
   "dependencies": {
@@ -42,13 +42,13 @@
     "@girs/glib-2.0": "^2.88.0-4.0.4",
     "@girs/gobject-2.0": "^2.88.0-4.0.4",
     "@girs/gtk-4.0": "^4.23.0-4.0.4",
-    "@gjsify/canvas2d": "^0.4.35",
-    "@gjsify/dom-elements": "^0.4.35",
-    "@gjsify/event-bridge": "^0.4.35",
-    "@gjsify/webgl": "^0.4.35",
-    "@gjsify/webrtc": "^0.4.35",
-    "@gjsify/ws": "^0.4.35",
-    "@gjsify/xmlhttprequest": "^0.4.35",
+    "@gjsify/canvas2d": "^0.4.36",
+    "@gjsify/dom-elements": "^0.4.36",
+    "@gjsify/event-bridge": "^0.4.36",
+    "@gjsify/webgl": "^0.4.36",
+    "@gjsify/webrtc": "^0.4.36",
+    "@gjsify/ws": "^0.4.36",
+    "@gjsify/xmlhttprequest": "^0.4.36",
     "@pixelrpg/engine": "workspace:^",
     "@pixelrpg/gjs": "workspace:^",
     "excalibur": "^0.32.0"

--- a/apps/maker-gjs/src/main.ts
+++ b/apps/maker-gjs/src/main.ts
@@ -19,32 +19,6 @@ if (debugPeerEnv !== '0' && debugPeerEnv !== 'false') {
   ;(globalThis as { __PIXELRPG_PEER_DEBUG?: boolean }).__PIXELRPG_PEER_DEBUG = true
 }
 
-// TEMPORARY SHIM — install `globalThis.reportError` so EventTarget's
-// listener-exception catch (in @gjsify/dom-events) delegates here
-// instead of falling back to `console.error(err)`. The fallback
-// path renders Error objects as `{}` via `@gjsify/console`'s
-// `_formatArgs` JSON.stringify pass (Error's enumerable property
-// set is empty), which is why hand-test logs showed mysterious
-// bare `{}` lines with no message + no stack — see PR gjsify#426
-// for the root-cause fix in @gjsify/dom-events itself.
-//
-// Once @gjsify ≥0.4.36 lands and this app bumps its dep, the
-// shim becomes redundant (the upstream fix delegates to reportError
-// natively when wired) and this block can be deleted.
-//
-// SpiderMonkey's `Error.stack` is frames-only — no name+message
-// embedded at the top — so the formatter always prepends them.
-if (typeof (globalThis as { reportError?: unknown }).reportError !== 'function') {
-  ;(globalThis as { reportError: (err: unknown) => void }).reportError = (err) => {
-    if (err instanceof Error) {
-      const head = `${err.name}: ${err.message}`
-      console.warn(`[unhandled listener exception] ${err.stack ? `${head}\n${err.stack}` : head}`)
-    } else {
-      console.warn(`[unhandled listener exception] ${String(err)}`)
-    }
-  }
-}
-
 export function main(argv: string[]) {
   const application = new Application()
   return application.runAsync(argv)

--- a/apps/signalling-server/package.json
+++ b/apps/signalling-server/package.json
@@ -18,13 +18,13 @@
   "author": "Pascal Garber <pascal@artandcode.studio>",
   "license": "MIT",
   "devDependencies": {
-    "@gjsify/cli": "^0.4.35",
-    "@gjsify/unit": "^0.4.35",
+    "@gjsify/cli": "^0.4.36",
+    "@gjsify/unit": "^0.4.36",
     "@types/ws": "^8.5.12",
     "typescript": "^6.0.3",
     "ws": "^8.18.0"
   },
   "dependencies": {
-    "@gjsify/ws": "^0.4.35"
+    "@gjsify/ws": "^0.4.36"
   }
 }

--- a/apps/storybook-gjs/package.json
+++ b/apps/storybook-gjs/package.json
@@ -23,13 +23,13 @@
     "@girs/glib-2.0": "^2.88.0-4.0.4",
     "@girs/gobject-2.0": "^2.88.0-4.0.4",
     "@girs/gtk-4.0": "^4.23.0-4.0.4",
-    "@gjsify/dom-elements": "^0.4.35",
+    "@gjsify/dom-elements": "^0.4.36",
     "@pixelrpg/games-zelda-like": "workspace:^",
     "@pixelrpg/gjs": "workspace:^",
     "@pixelrpg/story-gjs": "workspace:^"
   },
   "devDependencies": {
-    "@gjsify/cli": "^0.4.35",
+    "@gjsify/cli": "^0.4.36",
     "typescript": "^6.0.3"
   }
 }

--- a/gjsify-lock.json
+++ b/gjsify-lock.json
@@ -4,7 +4,7 @@
     "@biomejs/biome@^2.4.16",
     "typescript@^6.0.3",
     "excalibur@^0.32.0",
-    "@gjsify/cli@^0.4.35",
+    "@gjsify/cli@^0.4.36",
     "http-server@^14.1.1",
     "@girs/adw-1@^1.10.0-4.0.4",
     "@girs/gdk-4.0@^4.0.0-4.0.4",
@@ -14,14 +14,14 @@
     "@girs/glib-2.0@^2.88.0-4.0.4",
     "@girs/gobject-2.0@^2.88.0-4.0.4",
     "@girs/gtk-4.0@^4.23.0-4.0.4",
-    "@gjsify/canvas2d@^0.4.35",
-    "@gjsify/dom-elements@^0.4.35",
-    "@gjsify/event-bridge@^0.4.35",
-    "@gjsify/webgl@^0.4.35",
-    "@gjsify/webrtc@^0.4.35",
-    "@gjsify/ws@^0.4.35",
-    "@gjsify/xmlhttprequest@^0.4.35",
-    "@gjsify/unit@^0.4.35",
+    "@gjsify/canvas2d@^0.4.36",
+    "@gjsify/dom-elements@^0.4.36",
+    "@gjsify/event-bridge@^0.4.36",
+    "@gjsify/webgl@^0.4.36",
+    "@gjsify/webrtc@^0.4.36",
+    "@gjsify/ws@^0.4.36",
+    "@gjsify/xmlhttprequest@^0.4.36",
+    "@gjsify/unit@^0.4.36",
     "@types/ws@^8.5.12",
     "ws@^8.18.0",
     "serve@^14.2.6",
@@ -218,76 +218,55 @@
       }
     },
     "node_modules/@girs/gda-6.0": {
-      "version": "6.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gda-6.0/-/gda-6.0-6.0.0-4.0.1.tgz",
-      "integrity": "sha512-7I7edX34M124BiElbI/BHK5yBByWYTkQ8WMTltTGoAFUPg0EC6xiP3KyvzS2DxUFdgTwC+8xicOUQay07QsNxQ==",
+      "version": "6.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gda-6.0/-/gda-6.0-6.0.0-4.0.4.tgz",
+      "integrity": "sha512-Mnggm/CgqpkdyLENIahv4/SGiMG1eRkuskoJABysyqKblUX612V/m8nVNx/ispRIObFj2gE7w8Fw7Y784sjdSA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/libxml2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/libxml2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@girs/gda-6.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/gda-6.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/gda-6.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@girs/gda-6.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/gda-6.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/gda-6.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/gdk-4.0": {
@@ -365,75 +344,54 @@
       }
     },
     "node_modules/@girs/giounix-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/giounix-2.0/-/giounix-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-KpSps+1q4mImr+lVLmRDpiRNj+SMQ2OA5Y9KGeN/lkylgDfmOqn8E5tfn5BdAasvWJPuAZ8O3/CE4ro5NEwfpw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/giounix-2.0/-/giounix-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-ZNHwgRcXR1SPjBEsgq6WbYavGRFcCmiF8DFawg6RwYQxa6rFoED2v7yjGOxcbzlcy8QWcHj1jIa1Kcfd10d7TA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@girs/giounix-2.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/giounix-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/giounix-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@girs/giounix-2.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/giounix-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/giounix-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/gjs": {
@@ -708,74 +666,42 @@
       }
     },
     "node_modules/@girs/gst-1.0": {
-      "version": "1.28.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gst-1.0/-/gst-1.0-1.28.1-4.0.1.tgz",
-      "integrity": "sha512-lCt/7+4Pw4l7mdkkajAUSwTbKV6RjhTaLxtw29c96xp60CQNcMxYu4WDxvVYZhaQht0Euy9evPRzEMLNLbbP2w==",
+      "version": "1.28.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gst-1.0/-/gst-1.0-1.28.1-4.0.4.tgz",
+      "integrity": "sha512-AKjszaEue8vyeLSV6awkN5EN6D2FyQUz55DNqZSpnBmT1OlcQ98gAKeNstmOtdwxKjxdgWWmB+Alb0xWZ4agbw==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/gst-1.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/gst-1.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/gst-1.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@girs/gst-1.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/gst-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/gst-1.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/gstsdp-1.0": {
@@ -862,88 +788,56 @@
       }
     },
     "node_modules/@girs/gstwebrtc-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gstwebrtc-1.0/-/gstwebrtc-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-TUhH1WpInkzJux7awgEGgW0RniuixyccRM1lT9wIrcnld8fd4DBs9DeHGBH/uzM/W3zFh0gpaFvVneXdo82AjA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gstwebrtc-1.0/-/gstwebrtc-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-zoSHrwJuwPubNJBFnUAE6pyf898wvMyTfd+PvNqZj/lx6gWaqFcb2fNSbPwQ4QnirQXFXCaJuHgEWbHPsRLcVQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gst-1.0": "1.28.1-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gstsdp-1.0": "1.0.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gstsdp-1.0": "1.0.0-4.0.4",
+        "@girs/gst-1.0": "1.28.1-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/gstwebrtc-1.0/node_modules/@girs/gstsdp-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gstsdp-1.0/-/gstsdp-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-QOXjcoVN8UgyIG+RXaR+IiUWd7q239lVqNvtG9h5uHloYERdhm0d4S+D8vl0xf+zo8ub2AktTuOhnSOaQDYzEQ==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gstsdp-1.0/-/gstsdp-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-xbXQE4fV6hT9TCvRH5gRW9IgYL+YVedvg2si/ixeYKNeujb0uQSgCKawXpE4Y159zHt8iTzGkzb0QR3gauOV0Q==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gst-1.0": "1.28.1-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gst-1.0": "1.28.1-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@girs/gtk-4.0": {
@@ -1104,81 +998,30 @@
       }
     },
     "node_modules/@girs/libxml2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/libxml2-2.0/-/libxml2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-4OOeKPeIMuoS9JF1EwX6Fyca5+fz18Xy2yTacZlbDmZyb4G2WAx1B+Wng2qRMzKZS6rcgCoteWKD1pE0jEqR/w==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/libxml2-2.0/-/libxml2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-pNfIw6igT+PhLlx6Z8AuwrL4gVdjgjijrzR14VrA77PB1AVYNqicX/Uwut0pZKOAoB0J+OXg9WQiI6uQZEUOAg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/libxml2-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/libxml2-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/libxml2-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/libxml2-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/libxml2-2.0/node_modules/@girs/gjs/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/libxml2-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/libxml2-2.0/node_modules/@girs/gobject-2.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/pango-1.0": {
@@ -1235,955 +1078,809 @@
       }
     },
     "node_modules/@girs/soup-3.0": {
-      "version": "3.6.6-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/soup-3.0/-/soup-3.0-3.6.6-4.0.1.tgz",
-      "integrity": "sha512-6UbEMuyluSCq2kwyZMLfpoDplSEzWYgZEvN83CAV1fvCWVz+VD2BD/eabiaOCozu+7QsHdud9DhJglC86zH6dQ==",
+      "version": "3.6.6-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/soup-3.0/-/soup-3.0-3.6.6-4.0.4.tgz",
+      "integrity": "sha512-3RdCH+i48JXHzq5ruMRIfsconqkiKG6PDUWyEvDmcy8ouUFFOjWBZV83giEXS90GiPYUzMvfYe5XfcHJXXvI3g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@girs/soup-3.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/soup-3.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@girs/soup-3.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@girs/soup-3.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/soup-3.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@girs/soup-3.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/abort-controller": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.4.35.tgz",
-      "integrity": "sha512-L30OdENzidgglssMzxx0GI9egB8f8G8go2ljgzh8jMfbBm8IHgd3eVuRTHXg1kWCWOeYnjkqv36yTjjxkhk3Vg==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/abort-controller/-/abort-controller-0.4.36.tgz",
+      "integrity": "sha512-gk5y0DgLG9jVfuyKyaIFvWJ8DsL8Klnkm3PLEqjyOMa1RrIfi4e2zR6mzl7sW8b4WbremGzCEnaxXgxgo0Xq8A==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.35"
+        "@gjsify/dom-events": "^0.4.36"
       }
     },
     "node_modules/@gjsify/assert": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.4.35.tgz",
-      "integrity": "sha512-Cd+6LUYCGH7t0LKlQO8SF1f7MaZAZGssGezs3MJ6I0O6Kjr9OvrxEELQ938MxL8khrT8cyNU4CoTRiER0vX+Zg=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/assert/-/assert-0.4.36.tgz",
+      "integrity": "sha512-BwMc10JUVUZ2fwzs6BEFGDld97vHQkEWo5VnqAl/fKE35pYpUaXvTXiVdg8Co0P+UVypJzJVY9tbHeNFnDOasw=="
     },
     "node_modules/@gjsify/async_hooks": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.4.35.tgz",
-      "integrity": "sha512-GBFZEM+5SYOWuVv0Z3qpx941l84iJWbBUbKNVd2ySrWEsn8t6TtleSQHFvQfhTxCwoVnaJd9lGZ9Du+N9KE8aQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/async_hooks/-/async_hooks-0.4.36.tgz",
+      "integrity": "sha512-gZjVSeAU2xY+O/dyu2YdgTG1r2TjcJdu+VCWIWK51qybSWVQwWs0/d99FNQo/1k6rcK2/wSPQNgssrgpEyosRw==",
       "dependencies": {
-        "@gjsify/events": "^0.4.35"
+        "@gjsify/events": "^0.4.36"
       }
     },
     "node_modules/@gjsify/buffer": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.4.35.tgz",
-      "integrity": "sha512-fYGCvRAysNfxoZypO3mi1n6Te0J7XDnd/Xfcr/zdXosCDDKxfjKCPkghGz2NWrxeWzo6duCwHaEJGz+OvHfDTQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/buffer/-/buffer-0.4.36.tgz",
+      "integrity": "sha512-Nnk+EWI88ROULHdugsTfC8WwlZ8VxzPBEBcPN6zC3mzFP2iO4PZ4CfpszFPf8dIBZOtpX6rRQjqaaVmUeNBK1A==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.35"
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/canvas2d": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d/-/canvas2d-0.4.35.tgz",
-      "integrity": "sha512-ArXG69S8zh02kuz/Z5jtNpfl1sSkf69vD3B7I22Zwvr+OiJ8vEP9R8zIn065qYxyJCE4H3gvpb7RTL3RzO0ENQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d/-/canvas2d-0.4.36.tgz",
+      "integrity": "sha512-oVIoT6nqIJqFRXeInQ44HMp4gsh+h7n58huVIG7lwfNvukmsGSYnGrGclXt3kD2TFDum2zJ/7dVpzichm0Eu/A==",
       "dependencies": {
-        "@girs/gdk-4.0": "4.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/gtk-4.0": "4.23.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1",
-        "@gjsify/canvas2d-core": "^0.4.35",
-        "@gjsify/dom-elements": "^0.4.35",
-        "@gjsify/dom-events": "^0.4.35",
-        "@gjsify/event-bridge": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gdk-4.0": "4.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/gtk-4.0": "4.23.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@gjsify/canvas2d-core": "^0.4.36",
+        "@gjsify/dom-elements": "^0.4.36",
+        "@gjsify/dom-events": "^0.4.36",
+        "@gjsify/event-bridge": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/canvas2d-core": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d-core/-/canvas2d-core-0.4.35.tgz",
-      "integrity": "sha512-htOIC47kzrx1rlP5PQ2ByQssOst/CdEchxknwyny36M19nIXd0Gg1xZsWurAY3Xp0B7oQkK15BV+exLPDtUvVQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/canvas2d-core/-/canvas2d-core-0.4.36.tgz",
+      "integrity": "sha512-kPqysRyxVzvvvpwdegfy+LxcvqjyJXgjSMQaaJXqc6ZBkEYH3NZVwrzOoR14mdiBv7F+9G68s5y5A3j4OD6sxg==",
       "dependencies": {
-        "@girs/gdk-4.0": "4.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
+        "@girs/gdk-4.0": "4.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.1.tgz",
-      "integrity": "sha512-zrzRqPBD2PFh0/lqav7TYnL4qVHHIgH7SM6oEj/I7kQZWjk06GyfSj60cyhYOXUlX5O67tViZ0KPPnXO0O6eqA==",
+      "version": "4.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.4.tgz",
+      "integrity": "sha512-HehASXR1K7WRPC9rZDUtM1ty0mNItRjQ95tkGOMJ6UBK+XZLDfcVL/q72StL2tLDC20BnzoXLpw8Y5PP/uGljw==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-FKOxBYsfMW2KPTG2zML8No6Me5yM3cNatAt/Hr7Kjw8iPTZgGCV8TqtOHPTz9jvMajMDa/ETC+Y49GustIHi6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
-      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
+      "version": "13.2.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.4.tgz",
+      "integrity": "sha512-gj7dqsJ8vRYowHI5jd8/0Otb1HfIRVwVNH/F63TnqFCLbAFiuCavjNRBfTFZ1d9eIvmuGK34IsYm0hI802Uogg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-EaACHntZ7Wei0jfT/vBfKvuXZ5c6zr6UlqghH/tofDu2XjIyBCAuIIWAwv0lI7xj44oGSMTzzCNkswVaNNUpDA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0": {
-      "version": "1.57.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.1.tgz",
-      "integrity": "sha512-1GrH9fqEsB/feXy/02pYujF42/taO8IL/fzTwx9syisiRHEEXNQwSV6N3EbCDOKHeUbDzv2KyNJm5b3pVLszRw==",
+      "version": "1.57.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.4.tgz",
+      "integrity": "sha512-mN2MinF+2dkqHLquOIgQW7Q3GbW7wz/spQMOMtAwXuXMcfk8ZAtJl1ZQOEDh1NBZeSAM4Th46tH76+5OO9aJoA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-FKOxBYsfMW2KPTG2zML8No6Me5yM3cNatAt/Hr7Kjw8iPTZgGCV8TqtOHPTz9jvMajMDa/ETC+Y49GustIHi6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pango-1.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
-      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
+      "version": "13.2.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.4.tgz",
+      "integrity": "sha512-gj7dqsJ8vRYowHI5jd8/0Otb1HfIRVwVNH/F63TnqFCLbAFiuCavjNRBfTFZ1d9eIvmuGK34IsYm0hI802Uogg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-GRJbgTQap2LGPukqqL0WnrFpCZhR2i0DlLwD9QkSP1dFRCe4owaNizC6kQdbkvojqR+b3GfFbzqyVGlZKzD0Vg==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-baIguxy7m7G5TcAKF6ZWU6cow+3Gr/AZJBEZFmTYWmxEc3AE8s+ik9+ujEcHZP1DuGS9fVQskjJWFhd+LYNF8A==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-FKOxBYsfMW2KPTG2zML8No6Me5yM3cNatAt/Hr7Kjw8iPTZgGCV8TqtOHPTz9jvMajMDa/ETC+Y49GustIHi6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d-core/node_modules/@girs/pangocairo-1.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
-      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
+      "version": "13.2.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.4.tgz",
+      "integrity": "sha512-gj7dqsJ8vRYowHI5jd8/0Otb1HfIRVwVNH/F63TnqFCLbAFiuCavjNRBfTFZ1d9eIvmuGK34IsYm0hI802Uogg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.1.tgz",
-      "integrity": "sha512-zrzRqPBD2PFh0/lqav7TYnL4qVHHIgH7SM6oEj/I7kQZWjk06GyfSj60cyhYOXUlX5O67tViZ0KPPnXO0O6eqA==",
+      "version": "4.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.4.tgz",
+      "integrity": "sha512-HehASXR1K7WRPC9rZDUtM1ty0mNItRjQ95tkGOMJ6UBK+XZLDfcVL/q72StL2tLDC20BnzoXLpw8Y5PP/uGljw==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-FKOxBYsfMW2KPTG2zML8No6Me5yM3cNatAt/Hr7Kjw8iPTZgGCV8TqtOHPTz9jvMajMDa/ETC+Y49GustIHi6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
-      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
+      "version": "13.2.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.4.tgz",
+      "integrity": "sha512-gj7dqsJ8vRYowHI5jd8/0Otb1HfIRVwVNH/F63TnqFCLbAFiuCavjNRBfTFZ1d9eIvmuGK34IsYm0hI802Uogg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-EaACHntZ7Wei0jfT/vBfKvuXZ5c6zr6UlqghH/tofDu2XjIyBCAuIIWAwv0lI7xj44oGSMTzzCNkswVaNNUpDA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/canvas2d/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/canvas2d/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/canvas2d/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/canvas2d/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0": {
-      "version": "4.23.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.1.tgz",
-      "integrity": "sha512-a5wAjHPHI//ZiMODFM2EEV0R/+5wcoM5BkDBjlaX3eRbapq3+DWxhevsgmZRlwz4SOqLqgvusJRsjnX3nrf+tg==",
+      "version": "4.23.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.4.tgz",
+      "integrity": "sha512-voE7gQtNSOci4yc+r5Fon9kBLFfDY7E4+Ft9d8cEUz///9p64DwvVaUp9w/1hTfEqKQcA9ORcIgXCteQ6PSQuQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gdk-4.0": "4.0.0-4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gsk-4.0": "4.0.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/graphene-1.0": "1.0.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gsk-4.0": "4.0.0-4.0.4",
+        "@girs/graphene-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gdk-4.0": "4.0.0-4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-FKOxBYsfMW2KPTG2zML8No6Me5yM3cNatAt/Hr7Kjw8iPTZgGCV8TqtOHPTz9jvMajMDa/ETC+Y49GustIHi6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-fXHpp8NJUaUTA2/HU7KbGPUOVWE3N2HLrP7x4HQvxtvlUjo6BbyvQXTgyrnMED2ZlsvEy5RPVSAsk0RJiS81gg==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-CeM4su4CzuYvPXXBa0pg3CIihiC5Vw7At3Xe+4G5/GCzssl4xtoJmdQLHCRWVJInXelcfyENSK+XN2LOttvY/Q==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/gsk-4.0": {
-      "version": "4.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.1.tgz",
-      "integrity": "sha512-rayS9BQzgCF9ruVXZQ9pOvwoEHxVFaNoRGH9NU2N6XiTG6T3dk6QGSzSBuvnNtmN1af5/vldBPvkJRSvWzhQ6g==",
+      "version": "4.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.4.tgz",
+      "integrity": "sha512-Yq/x1OqN7BXww7rDxnUPT/K71Xq3QuYRI2ySpfDlhcQHldkxlRj3zgKIIXCIwHfXVyVmBEFKXlI2Wlrczn6tbw==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gdk-4.0": "4.0.0-4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/graphene-1.0": "1.0.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/graphene-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gdk-4.0": "4.0.0-4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/gtk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
-      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
+      "version": "13.2.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.4.tgz",
+      "integrity": "sha512-gj7dqsJ8vRYowHI5jd8/0Otb1HfIRVwVNH/F63TnqFCLbAFiuCavjNRBfTFZ1d9eIvmuGK34IsYm0hI802Uogg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0": {
-      "version": "1.57.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.1.tgz",
-      "integrity": "sha512-1GrH9fqEsB/feXy/02pYujF42/taO8IL/fzTwx9syisiRHEEXNQwSV6N3EbCDOKHeUbDzv2KyNJm5b3pVLszRw==",
+      "version": "1.57.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.4.tgz",
+      "integrity": "sha512-mN2MinF+2dkqHLquOIgQW7Q3GbW7wz/spQMOMtAwXuXMcfk8ZAtJl1ZQOEDh1NBZeSAM4Th46tH76+5OO9aJoA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-FKOxBYsfMW2KPTG2zML8No6Me5yM3cNatAt/Hr7Kjw8iPTZgGCV8TqtOHPTz9jvMajMDa/ETC+Y49GustIHi6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pango-1.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
-      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
+      "version": "13.2.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.4.tgz",
+      "integrity": "sha512-gj7dqsJ8vRYowHI5jd8/0Otb1HfIRVwVNH/F63TnqFCLbAFiuCavjNRBfTFZ1d9eIvmuGK34IsYm0hI802Uogg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-GRJbgTQap2LGPukqqL0WnrFpCZhR2i0DlLwD9QkSP1dFRCe4owaNizC6kQdbkvojqR+b3GfFbzqyVGlZKzD0Vg==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-baIguxy7m7G5TcAKF6ZWU6cow+3Gr/AZJBEZFmTYWmxEc3AE8s+ik9+ujEcHZP1DuGS9fVQskjJWFhd+LYNF8A==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-FKOxBYsfMW2KPTG2zML8No6Me5yM3cNatAt/Hr7Kjw8iPTZgGCV8TqtOHPTz9jvMajMDa/ETC+Y49GustIHi6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/canvas2d/node_modules/@girs/pangocairo-1.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
-      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
+      "version": "13.2.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.4.tgz",
+      "integrity": "sha512-gj7dqsJ8vRYowHI5jd8/0Otb1HfIRVwVNH/F63TnqFCLbAFiuCavjNRBfTFZ1d9eIvmuGK34IsYm0hI802Uogg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/child_process": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.4.35.tgz",
-      "integrity": "sha512-50LXAJy7xZI0yfkzQgxPoB4p1Dj1aaZvfJnvhOXnnbNqRfN5mjtOuiu/iWDid3YTdTRcjGNlcD4ihm7/yPZYgQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/child_process/-/child_process-0.4.36.tgz",
+      "integrity": "sha512-D+CAPS+4I+jOEYx7fb+SNvaYoP8oeBZ7EE/6249sbVzVJrw5FT0ZQZnFzJNNRnVY990mjaSv5T1+1s9tvADUuQ==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/child_process/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/child_process/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/child_process/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/cli": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.4.35.tgz",
-      "integrity": "sha512-T8cHroI5mdGa1rFEbCBQiQ0/Bp37SOJuz1VWPNFpH4V3YNu5dwizsLOCEh3qpV2yHYPvVHtkKDvXITBRN41InQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/cli/-/cli-0.4.36.tgz",
+      "integrity": "sha512-x5hyYIoV0AbWB+vphbw2O6q1xcA4l/zU0iUnUC0T56APYhusMLM32lCgzenEHcYGqz0+Bp1WGRiLrVvya+x50g==",
       "dependencies": {
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/create-app": "^0.4.35",
-        "@gjsify/node-globals": "^0.4.35",
-        "@gjsify/node-polyfills": "^0.4.35",
-        "@gjsify/npm-registry": "^0.4.35",
-        "@gjsify/resolve-npm": "^0.4.35",
-        "@gjsify/rolldown-plugin-gjsify": "^0.4.35",
-        "@gjsify/rolldown-plugin-pnp": "^0.4.35",
-        "@gjsify/semver": "^0.4.35",
-        "@gjsify/tar": "^0.4.35",
-        "@gjsify/web-polyfills": "^0.4.35",
-        "@gjsify/workspace": "^0.4.35",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/create-app": "^0.4.36",
+        "@gjsify/node-globals": "^0.4.36",
+        "@gjsify/node-polyfills": "^0.4.36",
+        "@gjsify/npm-registry": "^0.4.36",
+        "@gjsify/resolve-npm": "^0.4.36",
+        "@gjsify/rolldown-plugin-gjsify": "^0.4.36",
+        "@gjsify/rolldown-plugin-pnp": "^0.4.36",
+        "@gjsify/semver": "^0.4.36",
+        "@gjsify/tar": "^0.4.36",
+        "@gjsify/tsc": "^0.4.36",
+        "@gjsify/web-polyfills": "^0.4.36",
+        "@gjsify/workspace": "^0.4.36",
         "cosmiconfig": "^9.0.1",
         "get-tsconfig": "^4.14.0",
         "pkg-types": "^2.3.1",
-        "rolldown": "^1.0.0",
+        "rolldown": "^1.0.3",
         "yargs": "^18.0.0"
       },
       "bin": {
@@ -2191,1919 +1888,1304 @@
       }
     },
     "node_modules/@gjsify/cluster": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.4.35.tgz",
-      "integrity": "sha512-sP8WFAWFdzMRvps7CHHPeCrfFW41Neb5asXtrXstANgmVfeuKz6+K7UI3Er8EDLhql/khyS4rYEwdMIA7uox2g==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/cluster/-/cluster-0.4.36.tgz",
+      "integrity": "sha512-Lg5tSV1YJARFJHr6fCIY9Z1dn3W5aPEyFHZLs5BkiWhh6kWq7Mzpj1mctNLUZkhiddfjqfxf98bqdNyqdrIQpw==",
       "dependencies": {
-        "@gjsify/events": "^0.4.35"
+        "@gjsify/events": "^0.4.36"
       }
     },
     "node_modules/@gjsify/compression-streams": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.4.35.tgz",
-      "integrity": "sha512-F+IA8jBQWlugx+t4YaulwWu6HNtJ5fWoawGMz3gw7ft86CQFiIIGXCovoeIOuz2V4Q5jAC1pkz3jiplqe5Vcdg==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/compression-streams/-/compression-streams-0.4.36.tgz",
+      "integrity": "sha512-PshOSptAYYXWpWmRcJ9gyUARbsa1WSOKuO/JeUJQDb0IzPve7/sYgNx4sDr7WUdywSEfBulakwG9f362ggwUeg==",
       "dependencies": {
-        "@gjsify/web-streams": "^0.4.35"
+        "@gjsify/web-streams": "^0.4.36"
       }
     },
     "node_modules/@gjsify/console": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.4.35.tgz",
-      "integrity": "sha512-1jV9uvzPsXuRd/Xv/XgdusjI5DFqPMU2lVwWMa1vtiaet+ujzGOHqDlKl9UAXNPew3s7oW0o9hd8/HOhy/Qlrg=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/console/-/console-0.4.36.tgz",
+      "integrity": "sha512-VQj6/wnoacFM3WwD2ejsh7lLapRQgLBcoPcuc3lm+V6eNpjscLprXS+SBKjKWOXJgGLHdp/PlD7+e/+yEfDreg=="
     },
     "node_modules/@gjsify/constants": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.4.35.tgz",
-      "integrity": "sha512-nclEStc/p+SrvIikH/eg3y62tpy9tnoo6s8sJcp3vomEJEu3y9Lc8Rr2CSqep7hnjHkE73ovkzhkk9U6Bmp8Lw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/constants/-/constants-0.4.36.tgz",
+      "integrity": "sha512-vQKblUuJBKJPjeu0rEHvEgFwNQz6/up2E6G7W1/1CVyoEET+cko4nGgcniqqtNfWyohgfUVgaTEMOvWzjArVAQ==",
       "dependencies": {
-        "@gjsify/crypto": "^0.4.35",
-        "@gjsify/fs": "^0.4.35",
-        "@gjsify/os": "^0.4.35"
+        "@gjsify/crypto": "^0.4.36",
+        "@gjsify/fs": "^0.4.36",
+        "@gjsify/os": "^0.4.36"
       }
     },
     "node_modules/@gjsify/create-app": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.4.35.tgz",
-      "integrity": "sha512-z6B7q4P7ZtVxeTENydnWmpTTZFzw+yt5xElNe6qM2yh0EjObzskJpFBRMGoH4kJUKWJejTj/f+okR7y7AKeKwQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/create-app/-/create-app-0.4.36.tgz",
+      "integrity": "sha512-9r54cFPXPQT0b2un2LBOjoRODYo1+wvjrLjKLaXkfJgi0M96vLfuBCRuHk7pJ8dRBA3Bio+s2pVS4RKpuOV14g==",
       "dependencies": {
         "yargs": "^18.0.0"
       },
       "bin": "./lib/index.js"
     },
     "node_modules/@gjsify/crypto": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.4.35.tgz",
-      "integrity": "sha512-vXsH2pYg/02qN4VC6UNJkEFq+0zaOndVueMw5EodjdpZSaRbjv4xAE70hFb9o6Bf+HlRtf588b2a1ij2vF0Txw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/crypto/-/crypto-0.4.36.tgz",
+      "integrity": "sha512-ayt/2sDNGqAtmkw9JgeMezv1LbmsJWlbGrA0nuvpWPTpkK5rM4WD6aWgx2b7FURhtUdlnmnYm/F5GP0gqF7MdA==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/stream": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/stream": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/crypto/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dgram": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.4.35.tgz",
-      "integrity": "sha512-iRcGLgXffAnssVZthfM007P9eITxutUFYlqYhbCO4Yg5h+Icxq407ExZXh9yJurSvCXub5NmVFlYCly4PIAH2w==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/dgram/-/dgram-0.4.36.tgz",
+      "integrity": "sha512-xf7DJGnVIv87zvlmctALWr+vjHWu1+LV3zPpgJSsSNRYSENiVQ1RM6kzIAmvii8Cmk1S9nthqEjgiXYQcSJB0g==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dgram/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dgram/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dgram/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/diagnostics_channel": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.4.35.tgz",
-      "integrity": "sha512-m+8SqWPTv2r7CjkYfI3dglPeZFwB2Iz5Cr1XDT//3L4UOmYWzgi5oNg7vngembCVtLDlwYLE11T/CN993GaUfA=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/diagnostics_channel/-/diagnostics_channel-0.4.36.tgz",
+      "integrity": "sha512-o11AFveeo70EQI6kX6/uIszM9wspsfnJCQAzeEyX42FRsLGCYF8A16dufB45tXBOfXNaei7133pUlEYlRwzvJQ=="
     },
     "node_modules/@gjsify/dns": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.4.35.tgz",
-      "integrity": "sha512-LqLXZSZbbsKW6qBretHmPVM1jVs/L7ylq9b6Hvd231hrXf7AvIzSSLm2HdhmTGH44cEih7y/+Cn/b4EPcoBkCQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/dns/-/dns-0.4.36.tgz",
+      "integrity": "sha512-gaMdhqf3HLGHRNzDCCXDwacl1/54mdfB/qhDY9XDKn3wS2yOgP91UNQE5gCd75Em68I6hcV5o2KX5sRdTcrtWg==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/net": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/net": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dns/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dns/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dns/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dom-elements": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-elements/-/dom-elements-0.4.35.tgz",
-      "integrity": "sha512-tC+/jtBc0Dr/R6ELuQ8GoU14lWSXFSQr/BEEk1BXUhi99DRuqMsbY1kPrLY+1OS+GWqmSuuSl3L5mjr/ESZt3w==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-elements/-/dom-elements-0.4.36.tgz",
+      "integrity": "sha512-mtDJhT/fLPBoI/iwetGZzGXDGTQkBPYytD6P40uOCFIP0G9PEet4TRiYOp3l368YdvYdjaVEPufhuuoqX3VF5w==",
       "dependencies": {
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/abort-controller": "^0.4.35",
-        "@gjsify/canvas2d-core": "^0.4.35",
-        "@gjsify/dom-events": "^0.4.35",
-        "@gjsify/fetch": "^0.4.35"
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/abort-controller": "^0.4.36",
+        "@gjsify/canvas2d-core": "^0.4.36",
+        "@gjsify/dom-events": "^0.4.36",
+        "@gjsify/fetch": "^0.4.36"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-EaACHntZ7Wei0jfT/vBfKvuXZ5c6zr6UlqghH/tofDu2XjIyBCAuIIWAwv0lI7xj44oGSMTzzCNkswVaNNUpDA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dom-elements/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dom-elements/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dom-elements/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dom-elements/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/dom-elements/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dom-elements/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/dom-events": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.4.35.tgz",
-      "integrity": "sha512-MGsDz7fyunWS2blf8FBe37kup3R0dT9/GkBBDwUYBK6RotzAdQaGD4KouGNdeWbfCNRQGqVnd2kiZMyfaybxdQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-events/-/dom-events-0.4.36.tgz",
+      "integrity": "sha512-GfIjhqo0ur/gyJkyK/hj5FLVHOxiUBmzppBUp03r9laWpeC7njIzBZWrUeq7TZKBpL5riDX65W40d1zSDX2XGg==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.4.35"
+        "@gjsify/dom-exception": "^0.4.36"
       }
     },
     "node_modules/@gjsify/dom-exception": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.4.35.tgz",
-      "integrity": "sha512-Ealk1pf20LWev/DngflCQxTCENoTufSDRGLHAgz8ufRW2bfdZG5gsKqjdO1KDVB3/zI76lR9uGauNqLfIH1MRA=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/dom-exception/-/dom-exception-0.4.36.tgz",
+      "integrity": "sha512-kDWKP0o+hvgO0Xe0s6odtg6GKCQeMpgNgBdG03TbSAWmeu12aXZZh5DNfY6g8lvAClr76fc7F6CXI+wnX2W9Mg=="
     },
     "node_modules/@gjsify/domain": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.4.35.tgz",
-      "integrity": "sha512-hk5O4Nyha9IT9WgusN8iUZ/ddfmzw5Ns97SedI7+JS4q/JWu89np3ahA5dBlREUrL9WS6eG0dSvArtUQGbRMRw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/domain/-/domain-0.4.36.tgz",
+      "integrity": "sha512-ecOtKOfY5eBXDmWIBd6+Xszr96ec0aUoOjA0Y0BBDr7BpIVN0psp2AGKlxfjQ692PqNALhr7/3qnfXSLfDAoyA==",
       "dependencies": {
-        "@gjsify/events": "^0.4.35"
+        "@gjsify/events": "^0.4.36"
       }
     },
     "node_modules/@gjsify/domparser": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.4.35.tgz",
-      "integrity": "sha512-TK0rIuXjVeUHYnx7LDZNKOMSLVD+ztjalVtO4+cFt+DYvqfBMrCayIduwV+5BOMaCNZEs7p6Ebkwe365WiuBnQ=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/domparser/-/domparser-0.4.36.tgz",
+      "integrity": "sha512-C9Rl3F4oUowNAcRtHLwYYT9poWFZ8DgQTYHDApmah26mHap5BXvEsTgftNj+6zGabyonKBVY48AT54dmqfxkgg=="
     },
     "node_modules/@gjsify/event-bridge": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/event-bridge/-/event-bridge-0.4.35.tgz",
-      "integrity": "sha512-MhRRDHK/KvIscIkDbuER/h8dmabmGtP10k+v1jffOqsf+82p8K7x7yYnP+XXZIM9TgpbWgrzSbNVzUiBiacfPQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/event-bridge/-/event-bridge-0.4.36.tgz",
+      "integrity": "sha512-y1HOyRzM5sR1Dr8QWUCrrCaaOcPGjwJktjnJQivSrfcxziKEMCOA9Ta9F6p1RTxVhOOjscpnkTUuvT1cm8kHLQ==",
       "dependencies": {
-        "@girs/gdk-4.0": "4.0.0-4.0.1",
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gtk-4.0": "4.23.0-4.0.1",
-        "@gjsify/dom-events": "^0.4.35"
+        "@girs/gdk-4.0": "4.0.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gtk-4.0": "4.23.0-4.0.4",
+        "@gjsify/dom-events": "^0.4.36"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.1.tgz",
-      "integrity": "sha512-zrzRqPBD2PFh0/lqav7TYnL4qVHHIgH7SM6oEj/I7kQZWjk06GyfSj60cyhYOXUlX5O67tViZ0KPPnXO0O6eqA==",
+      "version": "4.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.4.tgz",
+      "integrity": "sha512-HehASXR1K7WRPC9rZDUtM1ty0mNItRjQ95tkGOMJ6UBK+XZLDfcVL/q72StL2tLDC20BnzoXLpw8Y5PP/uGljw==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-FKOxBYsfMW2KPTG2zML8No6Me5yM3cNatAt/Hr7Kjw8iPTZgGCV8TqtOHPTz9jvMajMDa/ETC+Y49GustIHi6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-EaACHntZ7Wei0jfT/vBfKvuXZ5c6zr6UlqghH/tofDu2XjIyBCAuIIWAwv0lI7xj44oGSMTzzCNkswVaNNUpDA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
-      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
+      "version": "13.2.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.4.tgz",
+      "integrity": "sha512-gj7dqsJ8vRYowHI5jd8/0Otb1HfIRVwVNH/F63TnqFCLbAFiuCavjNRBfTFZ1d9eIvmuGK34IsYm0hI802Uogg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/pango-1.0": {
-      "version": "1.57.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.1.tgz",
-      "integrity": "sha512-1GrH9fqEsB/feXy/02pYujF42/taO8IL/fzTwx9syisiRHEEXNQwSV6N3EbCDOKHeUbDzv2KyNJm5b3pVLszRw==",
+      "version": "1.57.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.4.tgz",
+      "integrity": "sha512-mN2MinF+2dkqHLquOIgQW7Q3GbW7wz/spQMOMtAwXuXMcfk8ZAtJl1ZQOEDh1NBZeSAM4Th46tH76+5OO9aJoA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gdk-4.0/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-GRJbgTQap2LGPukqqL0WnrFpCZhR2i0DlLwD9QkSP1dFRCe4owaNizC6kQdbkvojqR+b3GfFbzqyVGlZKzD0Vg==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-baIguxy7m7G5TcAKF6ZWU6cow+3Gr/AZJBEZFmTYWmxEc3AE8s+ik9+ujEcHZP1DuGS9fVQskjJWFhd+LYNF8A==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/event-bridge/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/event-bridge/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/event-bridge/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/event-bridge/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/event-bridge/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0": {
-      "version": "4.23.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.1.tgz",
-      "integrity": "sha512-a5wAjHPHI//ZiMODFM2EEV0R/+5wcoM5BkDBjlaX3eRbapq3+DWxhevsgmZRlwz4SOqLqgvusJRsjnX3nrf+tg==",
+      "version": "4.23.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.4.tgz",
+      "integrity": "sha512-voE7gQtNSOci4yc+r5Fon9kBLFfDY7E4+Ft9d8cEUz///9p64DwvVaUp9w/1hTfEqKQcA9ORcIgXCteQ6PSQuQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gdk-4.0": "4.0.0-4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gsk-4.0": "4.0.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/graphene-1.0": "1.0.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gsk-4.0": "4.0.0-4.0.4",
+        "@girs/graphene-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gdk-4.0": "4.0.0-4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-FKOxBYsfMW2KPTG2zML8No6Me5yM3cNatAt/Hr7Kjw8iPTZgGCV8TqtOHPTz9jvMajMDa/ETC+Y49GustIHi6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-EaACHntZ7Wei0jfT/vBfKvuXZ5c6zr6UlqghH/tofDu2XjIyBCAuIIWAwv0lI7xj44oGSMTzzCNkswVaNNUpDA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-fXHpp8NJUaUTA2/HU7KbGPUOVWE3N2HLrP7x4HQvxtvlUjo6BbyvQXTgyrnMED2ZlsvEy5RPVSAsk0RJiS81gg==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-CeM4su4CzuYvPXXBa0pg3CIihiC5Vw7At3Xe+4G5/GCzssl4xtoJmdQLHCRWVJInXelcfyENSK+XN2LOttvY/Q==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/gsk-4.0": {
-      "version": "4.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.1.tgz",
-      "integrity": "sha512-rayS9BQzgCF9ruVXZQ9pOvwoEHxVFaNoRGH9NU2N6XiTG6T3dk6QGSzSBuvnNtmN1af5/vldBPvkJRSvWzhQ6g==",
+      "version": "4.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.4.tgz",
+      "integrity": "sha512-Yq/x1OqN7BXww7rDxnUPT/K71Xq3QuYRI2ySpfDlhcQHldkxlRj3zgKIIXCIwHfXVyVmBEFKXlI2Wlrczn6tbw==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gdk-4.0": "4.0.0-4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/graphene-1.0": "1.0.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/graphene-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gdk-4.0": "4.0.0-4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
-      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
+      "version": "13.2.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.4.tgz",
+      "integrity": "sha512-gj7dqsJ8vRYowHI5jd8/0Otb1HfIRVwVNH/F63TnqFCLbAFiuCavjNRBfTFZ1d9eIvmuGK34IsYm0hI802Uogg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/pango-1.0": {
-      "version": "1.57.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.1.tgz",
-      "integrity": "sha512-1GrH9fqEsB/feXy/02pYujF42/taO8IL/fzTwx9syisiRHEEXNQwSV6N3EbCDOKHeUbDzv2KyNJm5b3pVLszRw==",
+      "version": "1.57.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.4.tgz",
+      "integrity": "sha512-mN2MinF+2dkqHLquOIgQW7Q3GbW7wz/spQMOMtAwXuXMcfk8ZAtJl1ZQOEDh1NBZeSAM4Th46tH76+5OO9aJoA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/event-bridge/node_modules/@girs/gtk-4.0/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-GRJbgTQap2LGPukqqL0WnrFpCZhR2i0DlLwD9QkSP1dFRCe4owaNizC6kQdbkvojqR+b3GfFbzqyVGlZKzD0Vg==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-baIguxy7m7G5TcAKF6ZWU6cow+3Gr/AZJBEZFmTYWmxEc3AE8s+ik9+ujEcHZP1DuGS9fVQskjJWFhd+LYNF8A==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/events": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.4.35.tgz",
-      "integrity": "sha512-KLi6lVRVQhPzkiuRy8Ee5lvX84QmY+Ncc++bhC9KllWQQEnZcqPSYZi3paGtcmFTBwfLauGFI+0pO+HAf2+isg==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/events/-/events-0.4.36.tgz",
+      "integrity": "sha512-uk17HOQUk3CaSJh7pmAH2VDxYouHW22vAzIULJKrxI+Ric5QXuptByVAm9U+agPs3RU15V5DA9nFTrxov1xMVA==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.35"
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/eventsource": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.4.35.tgz",
-      "integrity": "sha512-pjvu0pL8D+/n12St0E/dKNR9DOnp3IJl/IQrxSKeHfa5KaQZKh1k1WHi9b5TkCH164qtODexdNEnx5EzmEZ+gQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/eventsource/-/eventsource-0.4.36.tgz",
+      "integrity": "sha512-T+0kOK9eMyh5qKcR36PI+nuxV7BKUto8m7H6TJlSmHc7TBnuNYdnjObpPWZcENX0wwhIc++OHMNahlrvOx75fA==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.35",
-        "@gjsify/web-streams": "^0.4.35"
+        "@gjsify/dom-events": "^0.4.36",
+        "@gjsify/web-streams": "^0.4.36"
       }
     },
     "node_modules/@gjsify/fetch": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.4.35.tgz",
-      "integrity": "sha512-fZOSp51bWRMKCXVyla2BP5uuOuvxEZJlx9rzRqWHlGBL7EBDRLx7hCluAF7ffu/cn32oMfo65QHwkZGsK16sUA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/fetch/-/fetch-0.4.36.tgz",
+      "integrity": "sha512-1TjQNtzakDlhe8f+LguKS98wxIF4lNC98P3WBXRxdbdBopTcSfNljkD1gnSk0DygAXCB/3+H8KfvwIJzekbo7Q==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/formdata": "^0.4.35",
-        "@gjsify/http": "^0.4.35",
-        "@gjsify/url": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/soup-3.0": "3.6.6-4.0.4",
+        "@gjsify/formdata": "^0.4.36",
+        "@gjsify/http": "^0.4.36",
+        "@gjsify/url": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/fetch/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/fetch/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/fetch/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/fetch/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/formdata": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.4.35.tgz",
-      "integrity": "sha512-8/86g4tjReiwAMK2+Km/nh5C9b49PCG3GBRABRd2pKOgUEsrUp0VyxIyVpaqmh32leb7BSBs62drRzgNenbbhA=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/formdata/-/formdata-0.4.36.tgz",
+      "integrity": "sha512-UP0LzfPqg8QNsoL9uaXm69A7sDy7XctGPWgXQOu8iOUxiInAA8kdISfzxdzixrzo+d1tYpml5UmhlLY4zXhVmg=="
     },
     "node_modules/@gjsify/fs": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.4.35.tgz",
-      "integrity": "sha512-MVeDtm+AvE88p68AkLRJMuxOqRs6X0EfQDmGN47vMA3pvuBk2JcLpzDm0PcD0ybw6eoYgRZ3dGa9B3AxQxGZBA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/fs/-/fs-0.4.36.tgz",
+      "integrity": "sha512-mDWsr/yDJAO/BWT3rNUow/7WW08x8QX1x9QVsKAjp8tSG8PYkuA8HX6FfPaAGZEOT2EfcvqnyVmMIC7/IGYERg==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/stream": "^0.4.35",
-        "@gjsify/url": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/stream": "^0.4.36",
+        "@gjsify/url": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/fs/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/fs/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/fs/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/gamepad": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.4.35.tgz",
-      "integrity": "sha512-D+gRGGQ0U5rR7iTC9UKVMaq56rC/B9lWkzxSADuHELBeMO16MeWAzZUAOHGL0vrGxLtd2MCSNBXeNJWwnuwAhw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/gamepad/-/gamepad-0.4.36.tgz",
+      "integrity": "sha512-lmR1MiK5ewyyMIoYLrSh4uxixOZeAgf7bABuWj3GLs7Yum7ho/LlLLAlkZYLkypZT8f9ehnCoZ/6rWWNGra80A==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.35"
+        "@gjsify/dom-events": "^0.4.36"
       }
     },
     "node_modules/@gjsify/http": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.4.35.tgz",
-      "integrity": "sha512-op3MrN8Nj1tMaNrVwG1DEO5CH5xONE87CqXrVlAkrN9usRcT3t0jUE7I8hQe4K8nvynxWbixV1MZYP8pWL8PFw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/http/-/http-0.4.36.tgz",
+      "integrity": "sha512-s0Rmix6vRbDotcsFKbkotmyeBu18R5OD3sNLTL/aDEP//G9I1Wv3edTL4S73onGvnfS8yWVZS++i3F8IOVXTVw==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/http-soup-bridge": "^0.4.35",
-        "@gjsify/net": "^0.4.35",
-        "@gjsify/stream": "^0.4.35",
-        "@gjsify/url": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/soup-3.0": "3.6.6-4.0.4",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/http-soup-bridge": "^0.4.36",
+        "@gjsify/net": "^0.4.36",
+        "@gjsify/stream": "^0.4.36",
+        "@gjsify/url": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/http-soup-bridge": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.4.35.tgz",
-      "integrity": "sha512-xnMqmRvqTfQqjfT1FSJ8SLj8gqfMyo0Q41+xpzFove3K0sG/r+X8uFj2IEvxGWfYWMfVZtjxpBScTEJDk48UbA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/http-soup-bridge/-/http-soup-bridge-0.4.36.tgz",
+      "integrity": "sha512-GBQlP/VLp3sA+LzWh8+zYSFOMWGxkTGhyeuVRVrUAE5Sn2FqRsDJfLiFn5la6DGpKGb08MbY8tCoMdKPp57U9w==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/soup-3.0": "3.6.6-4.0.1"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/soup-3.0": "3.6.6-4.0.4"
       }
     },
     "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http-soup-bridge/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http2": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.4.35.tgz",
-      "integrity": "sha512-UyF5igg2mC+0aNsjpUNSn5PP9aOUxlyJcTvFX5QTNvPuri6gs8kbjxVJeMOTA3t2TjL8YGfxs9dQMjs2tlzV8A==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2/-/http2-0.4.36.tgz",
+      "integrity": "sha512-YL6saTpzk27GnPlsqxetXjN8CMQds+GTO7wZWFAJIFiXvK+eJkU66cduHZ9vjG3Dw2586itrUodSqnz2Rt5olA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/http2-native": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/soup-3.0": "3.6.6-4.0.4",
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/http2-native": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/http2-native": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.4.35.tgz",
-      "integrity": "sha512-P/sXLxfZxoyp5zW1GrFi4mvjKGxPWJZpWNQ+SbP3AppLHiV/u2gB2nbvXmSqv0svj3JJH5NzXo1wewx9bmYDUQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/http2-native/-/http2-native-0.4.36.tgz",
+      "integrity": "sha512-+yHO4KhvR66epR8hQUfMSGHJsWd2yAaPYH44avgXfEkrEPdQeRvwSimr+Sp0fJXBBG7qboxvUYOoZaHJmuBeig==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http2-native/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http2-native/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http2-native/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http2-native/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http2-native/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http2-native/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http2/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http2/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http2/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http2/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/http2/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http2/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/http2/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/https": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.4.35.tgz",
-      "integrity": "sha512-czyprVR6u7fyy9uKmvFB6jDliqVxThZnAR+jFl1SARsGKu3v9yEzxsoooKqQL5mUfT4Za/19TJT5iTU+3vN1WQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/https/-/https-0.4.36.tgz",
+      "integrity": "sha512-hZnscLhOVy1RGouVXwlqtnqVkLJbCtuOq6g1Y78/ZOccqTDrr6MMoBm3M1P7zAJhclama5MbOtgce/pW+dOWXQ==",
       "dependencies": {
-        "@gjsify/http": "^0.4.35",
-        "@gjsify/tls": "^0.4.35"
+        "@gjsify/http": "^0.4.36",
+        "@gjsify/tls": "^0.4.36"
       }
     },
     "node_modules/@gjsify/inspector": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.4.35.tgz",
-      "integrity": "sha512-YMSbk1ydy3MTZYdQOlrcJmDLctm5S8cxSvqQ/zCMBkCKyoMfIQuMM3ldoCLs8QuSKyqdizKdSlhX4Noum/Izlw=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/inspector/-/inspector-0.4.36.tgz",
+      "integrity": "sha512-pW/pi7TvlwemwfOoVS/TjNRVu6Wu+CY+OWkvstU+lWETn1aTnWyjzDbWz+73jF6d8O8Mg3LnmsL9ad0EGd0O7A=="
     },
     "node_modules/@gjsify/message-channel": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.4.35.tgz",
-      "integrity": "sha512-C4Bfnx1POS43zRrOyWGv77YOWsitFOBZnzN38fYT/VBrOpRppyCO922Ngpl2UvDA2gblam8jjcr/0yD7eQb9yw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/message-channel/-/message-channel-0.4.36.tgz",
+      "integrity": "sha512-vCOqfEbPuEYK2zHISLOdng+xZ+9gxHyEBWzf1QNbbBkGSGnpHJR6n4qC6zWyuR8JnXJP54m56O2NSv6RWbUWVg==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.35"
+        "@gjsify/dom-events": "^0.4.36"
       }
     },
     "node_modules/@gjsify/module": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.4.35.tgz",
-      "integrity": "sha512-wKdpix2mP1KnXhwkceCzUaOlWB0i9qIx5qAuCeisniubCYRqVQzzGSOZ/uv5E+5ElvhYO1wENTw1TPCaKKKFhQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/module/-/module-0.4.36.tgz",
+      "integrity": "sha512-4v+hsk/dT1XsXtjrA0jJQsvQHjYXkihy/w00q+IULdEfU9swLOiSsOlZvk7yfyTFyHzckdxqomGiY24zQWHuqQ==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/module/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/module/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/module/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/module/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/net": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.4.35.tgz",
-      "integrity": "sha512-yw08T9Wa4mA7GKDZKz6EN6z5jTJphM0C66CCn6D13MVcBG7MZgj/cps5VMYqTKcF5xNnSeXEnLO8SZAAjWjOfA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/net/-/net-0.4.36.tgz",
+      "integrity": "sha512-mdQwS9Hxf75qNmxuTJTrm5BGy0bb2lSlkf6SD15j21QRbPe4IHqzlK62aHs9X2dxsN3oJl/i8ZGLX3ZDBTo5xQ==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/stream": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/stream": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/net/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/net/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/net/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/net/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/net/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/node-globals": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.4.35.tgz",
-      "integrity": "sha512-+esVF+zEoO4EkjMF35/b8OmovxeefqtC8ZHHOXZgoGeqhqTwjvCEIefbkY9UDd7NqX2T11bn4a7ex/IQTDeSpA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-globals/-/node-globals-0.4.36.tgz",
+      "integrity": "sha512-xlt8aBNH3i6p8c1m42aH4Hvv0WWPpzq5m9gsoEnX7hKeyvcgEW/ybVj00cnTX7jJZuscZPBW7L8oYifctpDnEQ==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/process": "^0.4.35",
-        "@gjsify/url": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/process": "^0.4.36",
+        "@gjsify/url": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/node-globals/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/node-polyfills": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.4.35.tgz",
-      "integrity": "sha512-rapXZkL/GgiPjJm5+oiktc0idVbxpkE2sjJXZCuudwwQesx3k71KWa3O5TrW30jEJdkXlWEfXcs3eRwxgDhHsw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/node-polyfills/-/node-polyfills-0.4.36.tgz",
+      "integrity": "sha512-N+O76/EEsvLY4aaGODxxp+1waj5ivbfBxOijQm6ug8cMX4ZvuFqPdv7F8gr2LqgSMlu8m7cFEDqKYmabqUxHig==",
       "dependencies": {
-        "@gjsify/assert": "^0.4.35",
-        "@gjsify/async_hooks": "^0.4.35",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/child_process": "^0.4.35",
-        "@gjsify/cluster": "^0.4.35",
-        "@gjsify/console": "^0.4.35",
-        "@gjsify/constants": "^0.4.35",
-        "@gjsify/crypto": "^0.4.35",
-        "@gjsify/dgram": "^0.4.35",
-        "@gjsify/diagnostics_channel": "^0.4.35",
-        "@gjsify/dns": "^0.4.35",
-        "@gjsify/domain": "^0.4.35",
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/fs": "^0.4.35",
-        "@gjsify/http": "^0.4.35",
-        "@gjsify/http2": "^0.4.35",
-        "@gjsify/https": "^0.4.35",
-        "@gjsify/inspector": "^0.4.35",
-        "@gjsify/module": "^0.4.35",
-        "@gjsify/net": "^0.4.35",
-        "@gjsify/node-globals": "^0.4.35",
-        "@gjsify/os": "^0.4.35",
-        "@gjsify/path": "^0.4.35",
-        "@gjsify/perf_hooks": "^0.4.35",
-        "@gjsify/process": "^0.4.35",
-        "@gjsify/querystring": "^0.4.35",
-        "@gjsify/readline": "^0.4.35",
-        "@gjsify/sqlite": "^0.4.35",
-        "@gjsify/stream": "^0.4.35",
-        "@gjsify/string_decoder": "^0.4.35",
-        "@gjsify/sys": "^0.4.35",
-        "@gjsify/timers": "^0.4.35",
-        "@gjsify/tls": "^0.4.35",
-        "@gjsify/tty": "^0.4.35",
-        "@gjsify/url": "^0.4.35",
-        "@gjsify/util": "^0.4.35",
-        "@gjsify/v8": "^0.4.35",
-        "@gjsify/vm": "^0.4.35",
-        "@gjsify/worker_threads": "^0.4.35",
-        "@gjsify/zlib": "^0.4.35"
+        "@gjsify/assert": "^0.4.36",
+        "@gjsify/async_hooks": "^0.4.36",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/child_process": "^0.4.36",
+        "@gjsify/cluster": "^0.4.36",
+        "@gjsify/console": "^0.4.36",
+        "@gjsify/constants": "^0.4.36",
+        "@gjsify/crypto": "^0.4.36",
+        "@gjsify/dgram": "^0.4.36",
+        "@gjsify/diagnostics_channel": "^0.4.36",
+        "@gjsify/dns": "^0.4.36",
+        "@gjsify/domain": "^0.4.36",
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/fs": "^0.4.36",
+        "@gjsify/http": "^0.4.36",
+        "@gjsify/http2": "^0.4.36",
+        "@gjsify/https": "^0.4.36",
+        "@gjsify/inspector": "^0.4.36",
+        "@gjsify/module": "^0.4.36",
+        "@gjsify/net": "^0.4.36",
+        "@gjsify/node-globals": "^0.4.36",
+        "@gjsify/os": "^0.4.36",
+        "@gjsify/path": "^0.4.36",
+        "@gjsify/perf_hooks": "^0.4.36",
+        "@gjsify/process": "^0.4.36",
+        "@gjsify/querystring": "^0.4.36",
+        "@gjsify/readline": "^0.4.36",
+        "@gjsify/sqlite": "^0.4.36",
+        "@gjsify/stream": "^0.4.36",
+        "@gjsify/string_decoder": "^0.4.36",
+        "@gjsify/sys": "^0.4.36",
+        "@gjsify/timers": "^0.4.36",
+        "@gjsify/tls": "^0.4.36",
+        "@gjsify/tty": "^0.4.36",
+        "@gjsify/url": "^0.4.36",
+        "@gjsify/util": "^0.4.36",
+        "@gjsify/v8": "^0.4.36",
+        "@gjsify/vm": "^0.4.36",
+        "@gjsify/worker_threads": "^0.4.36",
+        "@gjsify/zlib": "^0.4.36"
       }
     },
     "node_modules/@gjsify/npm-registry": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.4.35.tgz",
-      "integrity": "sha512-6MxQYi5jONvu3cnYvYniYbE+xLlC/hiv9jLCtss+AcdavCAKkv4b6XE4oDJfhOYnqCNwIMZJfqTmZkdGNdZYaQ=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/npm-registry/-/npm-registry-0.4.36.tgz",
+      "integrity": "sha512-GqZ2y6IhrR9yMIDYRiJ64AUm88Oz4iU5Pq6zDNjkDLBQVoPgX7Fzuk4dKDCYm+D+fQoLhsLYEECHK4UMkR//VQ=="
     },
     "node_modules/@gjsify/os": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.4.35.tgz",
-      "integrity": "sha512-ukjcYagqjbKyWjNiz0/3x9MnQS6bEWU6d2FCaW/jsyusWQ50KiseiMtkaArkdGjFwnHHK8jInr9YXNpg6Ul4zQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/os/-/os-0.4.36.tgz",
+      "integrity": "sha512-MJzpdn91hcK8XzgSoJ7os0lptLDuImdFgxZw6mNyzIhcINi4xY5wmlPLiBd6vc8d2XgP71mX0TxACcUOL0BwRA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/os/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/os/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/os/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/os/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/os/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/path": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.4.35.tgz",
-      "integrity": "sha512-R4e+jAFtojfoBLnidzQlFlXoGiHcNCQdACYxRYiUbKXDvc8AtiS9qVY4YOX/tmFi7hgGaPfOSk9ehhiMHWO6Mw=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/path/-/path-0.4.36.tgz",
+      "integrity": "sha512-6J9lfrugDfCXIQ6knVuBA2AxBqLFo2nUj0u04e/AKpdHvBJm4JXJzMQa6pVvNmKoYeOe4Pq83FFNUWxcf8UbYQ=="
     },
     "node_modules/@gjsify/perf_hooks": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.4.35.tgz",
-      "integrity": "sha512-AhUMtBuPPc5y8ZILJA01sEF1lgZQmD9uAKcwsnfKzIX4A7LiqWqiFWFwx/KkAGywXb58T1cTrBr+Es9FWwj+4Q=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/perf_hooks/-/perf_hooks-0.4.36.tgz",
+      "integrity": "sha512-QueXC047b0XuRJ1Evl7UGW88i5dAUW48Y5nIqt852zggum3hAETa8PzZCcfAYPti3PPlxRwg6+pI4GW6Yx06wA=="
     },
     "node_modules/@gjsify/process": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.4.35.tgz",
-      "integrity": "sha512-xIfub50KCfZ5xyMV9tSn5KF76ih8Fo2cYLwu7g+o8rAE1cV3RXzc5FwpU9V8opJATSuVsnnS4vbeFWARWRZ1cw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/process/-/process-0.4.36.tgz",
+      "integrity": "sha512-Vk++CCHn/PgvD/0obQO87SWfdf7nUPizq/8xVGFAmXlOkQGjejsXhj/e8aK1XbmSJe844OeA5G+wJxT4TLpikg==",
       "dependencies": {
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/terminal-native": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/terminal-native": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/querystring": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.4.35.tgz",
-      "integrity": "sha512-NAbwjO+MDZ8ZTw3+CloOj+7bL5yTyk+ra3u8HsRkcqBn1mfxb/IH7pVIBCMXz6oFiXkXVBRH7eEN6+cZzu91Ug=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/querystring/-/querystring-0.4.36.tgz",
+      "integrity": "sha512-wKGbjKw+g0SysbytTzO1fI6UeSZrMolq4ToRKvSrBezYPUA0F9ln/RArGMTNRf/YVHSZjT2cowV6ZiPpICbPsA=="
     },
     "node_modules/@gjsify/readline": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.4.35.tgz",
-      "integrity": "sha512-tooWju5HXLmqtRburIGcQVNkvXNhltBFKX+8cQCIjlJvnQe1nEEanD3yox8EoUBhQh9gTtfXK4DbxTuUWH2uAA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/readline/-/readline-0.4.36.tgz",
+      "integrity": "sha512-b+szqy9ivHzjZmvk8SxQdmBNIUYE+yEj4U1p021vh8ZortbFVrWiZoSepUYw2ApghxNvUOw4OCEvyo2UYDPp/A==",
       "dependencies": {
-        "@gjsify/events": "^0.4.35"
+        "@gjsify/events": "^0.4.36"
       }
     },
     "node_modules/@gjsify/resolve-npm": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.4.35.tgz",
-      "integrity": "sha512-zHDZvxLvJQ6GHpeS7Qr+lm0vLn29aSSb1nMT37mDRCd9mFfNpkYJYYX1EzKp+7/kPD0UZ3lZwDp82UhHJU3TLA=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/resolve-npm/-/resolve-npm-0.4.36.tgz",
+      "integrity": "sha512-o8BS0UXKO3fZytb9knezN4Fl3ydlRWRZp4s22gsyEacAYCEe/UsKXQxQ7GLhVrHfBxU2jzOR32xftksLO35NaQ=="
     },
     "node_modules/@gjsify/rolldown-plugin-deepkit": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.4.35.tgz",
-      "integrity": "sha512-TwbwjGeUlw+eGHEfks8sNy6SBIEsebSaiBGb7LpFn+qvTWojIWl347EXHJeFI2VzLMRATKkuhSVrr4he55SAxw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-deepkit/-/rolldown-plugin-deepkit-0.4.36.tgz",
+      "integrity": "sha512-xdRAWzu9730PD8fS0OAZ5xHb/+zbh3i0lLkRAwaQVEQkCQpEcvKHS0zCzslx6FLoaM2pN9OI9v8G0hFFEnNl+w==",
       "dependencies": {
         "@deepkit/type-compiler": "^1.0.19",
-        "typescript": "^6.0.3"
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@gjsify/rolldown-plugin-deepkit/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       }
     },
     "node_modules/@gjsify/rolldown-plugin-gjsify": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.4.35.tgz",
-      "integrity": "sha512-6gsKLlaN8m2ATU/qaKTJid+nSgzv/SV7uvlLrRAx4Q2iF97rFSyWg/olf9kJ5XTosrHhmnfH84NId05x273V0A==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-gjsify/-/rolldown-plugin-gjsify-0.4.36.tgz",
+      "integrity": "sha512-6sNhKe1fpy1AUnvUWdzvS3yFGQVjwx84t049kRSxNhJvp0IiQ/vrKJdpZq1jEVa8HMwCq0eO+GH3UizoyLZ28w==",
       "dependencies": {
-        "@gjsify/console": "^0.4.35",
-        "@gjsify/resolve-npm": "^0.4.35",
-        "@gjsify/rolldown-plugin-deepkit": "^0.4.35",
-        "@gjsify/rolldown-plugin-pnp": "^0.4.35",
-        "@gjsify/vite-plugin-blueprint": "^0.4.35",
-        "@rollup/pluginutils": "^5.3.0",
+        "@gjsify/console": "^0.4.36",
+        "@gjsify/resolve-npm": "^0.4.36",
+        "@gjsify/rolldown-plugin-deepkit": "^0.4.36",
+        "@gjsify/rolldown-plugin-pnp": "^0.4.36",
+        "@gjsify/vite-plugin-blueprint": "^0.4.36",
+        "@rollup/pluginutils": "^5.4.0",
         "acorn": "^8.16.0",
         "acorn-walk": "^8.3.5",
         "fast-glob": "^3.3.3",
@@ -4111,816 +3193,400 @@
       }
     },
     "node_modules/@gjsify/rolldown-plugin-pnp": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.4.35.tgz",
-      "integrity": "sha512-bRf6BtKgcTFneW4nZJOEdxkZ5/7LjAlE7a15MOJ0BF6GczHBicFzFFctXyiHcKd15E4C5wxdNx0UbMrLoSmwqQ=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/rolldown-plugin-pnp/-/rolldown-plugin-pnp-0.4.36.tgz",
+      "integrity": "sha512-VO7HJUzfXK304Wwh5CoAQNOsM2H5aPtZL8rMSKOhFVVqJ38yxOXrylkU9nGOV4P//HWpGLrUw5SKPeYZCMt48Q=="
     },
     "node_modules/@gjsify/sab-native": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.4.35.tgz",
-      "integrity": "sha512-A1ExXUjHR6MZme+l27y4j+gJSFHIIVlts0c0Nk6Ze1alD0fs9Wiy5rOA42O8Em0tjjModdZgkCLjAihNm8eEEg==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/sab-native/-/sab-native-0.4.36.tgz",
+      "integrity": "sha512-tYobuxcTmP1odukbLQq8dmkSZgFofRXdvAQ+QfdtPbiPfiqiT7Fsk1PIoR7lJQvHnt2HplcMasQUdDguzNsewA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/sab-native/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/sab-native/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/sab-native/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/sab-native/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/sab-native/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/sab-native/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/semver": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.4.35.tgz",
-      "integrity": "sha512-gjKJH/5KjnmP3j16jz0SpUyL0ulxjrqt6I6QAqJzYKuPeLT1iiljaXO1kdWhBP1QK8O+Zx5s2GV5nrpMYC9jiQ=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/semver/-/semver-0.4.36.tgz",
+      "integrity": "sha512-JQ5TuaW++1PilSx8tFcENuA3/geSVSOFdqJQfx7mJ74MLxxTMeT3LucE0UKEp3ah8q/Yc/LM8Q+9GY+8BH8tZQ=="
     },
     "node_modules/@gjsify/sqlite": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.4.35.tgz",
-      "integrity": "sha512-T2KJWFszi1FcKq2YW6qUZamOLa/7AzbIFBNDXSLUNi1H4vWuxajCywA2dHCeE1Au6HlgbDE7wmY5eXMiL4q0ZQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/sqlite/-/sqlite-0.4.36.tgz",
+      "integrity": "sha512-2UOYHnNhp9IyTwkdF/wj/ej5AOJCkZHxhQqJxVolC+C89uWEgIIwbSH8zjdO+o14hwvNDgSO/bQohDzy1rIyhw==",
       "dependencies": {
-        "@girs/gda-6.0": "6.0.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gda-6.0": "6.0.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/sqlite/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/sqlite/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/sqlite/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/sqlite/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/sqlite/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/sqlite/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/sqlite/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/sqlite/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/sqlite/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/stream": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.4.35.tgz",
-      "integrity": "sha512-YnQNC17Cu7NYAj7WZl5M7T7qmpAUhdZue5DquUH7NcTniLnM1VjHuHsOTljqk81iuDiv2/NTgQGtol5yGy/Zvw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/stream/-/stream-0.4.36.tgz",
+      "integrity": "sha512-ztj2uuw0JrgCAjaZQXNkfLlb3VTEdcXoquuADjMP30KAyi7Ei+wy0kJZG9/EbA6Jyeuj1DM8FuixiRfhj0DnyQ==",
       "dependencies": {
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/utils": "^0.4.35",
-        "@gjsify/web-streams": "^0.4.35"
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/utils": "^0.4.36",
+        "@gjsify/web-streams": "^0.4.36"
       }
     },
     "node_modules/@gjsify/string_decoder": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.4.35.tgz",
-      "integrity": "sha512-UVVgWfRpbtJIXsjoC1w6pR8davrGaAhrcehVunWopToBRb1gHS/veNO36erY5+E+Q1egYtMJTVy4jpljlaDGjw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/string_decoder/-/string_decoder-0.4.36.tgz",
+      "integrity": "sha512-7337Vxp36JZL60/9usG8jbP54vSonFu+yuc8BIT4rf17Jvbuij6RximM8F/juUQjGNQa4oA86ZPGO1pGsyiQOg==",
       "dependencies": {
-        "@gjsify/buffer": "^0.4.35"
+        "@gjsify/buffer": "^0.4.36"
       }
     },
     "node_modules/@gjsify/sys": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.4.35.tgz",
-      "integrity": "sha512-6SwIiCNeF0odEGhHUAzhN7doaVVagod/Od81jDofsPIBycL3Q9NsBlDQJhq+zeZPXfUyI1fToIBANT7E8QPJIA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/sys/-/sys-0.4.36.tgz",
+      "integrity": "sha512-lRJq5zY4A9xbT9PW4o2Lif0qD5FHf06WsemjlZEfRyd8FffWHh3vt60k0QE/FAUDnIvoPoAr9ZWuX7XLiUcfvQ==",
       "dependencies": {
-        "@gjsify/util": "^0.4.35"
+        "@gjsify/util": "^0.4.36"
       }
     },
     "node_modules/@gjsify/tar": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.4.35.tgz",
-      "integrity": "sha512-fvMqfv3ghHpTixP+zaFNvzQakr81esI6I0RPeEaMN3l02Ta9cOoJA9y8n22ZFKYW3kqYcTSVui/vjxIW7bLIbQ=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/tar/-/tar-0.4.36.tgz",
+      "integrity": "sha512-6M58PiDg6reMtJIkabI7RpkuC8y4hJg+mxiV1XH7p3hXL2Ev75wTC0w8JXtT6kg4f/YDu0jWiJeRNdDgx2rhPA=="
     },
     "node_modules/@gjsify/terminal-native": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.4.35.tgz",
-      "integrity": "sha512-ZLj3qug43Tpl5f/mlFLEzsgWIscAmFBRG3o2vTXmhOCpZupmRdmzp5cuGPfnlWOQ4BS64npNUSJFay7FKe0+aA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/terminal-native/-/terminal-native-0.4.36.tgz",
+      "integrity": "sha512-kiTuDMfyCyCKlTKkmJjV7IXk3NeYOLONIRlq+veVKuvYlWu6aez/YIj0e0krux9Fc0k5Wt/IpBMQIdjEg+rnig==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/terminal-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/terminal-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/terminal-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/terminal-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/terminal-native/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/terminal-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/terminal-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/terminal-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/terminal-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/timers": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.4.35.tgz",
-      "integrity": "sha512-XJWQU5hKuqFvNHKXdXbQx9+mtSk57DicmWRzH87ERsyVpqlYhDI4K+WZe1FE8IuBz0TPzsdCZkVAagL3I+BHdQ=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/timers/-/timers-0.4.36.tgz",
+      "integrity": "sha512-ReIBq72fAVBR7/qqx965UOzOL9NXkIP5OHUwFL3b7GfDpN+q+tL33QU+HR+PHuvkI2jZWHXSg/fzRt+e0r+kTw=="
     },
     "node_modules/@gjsify/tls": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.4.35.tgz",
-      "integrity": "sha512-lbC+s2EphQYTbH2eKH7aItmwB/3Y7sYE6JG7l4meCLXSjFGF7NGH0ItlDfNqeeUf+YJoalYADjoH00qkTEw22Q==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls/-/tls-0.4.36.tgz",
+      "integrity": "sha512-c7LF8hdts996wi+CmMRIUWbLLN5ponzAsdn22l/i1zbrQwXvxlbEuwBZmF3BUE+DgNLSchcJydZS4cbXMHcPuA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/net": "^0.4.35",
-        "@gjsify/tls-native": "^0.4.35",
-        "@gjsify/utils": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/net": "^0.4.36",
+        "@gjsify/tls-native": "^0.4.36",
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/tls-native": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.4.35.tgz",
-      "integrity": "sha512-w2M6FBP7hh+EpsFU2X7s29dWS12SdbKk3HFWTv1nhPu2eLUdrNUAs5Ih4q6lO3BAYLxrFXPbTrB0TTg2BT5A9w==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/tls-native/-/tls-native-0.4.36.tgz",
+      "integrity": "sha512-LzVMTFqmZtpAzKFE5lNMG9/424W7jiJASKFYws3Qv9xcmCx6QHZ38353t2FB7rjaaGVEMEqGY83oVfze5NYxzA==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/tls-native/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls-native/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/tls-native/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls-native/node_modules/@girs/gobject-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tls/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/tls/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
+      }
+    },
+    "node_modules/@gjsify/tsc": {
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/tsc/-/tsc-0.4.36.tgz",
+      "integrity": "sha512-EGnnANDCICuYi1hvmVRFuC8Cs5yd60C3deVeTOQhuLBRUrwTfh9EgV2wPv1ueWqRyr4rDSg8wFuR/h0KIsc7AQ==",
+      "dependencies": {
+        "@gjsify/console": "^0.4.36",
+        "@gjsify/node-globals": "^0.4.36",
+        "@gjsify/web-globals": "^0.4.36"
+      },
+      "bin": {
+        "gjsify-tsc": "./dist/tsc.gjs.mjs"
       }
     },
     "node_modules/@gjsify/tty": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.4.35.tgz",
-      "integrity": "sha512-eg0ntJrAjQCjUtL1zB082TvBtqYMyFtVvodv1SRZlxvMos+Q8oz4JMe0pTK6vKL442gm1JNBufJn6cpsXxkIRQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/tty/-/tty-0.4.36.tgz",
+      "integrity": "sha512-yFKX0/oqDuHzHbssSWw1bJjYxFRKWA5jsLv7Uf10+pRlSwf80SGhupNHyVO2VzU5VSRjiah2UdwPISmBISfM/A==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/stream": "^0.4.35",
-        "@gjsify/terminal-native": "^0.4.35"
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/stream": "^0.4.36",
+        "@gjsify/terminal-native": "^0.4.36"
       }
     },
     "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/tty/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/unit": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/unit/-/unit-0.4.35.tgz",
-      "integrity": "sha512-IYjIvgu3zACQYmUxmRc940KJN8IhJZxf2Ebzq2M3TnSt9Zl10Kcf+m+O9aL5Jo93mVAVGcq0KWcIzDywwaYI0Q==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/unit/-/unit-0.4.36.tgz",
+      "integrity": "sha512-nGSclZTBuQeZ2RLjom8MJRQqaLjOdd9bnxVHzYkgZ1NEnLnNVSQVfkvqZKQLXX/czTBZC7rMJmPytSFbSOy1yQ==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.4.35",
-        "@gjsify/assert": "^0.4.35",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/dom-elements": "^0.4.35",
-        "@gjsify/dom-exception": "^0.4.35",
-        "@gjsify/node-globals": "^0.4.35",
-        "@gjsify/process": "^0.4.35",
-        "@gjsify/utils": "^0.4.35",
-        "@gjsify/web-globals": "^0.4.35",
-        "@gjsify/web-streams": "^0.4.35"
+        "@gjsify/abort-controller": "^0.4.36",
+        "@gjsify/assert": "^0.4.36",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/dom-elements": "^0.4.36",
+        "@gjsify/dom-exception": "^0.4.36",
+        "@gjsify/node-globals": "^0.4.36",
+        "@gjsify/process": "^0.4.36",
+        "@gjsify/utils": "^0.4.36",
+        "@gjsify/web-globals": "^0.4.36",
+        "@gjsify/web-streams": "^0.4.36"
       }
     },
     "node_modules/@gjsify/url": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.4.35.tgz",
-      "integrity": "sha512-sP5aY/W1xoeoI6ve9/VhnMiRFJrv11V51ajqtyryTWrzYcWMyrj7/FovijxepG9W8Ag2OKgU15EcJd/HrF7w9g==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/url/-/url-0.4.36.tgz",
+      "integrity": "sha512-AS4nXwITOkCsaFClkZnriMkzL8JxISGFwAI3Df+J5LzfrGvC3+PwK0qwj6nUUnPw7/5Al6tnIOq7/oOeYHW3XA==",
       "dependencies": {
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/url/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/url/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/url/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/url/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/url/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/url/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/util": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.4.35.tgz",
-      "integrity": "sha512-qycve3JSk2Ono0YgZtGslg0koeWJ+uU6fUqFa25udQ7aU2JtmNDfK5Eaqu4puRfQKzNYWa5ebHi2gwl5sBuorQ=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/util/-/util-0.4.36.tgz",
+      "integrity": "sha512-sRxavzICwJFVEygCAqDi2XIqcLIHt8nsgeVesGyX3cKE0kIhYt52QNoNCuRL4JfaJt38fKYdjhYuK1mGe4hvQA=="
     },
     "node_modules/@gjsify/utils": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.4.35.tgz",
-      "integrity": "sha512-m2WLdW610yXimABIdpdFpbDem7VuORavtDZcNm+UTw1UjBmqccHfr+wsYnuWyoHMqp0zYdn423RHdWtS9y2KmQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/utils/-/utils-0.4.36.tgz",
+      "integrity": "sha512-4oJ6Mtwyddekzv2Dyscrxo1VhBbv6RkiVmW9PjcA5hz3agnGyUXCeN4QPJnak4baoe/QKWYAt0h/WYbcBjwS2g==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/giounix-2.0": "2.0.0-4.0.1",
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/giounix-2.0": "2.0.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/utils/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/utils/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/utils/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/utils/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/v8": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.4.35.tgz",
-      "integrity": "sha512-xli0Neunu73KU0tiDeAvGYybmyEhR+e2Svr/4lvlNd8TZrZqvBJnb9w4nVrdeQW7850gJgGCjqEBdqqoDiCsHw=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/v8/-/v8-0.4.36.tgz",
+      "integrity": "sha512-b4m5KwRSq9V90wD/wGiSh98pFLmloobjY7u5/ov5BG19/l+O3Op3UV9lkL/HTcBGNwZtXoEw2txy+JUeydOB7g=="
     },
     "node_modules/@gjsify/vite-plugin-blueprint": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.4.35.tgz",
-      "integrity": "sha512-dWdG1JWrn5BmqYxwQvmC3r3AuOfZxyg5Ac2apzuDdXBmWma36M5pB/PRS6x5hOHtMdexvrB5aI0CGZzoRbtqhA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/vite-plugin-blueprint/-/vite-plugin-blueprint-0.4.36.tgz",
+      "integrity": "sha512-4U/8HbRBnlCgdsgSF/3E26daLqYh+EahcGEhR1IKzpl79ziZeLGT81S7TOxscBBQ99WwGLGi67hq5w91N1/ryA==",
       "dependencies": {
         "execa": "^9.6.1",
         "minify-xml": "^4.5.2"
@@ -4989,918 +3655,670 @@
       "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
     },
     "node_modules/@gjsify/vm": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.4.35.tgz",
-      "integrity": "sha512-/qWlPgdcCPz1Q7KOyKtBNn7eK9UpkJyWLeM3MDQ17lBjIwlC0nLOdkKOt07MzXYC+PemneRLUJHe7KeePMUvOw=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/vm/-/vm-0.4.36.tgz",
+      "integrity": "sha512-pQty0+Uj6fI7Gvw5Xhu7fGSKWiH670DCqApYbPEEAjyeKaaHh8IVM3BFVJlC1lXV7pA/I2Y36HAz0PLuvW5eKw=="
     },
     "node_modules/@gjsify/web-globals": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.4.35.tgz",
-      "integrity": "sha512-aHeNjxpSj8sO1W1IGRvVjOTthOAa3vH/iQUPK6Osc6MIrnLl81UmIYjToX0EJBu/h8SgjH5/V1SJ+D2vcUUMbA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-globals/-/web-globals-0.4.36.tgz",
+      "integrity": "sha512-GnYGcPNPsxIvqQv2cjAWkX+LbCBVspBRACN01Ui+tqmy74HemQpQt+Or0/uVMIjqYq3oOjsjU1DPWeA/IJ6mAA==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.4.35",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/compression-streams": "^0.4.35",
-        "@gjsify/dom-events": "^0.4.35",
-        "@gjsify/dom-exception": "^0.4.35",
-        "@gjsify/eventsource": "^0.4.35",
-        "@gjsify/formdata": "^0.4.35",
-        "@gjsify/gamepad": "^0.4.35",
-        "@gjsify/perf_hooks": "^0.4.35",
-        "@gjsify/url": "^0.4.35",
-        "@gjsify/web-streams": "^0.4.35",
-        "@gjsify/webaudio": "^0.4.35",
-        "@gjsify/webcrypto": "^0.4.35"
+        "@gjsify/abort-controller": "^0.4.36",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/compression-streams": "^0.4.36",
+        "@gjsify/dom-events": "^0.4.36",
+        "@gjsify/dom-exception": "^0.4.36",
+        "@gjsify/eventsource": "^0.4.36",
+        "@gjsify/formdata": "^0.4.36",
+        "@gjsify/gamepad": "^0.4.36",
+        "@gjsify/perf_hooks": "^0.4.36",
+        "@gjsify/url": "^0.4.36",
+        "@gjsify/web-streams": "^0.4.36",
+        "@gjsify/webaudio": "^0.4.36",
+        "@gjsify/webcrypto": "^0.4.36"
       }
     },
     "node_modules/@gjsify/web-polyfills": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.4.35.tgz",
-      "integrity": "sha512-KP5LfWhyQJi3+OCHFWpoBT5cbnum+U6ID7vnYWFEEyUHggqJn7xF4g3tchIsOeN6oPK43CL9pY2GkYNXnR1N6w==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-polyfills/-/web-polyfills-0.4.36.tgz",
+      "integrity": "sha512-YI5i0p3fHta1q9r0FXDezvJF9zM8yNEqxNXGhRksX8Pd0bVR8T1jp314FxtRvmQ80UhfdljEmNOkAEccGgi3gQ==",
       "dependencies": {
-        "@gjsify/abort-controller": "^0.4.35",
-        "@gjsify/compression-streams": "^0.4.35",
-        "@gjsify/dom-events": "^0.4.35",
-        "@gjsify/dom-exception": "^0.4.35",
-        "@gjsify/domparser": "^0.4.35",
-        "@gjsify/eventsource": "^0.4.35",
-        "@gjsify/fetch": "^0.4.35",
-        "@gjsify/formdata": "^0.4.35",
-        "@gjsify/gamepad": "^0.4.35",
-        "@gjsify/message-channel": "^0.4.35",
-        "@gjsify/web-globals": "^0.4.35",
-        "@gjsify/web-streams": "^0.4.35",
-        "@gjsify/webassembly": "^0.4.35",
-        "@gjsify/webaudio": "^0.4.35",
-        "@gjsify/webcrypto": "^0.4.35",
-        "@gjsify/websocket": "^0.4.35",
-        "@gjsify/webstorage": "^0.4.35",
-        "@gjsify/xmlhttprequest": "^0.4.35"
+        "@gjsify/abort-controller": "^0.4.36",
+        "@gjsify/compression-streams": "^0.4.36",
+        "@gjsify/dom-events": "^0.4.36",
+        "@gjsify/dom-exception": "^0.4.36",
+        "@gjsify/domparser": "^0.4.36",
+        "@gjsify/eventsource": "^0.4.36",
+        "@gjsify/fetch": "^0.4.36",
+        "@gjsify/formdata": "^0.4.36",
+        "@gjsify/gamepad": "^0.4.36",
+        "@gjsify/message-channel": "^0.4.36",
+        "@gjsify/web-globals": "^0.4.36",
+        "@gjsify/web-streams": "^0.4.36",
+        "@gjsify/webassembly": "^0.4.36",
+        "@gjsify/webaudio": "^0.4.36",
+        "@gjsify/webcrypto": "^0.4.36",
+        "@gjsify/websocket": "^0.4.36",
+        "@gjsify/webstorage": "^0.4.36",
+        "@gjsify/xmlhttprequest": "^0.4.36"
       }
     },
     "node_modules/@gjsify/web-streams": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.4.35.tgz",
-      "integrity": "sha512-cCCsBEJEcyRTmrEMOENCgW4O/SoV+88hlsbJiV5YVMEcd75HnoShALDCYWunzqQzpDCYC+WeY5MfUCCPEXm3IQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/web-streams/-/web-streams-0.4.36.tgz",
+      "integrity": "sha512-vHEZmLRwQVEe4+SQtXOtsasGHz5Cct16sy0j4q832KBU5hHLcLRu5kjzGrjh3UidukvMAZsOCnfZUmzQmZhPqQ==",
       "dependencies": {
-        "@gjsify/utils": "^0.4.35"
+        "@gjsify/utils": "^0.4.36"
       }
     },
     "node_modules/@gjsify/webassembly": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.4.35.tgz",
-      "integrity": "sha512-ELWvvNBh9yUShVhwJi0Z+8rtVj6BPPq3ZdKwofeOASd12FigFwJEpdyVQf/N1ppk80FNJYORbumu+hBwXtWt5Q=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/webassembly/-/webassembly-0.4.36.tgz",
+      "integrity": "sha512-hV4QzlrmUXm0MzpckJl4OL/PGP1q6s+kfb8Cb/PTwx4I0/8Su9OoDvz58DWFqqXthTSb9u1QZQ/HZV10xny/Cw=="
     },
     "node_modules/@gjsify/webaudio": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.4.35.tgz",
-      "integrity": "sha512-mA2EMzYSJjjXlmFrzDy4EZ4poG3R2ns3cMoHZcMNw1zdKwJ1AxUkLfZC1x8VUQeR7DVX79A9bQHvJKg8gFHzng==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/webaudio/-/webaudio-0.4.36.tgz",
+      "integrity": "sha512-utRtD5jHhpIkEl36F/aNgvqOf0HodrBOhs7X8NFUS0jspMCiKAM1Pv/7hiMt2BllD7SwLHT0JWqIgqS1aYIYBg==",
       "dependencies": {
-        "@gjsify/dom-events": "^0.4.35"
+        "@gjsify/dom-events": "^0.4.36"
       }
     },
     "node_modules/@gjsify/webcrypto": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.4.35.tgz",
-      "integrity": "sha512-j2w+nx+zbETvIt/Clj5GYvTh51jXFSdXCHfTrcDbsi+CwLsRD4s2IPVTs/mvDatJhPxzm0XUX4i24auDdnVnIw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/webcrypto/-/webcrypto-0.4.36.tgz",
+      "integrity": "sha512-flucKtBF2O/OyojjG8Fbtr55clMIj6k0TDyWODMcy3ieYcP4HwkqjnhFNHkGXoUKHUapKGA3uvfPhjGCWFl9wA==",
       "dependencies": {
-        "@gjsify/dom-exception": "^0.4.35"
+        "@gjsify/dom-exception": "^0.4.36"
       }
     },
     "node_modules/@gjsify/webgl": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/webgl/-/webgl-0.4.35.tgz",
-      "integrity": "sha512-ajYs9JAKsEBBvysviThcsC3wjtHQka56JULilT3yH3AFsEqUwQYlRvjLP55fu4qmZEPPSduwU6iO2WexgojXyQ==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/webgl/-/webgl-0.4.36.tgz",
+      "integrity": "sha512-6r8A55NeQQsugHTAkGt/DrXIwCAFkM8KXKBkY2SDirK8Bj1vjzvXO5oP2ADcnSQQf2hB78mf6BHI1NOFoJnbqg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gtk-4.0": "4.23.0-4.0.1",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/gtk-4.0": "4.23.0-4.0.4",
         "@girs/gwebgl-0.1": "0.1.0-4.0.0-rc.5",
-        "@gjsify/dom-elements": "^0.4.35",
-        "@gjsify/dom-events": "^0.4.35",
-        "@gjsify/event-bridge": "^0.4.35",
-        "@gjsify/utils": "^0.4.35",
+        "@gjsify/dom-elements": "^0.4.36",
+        "@gjsify/dom-events": "^0.4.36",
+        "@gjsify/event-bridge": "^0.4.36",
+        "@gjsify/utils": "^0.4.36",
         "bit-twiddle": "^1.0.2",
         "glsl-tokenizer": "^2.1.5"
       }
     },
-    "node_modules/@gjsify/webgl/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
+    "node_modules/@gjsify/webgl/node_modules/@girs/gdkpixbuf-2.0": {
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-EaACHntZ7Wei0jfT/vBfKvuXZ5c6zr6UlqghH/tofDu2XjIyBCAuIIWAwv0lI7xj44oGSMTzzCNkswVaNNUpDA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
-    "node_modules/@gjsify/webgl/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+    "node_modules/@gjsify/webgl/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gio-2.0": {
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
-    "node_modules/@gjsify/webgl/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+    "node_modules/@gjsify/webgl/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/glib-2.0": {
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
-    "node_modules/@gjsify/webgl/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+    "node_modules/@gjsify/webgl/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gmodule-2.0": {
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
-    "node_modules/@gjsify/webgl/node_modules/@girs/gjs/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+    "node_modules/@gjsify/webgl/node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gobject-2.0": {
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/webgl/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0": {
-      "version": "4.23.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.1.tgz",
-      "integrity": "sha512-a5wAjHPHI//ZiMODFM2EEV0R/+5wcoM5BkDBjlaX3eRbapq3+DWxhevsgmZRlwz4SOqLqgvusJRsjnX3nrf+tg==",
+      "version": "4.23.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.23.0-4.0.4.tgz",
+      "integrity": "sha512-voE7gQtNSOci4yc+r5Fon9kBLFfDY7E4+Ft9d8cEUz///9p64DwvVaUp9w/1hTfEqKQcA9ORcIgXCteQ6PSQuQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gdk-4.0": "4.0.0-4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gsk-4.0": "4.0.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/graphene-1.0": "1.0.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gsk-4.0": "4.0.0-4.0.4",
+        "@girs/graphene-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gdk-4.0": "4.0.0-4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-aGZmZyZgTxcOzb+v9LQhV8XuxQFjv8NGXl36xO62qb74pxBJy2IEpYf8U7HpGeiynI9sInbompE5r0gGzG3xOQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-9psgcmYfWpiAJ1F9dn93FltL0jwsETBp53niIZpudv2p0W6wwh47LFCZ0xnHl0C4CW/0jK70KDiZXjDHMGy8tQ==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-FKOxBYsfMW2KPTG2zML8No6Me5yM3cNatAt/Hr7Kjw8iPTZgGCV8TqtOHPTz9jvMajMDa/ETC+Y49GustIHi6g==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.1.tgz",
-      "integrity": "sha512-zrzRqPBD2PFh0/lqav7TYnL4qVHHIgH7SM6oEj/I7kQZWjk06GyfSj60cyhYOXUlX5O67tViZ0KPPnXO0O6eqA==",
+      "version": "4.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.4.tgz",
+      "integrity": "sha512-HehASXR1K7WRPC9rZDUtM1ty0mNItRjQ95tkGOMJ6UBK+XZLDfcVL/q72StL2tLDC20BnzoXLpw8Y5PP/uGljw==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-ZI5JfZDJnoohvC+qyXfsZRF2OXEN0C0/qPam/S4wsYcfLn1wzsskZhZ5LRUGLTBet/qk30EvTgYwRGSNI6F6lQ==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-fXHpp8NJUaUTA2/HU7KbGPUOVWE3N2HLrP7x4HQvxtvlUjo6BbyvQXTgyrnMED2ZlsvEy5RPVSAsk0RJiS81gg==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-CeM4su4CzuYvPXXBa0pg3CIihiC5Vw7At3Xe+4G5/GCzssl4xtoJmdQLHCRWVJInXelcfyENSK+XN2LOttvY/Q==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/gsk-4.0": {
-      "version": "4.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.1.tgz",
-      "integrity": "sha512-rayS9BQzgCF9ruVXZQ9pOvwoEHxVFaNoRGH9NU2N6XiTG6T3dk6QGSzSBuvnNtmN1af5/vldBPvkJRSvWzhQ6g==",
+      "version": "4.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.4.tgz",
+      "integrity": "sha512-Yq/x1OqN7BXww7rDxnUPT/K71Xq3QuYRI2ySpfDlhcQHldkxlRj3zgKIIXCIwHfXVyVmBEFKXlI2Wlrczn6tbw==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gdk-4.0": "4.0.0-4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/graphene-1.0": "1.0.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.1",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/graphene-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gdk-4.0": "4.0.0-4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "13.2.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.1.tgz",
-      "integrity": "sha512-AeL6J6NNIm60fjYR55Ru9duSwcwXJpKZJlTaw1LTQBxRPX45iDDrkwxzeu/PSsrNs3zRXe0sd9YEdfl2/xDqDw==",
+      "version": "13.2.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-13.2.1-4.0.4.tgz",
+      "integrity": "sha512-gj7dqsJ8vRYowHI5jd8/0Otb1HfIRVwVNH/F63TnqFCLbAFiuCavjNRBfTFZ1d9eIvmuGK34IsYm0hI802Uogg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/pango-1.0": {
-      "version": "1.57.1-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.1.tgz",
-      "integrity": "sha512-1GrH9fqEsB/feXy/02pYujF42/taO8IL/fzTwx9syisiRHEEXNQwSV6N3EbCDOKHeUbDzv2KyNJm5b3pVLszRw==",
+      "version": "1.57.1-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.1-4.0.4.tgz",
+      "integrity": "sha512-mN2MinF+2dkqHLquOIgQW7Q3GbW7wz/spQMOMtAwXuXMcfk8ZAtJl1ZQOEDh1NBZeSAM4Th46tH76+5OO9aJoA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webgl/node_modules/@girs/gtk-4.0/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-GRJbgTQap2LGPukqqL0WnrFpCZhR2i0DlLwD9QkSP1dFRCe4owaNizC6kQdbkvojqR+b3GfFbzqyVGlZKzD0Vg==",
+      "version": "1.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.4.tgz",
+      "integrity": "sha512-baIguxy7m7G5TcAKF6ZWU6cow+3Gr/AZJBEZFmTYWmxEc3AE8s+ik9+ujEcHZP1DuGS9fVQskjJWFhd+LYNF8A==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/pango-1.0": "1.57.1-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/harfbuzz-0.0": "13.2.1-4.0.1",
-        "@girs/freetype2-2.0": "2.0.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/cairo-1.0": "1.0.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/pango-1.0": "1.57.1-4.0.4",
+        "@girs/harfbuzz-0.0": "13.2.1-4.0.4",
+        "@girs/freetype2-2.0": "2.0.0-4.0.4",
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webrtc": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/webrtc/-/webrtc-0.4.35.tgz",
-      "integrity": "sha512-w+qIAA1ivWIA3NBTYJicswtreFhU6tEmA/JD/nUPabrEXBrbUSC3++F/qfkl/pMVcSC/W0jMcblYptsefVFgpA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/webrtc/-/webrtc-0.4.36.tgz",
+      "integrity": "sha512-PmADRqmG0rym1NNnhbnQcBipDLyUfAxwsquGq76Xol+816GywokzoPQflNQEwQ2x2IAAK6BfDY+trtruA3aVOw==",
       "dependencies": {
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/dom-events": "^0.4.35",
-        "@gjsify/dom-exception": "^0.4.35",
-        "@gjsify/webrtc-native": "^0.4.35"
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/dom-events": "^0.4.36",
+        "@gjsify/dom-exception": "^0.4.36",
+        "@gjsify/webrtc-native": "^0.4.36"
       }
     },
     "node_modules/@gjsify/webrtc-native": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/webrtc-native/-/webrtc-native-0.4.35.tgz",
-      "integrity": "sha512-ev6PvvdDE0w0ze4LRZK8RNhwxyYMsjItXR+hZrewajdkjkSII7Bh3gyvnyPmKvDjenfl+zFbXkBadYgK8gy6xw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/webrtc-native/-/webrtc-native-0.4.36.tgz",
+      "integrity": "sha512-VVyriJzpZKlFv3n01viAfV45JK2REHT8NFYxLZVyhYTYOxmKK+Ix6d4x65Qr6kBBlNNRGZX615UgQ+WpViZFMg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
+        "@girs/gjs": "4.0.4",
         "@girs/gjsifywebrtc-0.1": "0.1.0-4.0.0-rc.5",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1",
-        "@girs/gst-1.0": "1.28.1-4.0.1",
-        "@girs/gstwebrtc-1.0": "1.0.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/webrtc-native/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/webrtc-native/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/webrtc-native/node_modules/@girs/gjs/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/webrtc-native/node_modules/@girs/gjs/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/gst-1.0": "1.28.1-4.0.4",
+        "@girs/gstwebrtc-1.0": "1.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webrtc-native/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webrtc-native/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/websocket": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.4.35.tgz",
-      "integrity": "sha512-w4nD+S533ioPaJPSKVEFCz456WdWdiOZ9gdbJ9Q+Fu0VKknQLYzKuM5XbBNQskRbLkYQwHIfoJQnUfRQ9XvSmg==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/websocket/-/websocket-0.4.36.tgz",
+      "integrity": "sha512-/2KOROsJF2FVIfEirBiJbbMZo01Gwg2SzBOj18dSytnntmRrv6nfX0go2D0ioU48QhA0XmqUGC2UJo86BIwL/Q==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/dom-events": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/soup-3.0": "3.6.6-4.0.4",
+        "@gjsify/dom-events": "^0.4.36"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/websocket/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/websocket/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/websocket/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/websocket/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/webstorage": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.4.35.tgz",
-      "integrity": "sha512-PVHoQR2E2Yn5hByQjUEx6QwUwQhPcxBV7GoFJj6gAz9sdBx2EWEc5CCa3VWSbRCibw1xpZDYWRZ6ssO5kBHmlQ=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/webstorage/-/webstorage-0.4.36.tgz",
+      "integrity": "sha512-uFiIt/X2ewttUYw7+MfSv7rPNsGgmFAWMvh9tLgvLdD3YEFz6OfHRg2i4kUK9MATe0Qsj+cXOQlygNb9vFMtoA=="
     },
     "node_modules/@gjsify/worker_threads": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.4.35.tgz",
-      "integrity": "sha512-4I2sVvblJOTVSbiEHxc8Y+dRLTMNwwyz5W8oqFBQ5+NqOPXhpn83eo3xbd1d9drHJpd0XCNBnfosmAGHeGbKDA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/worker_threads/-/worker_threads-0.4.36.tgz",
+      "integrity": "sha512-dV1UHeIS+wr075t2qzRH/H61EJNJOxw4GyfGa793iwvQrLZquWV7LXLP3CrfJ/6iRxhQGCGahN0vKhXpV83UsQ==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/message-channel": "^0.4.35",
-        "@gjsify/sab-native": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/message-channel": "^0.4.36",
+        "@gjsify/sab-native": "^0.4.36"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/worker_threads/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/worker_threads/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/worker_threads/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/workspace": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.4.35.tgz",
-      "integrity": "sha512-PKi5vNh3ZpqlXAusISCsVFsVeNh3tGI7lu+CumLJ2LbBUeysoTCi1W+jzKw5Zbk9CYSXf0/lV3VMjn1ol4qx1A=="
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/workspace/-/workspace-0.4.36.tgz",
+      "integrity": "sha512-XFaZDXBEWBSBfEhKIKukxPH1eDdtpZYHXEr0NX/QPTbxSiYy7MyRFuzu47RP7Q84mOkSncFCJ80x+KeF3AEKog=="
     },
     "node_modules/@gjsify/ws": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/ws/-/ws-0.4.35.tgz",
-      "integrity": "sha512-61egGarg8JrbHh3YaXyUJO3TgQo77YivyY7CrBpTMM/zPFbdepOSCoxrgPKf9APhI96Nc+IJPAF6QSKYqU4n2A==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/ws/-/ws-0.4.36.tgz",
+      "integrity": "sha512-9OoqN5cEvZt4UjCtypm2KH8INxZo9pJw2JOOa76f7yXtjcWuwKYBcK+p/jNi6BBRAWi9ql84PiKYvZxRTUN8Fg==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/soup-3.0": "3.6.6-4.0.1",
-        "@gjsify/buffer": "^0.4.35",
-        "@gjsify/crypto": "^0.4.35",
-        "@gjsify/events": "^0.4.35",
-        "@gjsify/utils": "^0.4.35",
-        "@gjsify/websocket": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/soup-3.0": "3.6.6-4.0.4",
+        "@gjsify/buffer": "^0.4.36",
+        "@gjsify/crypto": "^0.4.36",
+        "@gjsify/events": "^0.4.36",
+        "@gjsify/utils": "^0.4.36",
+        "@gjsify/websocket": "^0.4.36"
       }
     },
     "node_modules/@gjsify/ws/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/ws/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/ws/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/ws/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/ws/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/ws/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/ws/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/ws/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/ws/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/xmlhttprequest": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.4.35.tgz",
-      "integrity": "sha512-Gys34OQrOCxyvj2uNcMf2DjP9Zu71SV9pzOVbRj0FBbG3SlvF8oRwo2soNfvQCHUOBi9PjC4gujS8fC1oyhMHA==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/xmlhttprequest/-/xmlhttprequest-0.4.36.tgz",
+      "integrity": "sha512-+HXccI/fq3VcCcJ/zk3MoY9e9zQ281ZJK48YAsEjXo5DQ1wCKRk5YcoiLqTzNXjFO0x6o8ZhUgysDuzfH89kzA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@gjsify/fetch": "^0.4.35"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@gjsify/fetch": "^0.4.36"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/gjs/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/xmlhttprequest/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/zlib": {
-      "version": "0.4.35",
-      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.4.35.tgz",
-      "integrity": "sha512-f5cx2WYJadiLl2IQIxUPqBYyhu3wbd19xSL9oz9CaxT8EY9pULIzePKm+rRQnRML6P86GWVysN9IZrOw0C0vMw==",
+      "version": "0.4.36",
+      "resolved": "https://registry.npmjs.org/@gjsify/zlib/-/zlib-0.4.36.tgz",
+      "integrity": "sha512-1Jw0dk0lR5E5zrE6K2peFd8czeJvJhazF9Xw05UwWiXYcqPIQz7+SAnAGH7IgAnhwqMXyVSa/X4GKcwpFyQWcA==",
       "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gio-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-Cy8xQM0UTQr5BN6+Zi8arEBDtVy1sXjPqUZvsJ3BFukcjmaa8XzOOCrNEfnWWZ8XZWRtpHgmwP8EgNWM5MeCrA==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-RcEUDQm45rYqbcQzbGgBkKlU5+W5UJX2JKdCPGVF66rZXwNkG1bHiTVR14oYg6GB4jwmGue15ZSwX2u0n/X/FA==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gmodule-2.0": "2.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gmodule-2.0": "2.0.0-4.0.4"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.1.tgz",
-      "integrity": "sha512-EQXZpmYt+00u/LrjOqFRYnb+BoIWCw+aHQzcYqdvbAbt+hR3euiNVc5PG/4WVV5IeZiawb5gdRP9DwOJJaixGw==",
+      "version": "2.0.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.4.tgz",
+      "integrity": "sha512-teRoTE8RlYk1aSpaYzxyV2Xgz4hn+qcU1UX+GmF+LK/F2sT1tKbYk6L7O7peWh1EK6+bCqx97ciIiylT7j97gQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/gio-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/glib-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-a3qQev6wxfULr1gAIJHWcvoHIVc7maD+s93tYBV+7cpfC0w8eHvtkdJ9Vod6uZW++eetF2xo3FA3AxdwzRmeqw==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-xJL43uQFKnULX6R+Jc/2IR2GjPHQL/jhj0KJvpPsX1zNzOFrudqYvrjeM/Yg8ByPxzZoW2R25ELmRzNXxeNjWQ==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/zlib/node_modules/@girs/glib-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.1.tgz",
-      "integrity": "sha512-mWm7zJjsfuQdbDViwUdy3844M/F6w+s6BVojao4CoZPy+Me43zo2tnnM28qJgSKSEYmvHvmi6ThALUgFvesFnw==",
-      "dependencies": {
-        "@girs/gio-2.0": "2.88.0-4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/cairo-1.0": "1.0.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
-      }
-    },
-    "node_modules/@gjsify/zlib/node_modules/@girs/glib-2.0/node_modules/@girs/gjs/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.1.tgz",
-      "integrity": "sha512-mq/YmZksudGKGYT5HiKs5+V7CqNkoSFrODhWf2lC90isfrZ6Hpy0VUFQgbWhoJpIICk6vPDAozSY3WTyETodUA==",
-      "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1",
-        "@girs/gobject-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/gobject-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@gjsify/zlib/node_modules/@girs/glib-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.88.0-4.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.1.tgz",
-      "integrity": "sha512-TF0YSAbG/f/WCp9oAkUcpnNL8fjs5fbURlq3kqHjp8kQmz4bFZ4XUvFLAL9lsdivU4AGEfQmc6+wokBDii62pg==",
+      "version": "2.88.0-4.0.4",
+      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.88.0-4.0.4.tgz",
+      "integrity": "sha512-Cp6+TTANdOlUv0oy/WaLtoUWW0hu9vXgxDu0MDQczzg0GFV7HlVMVyjBp1L9Faz7WWYXjDB6LqPwNGnOxoXkQg==",
       "dependencies": {
-        "@girs/gjs": "4.0.1",
-        "@girs/glib-2.0": "2.88.0-4.0.1"
+        "@girs/gjs": "4.0.4",
+        "@girs/glib-2.0": "2.88.0-4.0.4"
       }
     },
     "node_modules/@marcj/ts-clone-node": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -20,7 +20,7 @@
   "author": "Pascal Garber <pascal@artandcode.studio>",
   "license": "MIT",
   "devDependencies": {
-    "@gjsify/unit": "^0.4.35",
+    "@gjsify/unit": "^0.4.36",
     "typescript": "^6.0.3"
   },
   "dependencies": {

--- a/packages/gjs/package.json
+++ b/packages/gjs/package.json
@@ -16,10 +16,10 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@gjsify/canvas2d": "^0.4.35",
-    "@gjsify/dom-elements": "^0.4.35",
-    "@gjsify/event-bridge": "^0.4.35",
-    "@gjsify/webgl": "^0.4.35",
+    "@gjsify/canvas2d": "^0.4.36",
+    "@gjsify/dom-elements": "^0.4.36",
+    "@gjsify/event-bridge": "^0.4.36",
+    "@gjsify/webgl": "^0.4.36",
     "@pixelrpg/engine": "workspace:*",
     "@pixelrpg/story-gjs": "workspace:^",
     "excalibur": "^0.32.0"


### PR DESCRIPTION
## What this PR does

[gjsify v0.4.36](https://github.com/gjsify/gjsify/releases/tag/v0.4.36) just published with the two upstream fixes that close the Pair-Editing diagnostic-disaster bug chains we hit on 2026-05-30 / 2026-05-31:

- **[gjsify#426](https://github.com/gjsify/gjsify/pull/426)** — \`@gjsify/dom-events\`: \`EventTarget.dispatchEvent\` listener-exception catch now delegates to \`globalThis.reportError\` (W3C standard since 2022) when wired, otherwise falls back to safely-formatted \`\${name}: \${message}\\n\${stack}\`. The bare \`{}\` line that obscured every WS-event-listener exception in the joiner terminal is gone.
- **[gjsify#427](https://github.com/gjsify/gjsify/pull/427)** — \`@gjsify/ws\`: \`WebSocketServer\` calls \`remove_websocket_extension(WebsocketExtensionDeflate)\` so the handshake refuses permessage-deflate, side-stepping Soup's buggy loopback encode/decode path. Server-to-client frames flow on every same-machine code path; the host's 13-frame ICE-plus-SDP burst gets through to the joiner instead of dropping silently.

## Changes

- **Bumps** (workspace-wide): \`apps/{maker-gjs,game-browser,signalling-server,storybook-gjs}/package.json\` + \`packages/{engine,gjs}/package.json\` — every \`@gjsify/*\` dep \`^0.4.35\` → \`^0.4.36\`
- **\`gjsify-lock.json\`** regenerated by \`gjsify install\`
- **\`apps/maker-gjs/src/main.ts\`** — interim \`globalThis.reportError\` shim (landed in PR #114) DROPPED. Now redundant: \`@gjsify/dom-events\` 0.4.36 wires it natively, and falls back to a safe formatted console.error when it isn't. The \`__PIXELRPG_PEER_DEBUG\` flag stays.

## Tests

- maker-gjs **188/188** green on both GJS + Node (~5 s)
- \`gjsify foreach check -v -t\` workspace-wide clean

## Hand-test acceptance (post-merge)

You should finally see Pair-Editing work end-to-end:

\`\`\`
[lan-signalling/#1] send #1 (type=ice-candidate, len=...)
[lan-signalling/#1] send #2 (type=ice-candidate, len=...)
...
[lan-signalling/#1] send #13 (type=sdp, len=...)
\`\`\`

…and on the joiner:

\`\`\`
[lan-signalling/#1] raw frame #1 (binary=false, len=...): {"type":"ice-candidate",...}
[lan-signalling/#1] → deliver to handler (type=ice-candidate)
[peer-session/joiner] ICE remote #1: candidate:1 1 UDP ...
...
[lan-signalling/#1] raw frame #13 (binary=false, len=...): {"type":"sdp",...}
[peer-session/joiner] received SDP offer (sdp.length=...)
[peer-session/joiner] createAnswer OK
[peer-session/joiner] sending SDP answer
[peer-session/host] received SDP answer
[peer-session/host] channel "op" → open
[peer-session/host] channel "awareness" → open
[peer-session/host] state negotiating → connected
[peer-session/host] pc.connectionState → connected
\`\`\`

No bare \`{}\` lines. Both peers reach \`connected\`. Joiner gets the snapshot and the sandbox project loads.

## Test plan

- [x] \`gjsify foreach check -v -t\` clean
- [x] \`gjsify workspace @pixelrpg/maker-gjs test\` — 188/188 green on both runtimes
- [ ] CI passes
- [ ] Hand-test: two-instance Pair-Editing finally works end-to-end