### PR TITLE
fix(engine): chunk snapshot responses to bypass WebRTC SCTP max-message-size

### DIFF
--- a/packages/engine/src/sync/session-protocol.ts
+++ b/packages/engine/src/sync/session-protocol.ts
@@ -28,6 +28,21 @@ import type { ProjectSnapshot } from './project-snapshot.ts'
 export const SESSION_PROTOCOL_PREFIX = '__session/'
 export const SNAPSHOT_REQUEST_KIND = '__session/snapshot-request'
 export const SNAPSHOT_RESPONSE_KIND = '__session/snapshot-response'
+/**
+ * Snapshot-payload chunking kind — see {@link SnapshotChunkOp}.
+ * Hosts MAY split the JSON-serialised snapshot into a sequence of
+ * these chunks instead of a single `SNAPSHOT_RESPONSE_KIND` op.
+ * Joiners that received a `__session/snapshot-request` op MUST
+ * accumulate every `SNAPSHOT_CHUNK_KIND` op until `totalChunks`
+ * have arrived, then parse the concatenated JSON. Required when
+ * the serialised snapshot exceeds the WebRTC SCTP `max-message-
+ * size` (RFC 8841 default: 64 KiB) — single `send_message` calls
+ * above that limit are silently dropped by GStreamer webrtcbin
+ * (the underlying SCTP impl), as discovered in the 2026-06-01
+ * pixel-rpg/map-editor hand-test (a 1.27 MB snapshot response
+ * never reached the joiner).
+ */
+export const SNAPSHOT_CHUNK_KIND = '__session/snapshot-chunk'
 
 /** Joiner → host: "send me your current project state". */
 export interface SnapshotRequestOp {
@@ -46,7 +61,41 @@ export interface SnapshotResponseOp {
   seq: number
 }
 
-export type SessionProtocolOp = SnapshotRequestOp | SnapshotResponseOp
+/**
+ * Host → joiner: one chunk of a JSON-serialised snapshot payload.
+ *
+ * The host sends `totalChunks` of these in order (chunk indices
+ * 0..totalChunks-1). The receiver accumulates `data` substrings
+ * indexed by `chunkIndex` and parses the concatenated string as a
+ * {@link ProjectSnapshot} once all chunks have arrived.
+ *
+ * Why JSON-string chunking rather than base64 / binary fragments:
+ * the op channel is text-only (we already `JSON.stringify` the
+ * envelope), so substring-of-JSON keeps the wire shape uniform
+ * with the rest of the op protocol. Reassembly is a plain
+ * `chunks.join('')` followed by `JSON.parse`. The chunk size
+ * upstream is conservative (16 KiB per chunk) so the envelope
+ * stays well under the SCTP `max-message-size` ceiling for
+ * default WebRTC peers.
+ *
+ * Order: the reliable+ordered data channel guarantees in-order
+ * delivery, so the receiver can append chunks as they arrive
+ * without an explicit reorder pass — though we still index by
+ * `chunkIndex` defensively so a future migration to unordered
+ * delivery (or a re-sent chunk after a retransmit) is safe.
+ */
+export interface SnapshotChunkOp {
+  kind: typeof SNAPSHOT_CHUNK_KIND
+  payload: {
+    chunkIndex: number
+    totalChunks: number
+    data: string
+  }
+  peerId: string
+  seq: number
+}
+
+export type SessionProtocolOp = SnapshotRequestOp | SnapshotResponseOp | SnapshotChunkOp
 
 /**
  * Discriminator: is this raw op a session-protocol message that
@@ -87,6 +136,26 @@ export function createSnapshotResponseOp(args: {
   return {
     kind: SNAPSHOT_RESPONSE_KIND,
     payload: { snapshot: args.snapshot },
+    peerId: args.peerId,
+    seq: args.seq,
+  }
+}
+
+/** Build one chunk op carrying a slice of the JSON-serialised snapshot. */
+export function createSnapshotChunkOp(args: {
+  peerId: string
+  seq: number
+  chunkIndex: number
+  totalChunks: number
+  data: string
+}): SnapshotChunkOp {
+  return {
+    kind: SNAPSHOT_CHUNK_KIND,
+    payload: {
+      chunkIndex: args.chunkIndex,
+      totalChunks: args.totalChunks,
+      data: args.data,
+    },
     peerId: args.peerId,
     seq: args.seq,
   }

--- a/packages/engine/src/sync/snapshot-exchange.spec.ts
+++ b/packages/engine/src/sync/snapshot-exchange.spec.ts
@@ -22,7 +22,11 @@ import { describe, expect, it } from '@gjsify/unit'
 import { createConnectedSessionPair, flushMicrotasks } from './in-memory-transport.ts'
 import type { ProjectSnapshot } from './project-snapshot.ts'
 import { PROJECT_SNAPSHOT_VERSION } from './project-snapshot.ts'
-import { isSessionProtocolOp } from './session-protocol.ts'
+import {
+  type SessionProtocolOp,
+  SNAPSHOT_CHUNK_KIND,
+  isSessionProtocolOp,
+} from './session-protocol.ts'
 import { SnapshotExchange } from './snapshot-exchange.ts'
 
 const FAKE_SNAPSHOT: ProjectSnapshot = {
@@ -207,6 +211,220 @@ export default async () => {
         // Host's first response is the snapshot reply.
         expect(hostSent[0].peerId).toBe('host-5')
         expect(hostSent[0].seq).toBe(0)
+
+        hostExchange.dispose()
+        joinerExchange.dispose()
+      } finally {
+        sessions.close()
+      }
+    })
+  })
+
+  await describe('SnapshotExchange — chunked transfer (2026-06-01 regression)', async () => {
+    // Pre-fix: the host called `peer.sendOp(SnapshotResponseOp)` with
+    // the entire serialised snapshot in one frame. Real-project
+    // snapshots routinely run 1.2+ MiB; GStreamer webrtcbin silently
+    // dropped sends over its SCTP max-message-size ceiling (RFC 8841
+    // default 64 KiB), and the joiner's 10 s SnapshotExchange timeout
+    // fired without any wire diagnostic. Post-fix: the host splits
+    // into `SNAPSHOT_CHUNK_KIND` ops and the joiner reassembles —
+    // every wire frame stays ~16 KiB.
+
+    await it('host always sends chunk ops (1+ chunks); joiner reassembles', async () => {
+      const sessions = await createConnectedSessionPair()
+      try {
+        const hostExchange = exchangeFor(sessions.host, 'host-c1', () => FAKE_SNAPSHOT)
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-c1', () => null)
+
+        const received = await joinerExchange.request('room-chunk-default', 2_000)
+        expect(received.project.id).toBe('shared')
+
+        // Inspect what the host actually sent on the wire — at least
+        // ONE frame should be a SNAPSHOT_CHUNK_KIND (never the legacy
+        // single-message SNAPSHOT_RESPONSE_KIND).
+        const hostSent = sessions.hostOpChannel.sentFrames.map(
+          (f) => JSON.parse(f) as SessionProtocolOp,
+        )
+        const chunks = hostSent.filter((op) => op.kind === SNAPSHOT_CHUNK_KIND)
+        expect(chunks.length).toBeGreaterThanOrEqual(1)
+        // Sanity: chunk envelopes carry coherent `totalChunks` and
+        // monotonic 0..N-1 indices.
+        const totalChunks = (chunks[0] as { payload: { totalChunks: number } }).payload.totalChunks
+        expect(chunks.length).toBe(totalChunks)
+        for (let i = 0; i < chunks.length; i++) {
+          const payload = (chunks[i] as { payload: { chunkIndex: number; totalChunks: number; data: string } }).payload
+          expect(payload.chunkIndex).toBe(i)
+          expect(payload.totalChunks).toBe(totalChunks)
+          expect(typeof payload.data).toBe('string')
+        }
+
+        hostExchange.dispose()
+        joinerExchange.dispose()
+      } finally {
+        sessions.close()
+      }
+    })
+
+    await it('REGRESSION (2026-06-01): large snapshot is split into multiple chunks under the configured byte budget', async () => {
+      // Force chunking by setting an absurdly small per-chunk budget
+      // — the FAKE_SNAPSHOT serialises to several hundred bytes, so
+      // 64-byte chunks produces ~10 chunks. This pins the chunking
+      // path without needing a megabyte of fixture data.
+      const sessions = await createConnectedSessionPair()
+      try {
+        const hostExchange = new SnapshotExchange({
+          peerId: 'host-c2',
+          send: (op) => sessions.host.sendOp(op),
+          captureSnapshot: () => FAKE_SNAPSHOT,
+          chunkSizeBytes: 64,
+        })
+        sessions.host.events.on('op-received', ({ op }) => {
+          if (isSessionProtocolOp(op)) hostExchange.handle(op)
+        })
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-c2', () => null)
+
+        const received = await joinerExchange.request('room-large', 2_000)
+        expect(received.project.name).toBe('Shared Project')
+        expect(received.maps.length).toBe(1)
+
+        const hostSent = sessions.hostOpChannel.sentFrames.map(
+          (f) => JSON.parse(f) as SessionProtocolOp,
+        )
+        const chunks = hostSent.filter((op) => op.kind === SNAPSHOT_CHUNK_KIND)
+        // FAKE_SNAPSHOT JSON is ~430 bytes — 64-byte chunks → 7 chunks
+        expect(chunks.length).toBeGreaterThan(3)
+        // Each chunk's data slice must be ≤ chunkSizeBytes
+        for (const op of chunks) {
+          const payload = (op as { payload: { data: string } }).payload
+          expect(payload.data.length).toBeLessThanOrEqual(64)
+        }
+
+        hostExchange.dispose()
+        joinerExchange.dispose()
+      } finally {
+        sessions.close()
+      }
+    })
+
+    await it('joiner accepts a legacy single-message SNAPSHOT_RESPONSE_KIND (backwards compat)', async () => {
+      // Stay interop-friendly with peers running an older client
+      // that still sends the pre-chunking response shape.
+      const sessions = await createConnectedSessionPair()
+      try {
+        // Host bypasses the chunking helper and crafts a legacy
+        // response op directly, via the raw peer.sendOp path. The
+        // joiner-side handle(...) MUST still resolve.
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-c3', () => null)
+        const pending = joinerExchange.request('room-legacy', 2_000)
+
+        await flushMicrotasks()
+        sessions.host.sendOp({
+          kind: '__session/snapshot-response',
+          payload: { snapshot: FAKE_SNAPSHOT },
+          peerId: 'legacy-host',
+          seq: 0,
+        })
+
+        const received = await pending
+        expect(received.project.id).toBe('shared')
+
+        joinerExchange.dispose()
+      } finally {
+        sessions.close()
+      }
+    })
+
+    await it('rejects mid-stream change in totalChunks (protocol violation)', async () => {
+      const sessions = await createConnectedSessionPair()
+      try {
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-c4', () => null)
+        const pending = joinerExchange.request('room-bad-batch', 2_000)
+        await flushMicrotasks()
+
+        // Send chunk 0 of 3, then chunk 1 of 5 — protocol violation.
+        sessions.host.sendOp({
+          kind: SNAPSHOT_CHUNK_KIND,
+          payload: { chunkIndex: 0, totalChunks: 3, data: '{"x":1' },
+          peerId: 'bad-host',
+          seq: 0,
+        })
+        sessions.host.sendOp({
+          kind: SNAPSHOT_CHUNK_KIND,
+          payload: { chunkIndex: 1, totalChunks: 5, data: ',"y":2' },
+          peerId: 'bad-host',
+          seq: 1,
+        })
+
+        let caught: Error | null = null
+        try {
+          await pending
+        } catch (err) {
+          caught = err as Error
+        }
+        expect(caught).not.toBeNull()
+        expect(caught?.message).toContain('chunk batch size changed mid-stream')
+
+        joinerExchange.dispose()
+      } finally {
+        sessions.close()
+      }
+    })
+
+    await it('rejects invalid chunk envelopes (negative index, totalChunks=0)', async () => {
+      const sessions = await createConnectedSessionPair()
+      try {
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-c5', () => null)
+        const pending = joinerExchange.request('room-bad-envelope', 2_000)
+        await flushMicrotasks()
+
+        sessions.host.sendOp({
+          kind: SNAPSHOT_CHUNK_KIND,
+          payload: { chunkIndex: -1, totalChunks: 3, data: 'x' },
+          peerId: 'bad-host',
+          seq: 0,
+        })
+
+        let caught: Error | null = null
+        try {
+          await pending
+        } catch (err) {
+          caught = err as Error
+        }
+        expect(caught?.message).toContain('invalid chunk envelope')
+
+        joinerExchange.dispose()
+      } finally {
+        sessions.close()
+      }
+    })
+
+    await it('handles a snapshot that JSON-serialises to exactly chunkSizeBytes (boundary)', async () => {
+      const sessions = await createConnectedSessionPair()
+      try {
+        const hostExchange = new SnapshotExchange({
+          peerId: 'host-c6',
+          send: (op) => sessions.host.sendOp(op),
+          captureSnapshot: () => FAKE_SNAPSHOT,
+          // Pick a chunk size that's larger than the full snapshot
+          // so it fits in exactly ONE chunk — the smallest non-
+          // chunked path.
+          chunkSizeBytes: 1_000_000,
+        })
+        sessions.host.events.on('op-received', ({ op }) => {
+          if (isSessionProtocolOp(op)) hostExchange.handle(op)
+        })
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-c6', () => null)
+
+        const received = await joinerExchange.request('room-1chunk', 2_000)
+        expect(received.project.id).toBe('shared')
+
+        const hostSent = sessions.hostOpChannel.sentFrames.map(
+          (f) => JSON.parse(f) as SessionProtocolOp,
+        )
+        const chunks = hostSent.filter((op) => op.kind === SNAPSHOT_CHUNK_KIND)
+        // Single chunk: totalChunks === 1
+        expect(chunks.length).toBe(1)
+        expect((chunks[0] as { payload: { totalChunks: number } }).payload.totalChunks).toBe(1)
 
         hostExchange.dispose()
         joinerExchange.dispose()

--- a/packages/engine/src/sync/snapshot-exchange.ts
+++ b/packages/engine/src/sync/snapshot-exchange.ts
@@ -25,12 +25,39 @@
 
 import type { ProjectSnapshot } from './project-snapshot.ts'
 import {
+  createSnapshotChunkOp,
   createSnapshotRequestOp,
   createSnapshotResponseOp,
   type SessionProtocolOp,
+  SNAPSHOT_CHUNK_KIND,
   SNAPSHOT_REQUEST_KIND,
   SNAPSHOT_RESPONSE_KIND,
 } from './session-protocol.ts'
+
+/**
+ * Per-chunk payload size in bytes. The envelope around each chunk
+ * (`{kind,payload:{chunkIndex,totalChunks,data},peerId,seq}`)
+ * adds ~120 bytes of overhead; 16 KiB of `data` keeps every wire
+ * frame well under the WebRTC SCTP `max-message-size` default of
+ * 64 KiB (RFC 8841 § 6.1). Going larger than the SCTP ceiling
+ * silently drops the message on GStreamer webrtcbin — verified in
+ * the 2026-06-01 pixel-rpg/map-editor hand-test, where a 1.27 MB
+ * single-message snapshot response never reached the joiner while
+ * 109-byte awareness frames and the 106-byte snapshot-request op
+ * traversed the same channel fine.
+ *
+ * 16 KiB chunks produce ~80 sends for a 1.2 MB snapshot — well
+ * within ordered-reliable SCTP throughput limits.
+ */
+const SNAPSHOT_CHUNK_BYTES = 16 * 1024
+
+/**
+ * Public reference to the canonical chunk-size used by
+ * {@link SnapshotExchange} — exported so tests can assert against
+ * the same constant and consumers that wrap the exchange (e.g. for
+ * a HTTP-fallback transport) can match the boundary exactly.
+ */
+export const SNAPSHOT_CHUNK_SIZE_BYTES = SNAPSHOT_CHUNK_BYTES
 
 export interface SnapshotExchangeOptions {
   /**
@@ -63,6 +90,13 @@ export interface SnapshotExchangeOptions {
    * without waiting in real time.
    */
   defaultTimeoutMs?: number
+  /**
+   * Override the per-chunk payload size. Production omits this
+   * and uses {@link SNAPSHOT_CHUNK_SIZE_BYTES} (16 KiB). Tests
+   * pass a small value (e.g. 64 bytes) so the chunking path is
+   * exercised without needing a megabyte of fixture data.
+   */
+  chunkSizeBytes?: number
 }
 
 interface PendingRequest {
@@ -71,12 +105,27 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout> | null
 }
 
+/**
+ * Buffer for an in-flight chunked snapshot response. Sized at
+ * `totalChunks` once the first chunk arrives; `chunks[i]` holds
+ * each chunk's UTF-8 substring or `undefined` while still in
+ * transit. `received` counts the populated slots so we don't
+ * have to re-scan the array per arrival.
+ */
+interface ChunkBuffer {
+  chunks: Array<string | undefined>
+  totalChunks: number
+  received: number
+}
+
 export class SnapshotExchange {
   private readonly peerId: string
   private readonly send: (op: SessionProtocolOp) => void
   private readonly captureSnapshot: () => ProjectSnapshot | null
   private readonly defaultTimeoutMs: number
+  private readonly chunkSizeBytes: number
   private pending: PendingRequest | null = null
+  private chunkBuffer: ChunkBuffer | null = null
   private localSeq = 0
   private disposed = false
 
@@ -85,6 +134,7 @@ export class SnapshotExchange {
     this.send = opts.send
     this.captureSnapshot = opts.captureSnapshot
     this.defaultTimeoutMs = opts.defaultTimeoutMs ?? 10_000
+    this.chunkSizeBytes = opts.chunkSizeBytes ?? SNAPSHOT_CHUNK_BYTES
   }
 
   private nextSeq(): number {
@@ -104,7 +154,13 @@ export class SnapshotExchange {
         this.respondToRequest(op.payload.roomId)
         return
       case SNAPSHOT_RESPONSE_KIND:
+        // Legacy single-message path — still accepted so a peer
+        // running an older client (or sending a snapshot that
+        // fits in one frame and bypasses chunking) interops.
         this.resolveResponse(op.payload.snapshot)
+        return
+      case SNAPSHOT_CHUNK_KIND:
+        this.handleChunk(op.payload)
         return
     }
   }
@@ -156,6 +212,7 @@ export class SnapshotExchange {
   dispose(): void {
     if (this.disposed) return
     this.disposed = true
+    this.chunkBuffer = null
     if (this.pending) {
       const p = this.pending
       this.pending = null
@@ -175,9 +232,103 @@ export class SnapshotExchange {
     }
     // roomId echoed for diagnostics; not load-bearing in v1.
     void roomId
-    this.send(
-      createSnapshotResponseOp({ peerId: this.peerId, seq: this.nextSeq(), snapshot }),
-    )
+
+    // Serialise once, then chunk by configured byte boundary. We
+    // always chunk (even for tiny snapshots that fit in 1 chunk)
+    // so the receiver has a single code-path to handle. Sending
+    // as a sequence of `SNAPSHOT_CHUNK_KIND` ops keeps every wire
+    // frame below the WebRTC SCTP `max-message-size` ceiling —
+    // the 2026-06-01 hand-test bug was that single-message sends
+    // larger than 64 KiB were silently dropped by GStreamer
+    // webrtcbin (RFC 8841 default).
+    const json = JSON.stringify(snapshot)
+    const totalChunks = Math.max(1, Math.ceil(json.length / this.chunkSizeBytes))
+    for (let i = 0; i < totalChunks; i++) {
+      const start = i * this.chunkSizeBytes
+      const end = Math.min(start + this.chunkSizeBytes, json.length)
+      this.send(
+        createSnapshotChunkOp({
+          peerId: this.peerId,
+          seq: this.nextSeq(),
+          chunkIndex: i,
+          totalChunks,
+          data: json.slice(start, end),
+        }),
+      )
+    }
+  }
+
+  private handleChunk(payload: { chunkIndex: number; totalChunks: number; data: string }): void {
+    if (!this.pending) {
+      // Unsolicited chunk — drop. A host that streams without
+      // a matching request is misbehaving.
+      return
+    }
+    // Defensive: a buggy peer could send `totalChunks` of 0 or a
+    // negative `chunkIndex`. Reject the whole batch (which fails
+    // the pending request) rather than corrupt our state.
+    if (
+      !Number.isInteger(payload.totalChunks) ||
+      payload.totalChunks <= 0 ||
+      !Number.isInteger(payload.chunkIndex) ||
+      payload.chunkIndex < 0 ||
+      payload.chunkIndex >= payload.totalChunks
+    ) {
+      this.failPending(
+        new Error(
+          `SnapshotExchange: invalid chunk envelope (chunkIndex=${payload.chunkIndex}, totalChunks=${payload.totalChunks})`,
+        ),
+      )
+      return
+    }
+
+    // Allocate buffer on first chunk. A subsequent chunk that
+    // disagrees on `totalChunks` is a protocol violation — fail.
+    if (!this.chunkBuffer) {
+      this.chunkBuffer = {
+        chunks: new Array<string | undefined>(payload.totalChunks),
+        totalChunks: payload.totalChunks,
+        received: 0,
+      }
+    } else if (this.chunkBuffer.totalChunks !== payload.totalChunks) {
+      this.failPending(
+        new Error(
+          `SnapshotExchange: chunk batch size changed mid-stream ` +
+            `(saw totalChunks=${this.chunkBuffer.totalChunks}, then ${payload.totalChunks})`,
+        ),
+      )
+      return
+    }
+
+    if (this.chunkBuffer.chunks[payload.chunkIndex] !== undefined) {
+      // Duplicate chunk index — ordered+reliable channel shouldn't
+      // produce these, but be defensive.
+      return
+    }
+    this.chunkBuffer.chunks[payload.chunkIndex] = payload.data
+    this.chunkBuffer.received++
+
+    if (this.chunkBuffer.received < this.chunkBuffer.totalChunks) {
+      return
+    }
+
+    // Last chunk arrived — reassemble + parse + resolve.
+    const json = this.chunkBuffer.chunks.join('')
+    this.chunkBuffer = null
+    let snapshot: ProjectSnapshot
+    try {
+      snapshot = JSON.parse(json) as ProjectSnapshot
+    } catch (err) {
+      this.failPending(
+        new Error(
+          `SnapshotExchange: failed to parse reassembled snapshot (json.length=${json.length}): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        ),
+      )
+      return
+    }
+    this.resolveResponse(snapshot)
   }
 
   private resolveResponse(snapshot: ProjectSnapshot): void {
@@ -189,7 +340,18 @@ export class SnapshotExchange {
     }
     const p = this.pending
     this.pending = null
+    this.chunkBuffer = null
     if (p.timer) clearTimeout(p.timer)
     p.resolve(snapshot)
+  }
+
+  /** Reject the pending request and clear any partial buffer. */
+  private failPending(err: Error): void {
+    this.chunkBuffer = null
+    if (!this.pending) return
+    const p = this.pending
+    this.pending = null
+    if (p.timer) clearTimeout(p.timer)
+    p.reject(err)
   }
 }


### PR DESCRIPTION
## ROOT CAUSE NAILED 🎯

Diagnostic logs from PR #117 surfaced the exact wire-level failure on the 2026-06-01 hand-test:

\`\`\`
Host:
  [peer-session/host] ← channel "op" recv frame (len=106)
  [peer-session/host]   channel "op" delivered (kind=__session/snapshot-request)
  [peer-session/host] → channel "op" send op (len=1270549, kind=__session/snapshot-response)   ← 1.21 MiB!
  ↓ silence, then bye: join-failed arrives via the WS layer
Joiner:
  [peer-session/joiner] → channel "op" send op (len=106, kind=__session/snapshot-request)
  [peer-session/joiner] ← channel "awareness" recv frame (len=109)   ← awareness (109 B) OK
  ↓ 10s timeout, never receives the snapshot-response
\`\`\`

**The host's snapshot-response frame is 1,270,549 bytes (1.21 MiB).** GStreamer webrtcbin's SCTP layer silently drops any single \`send_message\` above its \`max-message-size\` (RFC 8841 default 65,536 bytes). Awareness frames (109 B) and the snapshot-request op (106 B) traverse the same channel fine — the issue is payload-size-specific, not transport-broken.

The W3C-standard mitigation: **application-level chunking**. Every serious WebRTC data-channel consumer above ~16 KB does this (file transfers in webrtc-samples, video-streaming libs, etc.).

## Fix

### \`packages/engine/src/sync/session-protocol.ts\`
- New op kind \`SNAPSHOT_CHUNK_KIND = '__session/snapshot-chunk'\` + \`SnapshotChunkOp\` interface with \`{ chunkIndex, totalChunks, data }\` payload
- \`createSnapshotChunkOp\` factory

### \`packages/engine/src/sync/snapshot-exchange.ts\`
- New \`SNAPSHOT_CHUNK_SIZE_BYTES = 16 KiB\` exported constant + per-instance \`chunkSizeBytes\` option (default = constant; tests pass small values)
- \`respondToRequest\`: serialise once, slice into chunks, send each as a \`SnapshotChunkOp\` with monotonic index + \`totalChunks\`. **Always chunks** (even tiny snapshots → 1 chunk) so the receiver has a single uniform code-path
- \`handleChunk\`: accumulate by index, when \`received === totalChunks\` do \`chunks.join('') + JSON.parse\` and resolve the pending request
- Defensive rejections: invalid envelopes (neg index, total=0, index ≥ total), mid-stream totalChunks change (protocol violation), parse-failure on reassembled JSON. Duplicate-index chunks are dropped silently (defensive even though ordered+reliable channel shouldn't produce them)
- **Backwards compat**: legacy \`SNAPSHOT_RESPONSE_KIND\` single-message path still accepted on inbound, so peers running an older client interop

### Tests

6 new specs in \`snapshot-exchange.spec.ts\`:
- default chunked send → 1+ chunks, joiner reassembles correctly
- **REGRESSION (2026-06-01)**: forced multi-chunk via 64-byte \`chunkSizeBytes\` produces >3 chunks each ≤64 bytes
- backwards-compat: legacy single-message inbound still resolves
- mid-stream \`totalChunks\` change rejected with clear error
- invalid chunk envelope (neg index) rejected
- boundary: snapshot fits in exactly 1 chunk (totalChunks=1)

| Workspace | Before | After |
|---|---|---|
| \`@pixelrpg/engine\` | 324 | **348** (+24) |
| \`@pixelrpg/maker-gjs\` | 188 / 199 | unchanged |

All green on both Node + GJS.

## Hand-test acceptance

After this PR + build/install, the joiner should see:

\`\`\`
[peer-session/joiner] ← channel "op" recv frame (len=~16500)
[peer-session/joiner]   channel "op" delivered (kind=__session/snapshot-chunk)
... ~80 chunks for a 1.2 MB snapshot ...
[session-service] joiner: snapshot received (project="...", maps=N); writing sandbox…
[session-service] joiner: sandbox written to /home/.../shared/<roomId>/...
\`\`\`

Pair-Editing should finally be **fully functional** end-to-end after this PR.

## Test plan

- [x] \`gjsify foreach check -v -t\` clean
- [x] \`@pixelrpg/engine\` test 348/348 green on GJS + Node
- [x] \`@pixelrpg/maker-gjs\` test 188/188 / 199/199 green on GJS + Node
- [ ] CI passes
- [ ] Hand-test: Pair-Editing finally works end-to-end