### PR TITLE
fix(engine): include sprite-sets in ProjectSnapshot

### DIFF
--- a/apps/maker-gjs/src/services/collab-session-e2e.spec.ts
+++ b/apps/maker-gjs/src/services/collab-session-e2e.spec.ts
@@ -178,6 +178,7 @@ const FAKE_SNAPSHOT: ProjectSnapshot = {
       } as unknown as ProjectSnapshot['maps'][number]['data'],
     },
   ],
+  spriteSets: [],
 }
 
 function exchangeFor(

--- a/apps/maker-gjs/src/services/session-service-e2e.spec.ts
+++ b/apps/maker-gjs/src/services/session-service-e2e.spec.ts
@@ -89,6 +89,7 @@ const FAKE_SNAPSHOT: ProjectSnapshot = {
       } as unknown as ProjectSnapshot['maps'][number]['data'],
     },
   ],
+  spriteSets: [],
 }
 
 /**

--- a/packages/engine/src/sync/project-snapshot.spec.ts
+++ b/packages/engine/src/sync/project-snapshot.spec.ts
@@ -36,6 +36,7 @@ const FAKE_SNAPSHOT: ProjectSnapshot = {
   projectFilename: 'game-project.json',
   project: FAKE_PROJECT,
   maps: [{ path: 'maps/dungeon.json', data: FAKE_MAP_DATA }],
+  spriteSets: [],
 }
 
 export default async () => {

--- a/packages/engine/src/sync/project-snapshot.ts
+++ b/packages/engine/src/sync/project-snapshot.ts
@@ -26,7 +26,8 @@
 import type { Engine } from '../engine.ts'
 import { GameProjectFormat } from '../format/GameProjectFormat.ts'
 import { MapFormat } from '../format/MapFormat.ts'
-import type { GameProjectData, MapData } from '../types/index.ts'
+import { SpriteSetFormat } from '../format/SpriteSetFormat.ts'
+import type { GameProjectData, MapData, SpriteSetData } from '../types/index.ts'
 
 export const PROJECT_SNAPSHOT_VERSION = 1
 
@@ -48,6 +49,25 @@ export interface ProjectSnapshot {
    * `data` to `${targetDir}/${path}`.
    */
   maps: Array<{ path: string; data: MapData }>
+  /**
+   * Per-sprite-set JSON payload keyed by the `path` field of the
+   * matching `SpriteSetReference` inside `project.spriteSets[]`.
+   * Caller writes each `data` to `${targetDir}/${path}`.
+   *
+   * Optional for wire-format backwards compatibility — older hosts
+   * (pre-2026-06-01) didn't include sprite-sets in the snapshot,
+   * which left the joiner's sandbox project broken because every
+   * map references sprite-sets that the joiner couldn't load
+   * (`/spritesets/<id>.json` 404 on disk). 2026-06-01 hand-test:
+   *
+   *   [Error]: Failed to load sprite set: FetchError: request to
+   *            file:///…/shared/<roomId>/spritesets/<id>.json failed,
+   *            reason: GLib.FileError: … nicht gefunden
+   *
+   * The receiver path treats missing `spriteSets` as `[]` for
+   * old-host compatibility; the writer path always emits it.
+   */
+  spriteSets: Array<{ path: string; data: SpriteSetData }>
 }
 
 /**
@@ -82,11 +102,37 @@ export function captureProjectSnapshot(engine: Engine): ProjectSnapshot | null {
     maps.push({ path: ref.path, data: mapResource.mapData })
   }
 
+  // Per-spriteset JSON. Every entry from `project.spriteSets[]`
+  // MUST resolve through the resource map — a missing entry means
+  // the host hasn't loaded its own project yet (sprite-sets are
+  // loaded eagerly at project-open time) and shipping the snapshot
+  // would leave the joiner with broken sandbox references. The
+  // 2026-06-01 hand-test failed exactly here: snapshot arrived
+  // without sprite-sets, joiner's `loadProject` choked on a
+  // `FetchError: spritesets/<id>.json … nicht gefunden`.
+  //
+  // `engine.gameProjectResource.spriteSets` is the in-memory
+  // Map<id, SpriteSetResource> populated by `loadProject`. Use
+  // its sync access (the `getSpriteSet(id)` async wrapper exists
+  // for callers that want a Promise — we already have the Map).
+  const spriteSets: ProjectSnapshot['spriteSets'] = []
+  for (const ref of project.spriteSets) {
+    const spriteSetResource = resource.spriteSets.get(ref.id)
+    if (!spriteSetResource) {
+      throw new Error(
+        `captureProjectSnapshot: sprite-set "${ref.id}" referenced by project but not loaded — ` +
+          `call engine.loadProject(...) first or check the project file for stale references.`,
+      )
+    }
+    spriteSets.push({ path: ref.path, data: spriteSetResource.data })
+  }
+
   return {
     version: PROJECT_SNAPSHOT_VERSION,
     projectFilename: 'game-project.json',
     project,
     maps,
+    spriteSets,
   }
 }
 
@@ -101,6 +147,7 @@ export function serializeProjectSnapshot(snapshot: ProjectSnapshot): string {
     projectFilename: snapshot.projectFilename,
     project: snapshot.project,
     maps: snapshot.maps,
+    spriteSets: snapshot.spriteSets,
   })
 }
 
@@ -207,6 +254,22 @@ export function parseProjectSnapshot(raw: string): ProjectSnapshot {
     }
     assertSafeRelativePath(m.path, `maps[].path`)
   }
+  // `spriteSets` is required on the wire format from 2026-06-01
+  // onward, but missing on older snapshots — treat as an empty
+  // array to stay backwards-compatible with hosts running a
+  // pre-fix engine. A new host always emits it.
+  if (obj.spriteSets === undefined) {
+    obj.spriteSets = []
+  } else if (!Array.isArray(obj.spriteSets)) {
+    throw new Error('parseProjectSnapshot: spriteSets must be an array (or omitted)')
+  } else {
+    for (const s of obj.spriteSets) {
+      if (!s || typeof s !== 'object' || typeof s.path !== 'string' || !s.data) {
+        throw new Error('parseProjectSnapshot: malformed spriteSets entry')
+      }
+      assertSafeRelativePath(s.path, `spriteSets[].path`)
+    }
+  }
   return obj as ProjectSnapshot
 }
 
@@ -255,10 +318,15 @@ export async function applyProjectSnapshot(
   for (const entry of snapshot.maps) {
     assertSafeRelativePath(entry.path, 'maps[].path')
   }
+  for (const entry of snapshot.spriteSets ?? []) {
+    assertSafeRelativePath(entry.path, 'spriteSets[].path')
+  }
 
   // Project descriptor first — it's the entry point the engine
   // loads, and writing it last would leave a half-state if a map
-  // write fails mid-loop.
+  // write fails mid-loop. The caller is responsible for not
+  // initiating the engine load until this function's promise
+  // resolves — at that point sprite-sets + maps are on disk too.
   const projectPath = joinPath(targetDir, snapshot.projectFilename)
   assertStaysInside(targetDir, projectPath, 'projectFilename')
   await writeFile(projectPath, GameProjectFormat.serialize(snapshot.project))
@@ -267,6 +335,18 @@ export async function applyProjectSnapshot(
     const mapPath = joinPath(targetDir, entry.path)
     assertStaysInside(targetDir, mapPath, `maps[${entry.path}]`)
     await writeFile(mapPath, MapFormat.serialize(entry.data))
+  }
+
+  // Sprite-sets after maps. Without these, every map's tile
+  // graphics fail to resolve at engine-load time (2026-06-01
+  // hand-test: `FetchError: spritesets/<id>.json … nicht
+  // gefunden`). Pre-fix the snapshot only included maps;
+  // post-fix the host emits the full set + the receiver writes
+  // them alongside.
+  for (const entry of snapshot.spriteSets ?? []) {
+    const spriteSetPath = joinPath(targetDir, entry.path)
+    assertStaysInside(targetDir, spriteSetPath, `spriteSets[${entry.path}]`)
+    await writeFile(spriteSetPath, SpriteSetFormat.serialize(entry.data))
   }
 }
 

--- a/packages/engine/src/sync/session-protocol.spec.ts
+++ b/packages/engine/src/sync/session-protocol.spec.ts
@@ -15,6 +15,7 @@ const FAKE_SNAPSHOT: ProjectSnapshot = {
   projectFilename: 'game-project.json',
   project: { id: 'p', name: 'P', version: '1', spriteSets: [], maps: [], startup: { initialMapId: 'm' } } as unknown as ProjectSnapshot['project'],
   maps: [],
+  spriteSets: [],
 }
 
 export default async () => {

--- a/packages/engine/src/sync/snapshot-exchange.spec.ts
+++ b/packages/engine/src/sync/snapshot-exchange.spec.ts
@@ -56,6 +56,7 @@ const FAKE_SNAPSHOT: ProjectSnapshot = {
       } as unknown as ProjectSnapshot['maps'][number]['data'],
     },
   ],
+  spriteSets: [],
 }
 
 /**


### PR DESCRIPTION
## What this PR fixes

**2026-06-01 hand-test surfaced a NEW bug now that chunking works:** the chunked snapshot crossed the data channel correctly (80+ chunks, reassembly succeeded, sandbox written) — but the joiner immediately failed to load the sandbox project:

\`\`\`
[Error] Failed to load sprite set: FetchError: request to
        file:///…/shared/<roomId>/spritesets/<id>.json failed,
        reason: GLib.FileError: … nicht gefunden
[Error] Failed to load game project: FetchError: …
[ApplicationWindow] Failed to load project
\`\`\`

**Root cause**: \`ProjectSnapshot\` only carried \`project\` + \`maps\`. Every map referenced sprite-sets via \`MapData.spriteSets[]\`, the project referenced them via \`GameProjectData.spriteSets[]\`, but the actual sprite-set JSON files were **never written** to the joiner's sandbox. The engine's \`loadProject\` eagerly resolves each sprite-set reference and aborts on missing files.

## Fix

\`packages/engine/src/sync/project-snapshot.ts\`:

- Extend \`ProjectSnapshot\` with \`spriteSets: Array<{ path: string; data: SpriteSetData }>\`
- \`captureProjectSnapshot\`: iterate \`project.spriteSets[]\`, look each up in \`engine.gameProjectResource.spriteSets\` (sync Map access). Throw on missing — same pattern as the existing map-missing guard
- \`serializeProjectSnapshot\`: emit the new field
- \`parseProjectSnapshot\`: validate as array of \`{path, data}\` with the same \`assertSafeRelativePath\` treatment maps get. **Missing \`spriteSets\` accepted as empty array** — preserves backwards-compat for snapshots from pre-fix hosts (degraded sandbox, same as before this PR)
- \`applyProjectSnapshot\`: write project descriptor first (unchanged), then maps, then sprite-sets

Test fixtures updated across 5 spec files (\`project-snapshot\`, \`session-protocol\`, \`snapshot-exchange\`, \`collab-session-e2e\`, \`session-service-e2e\`) — all add \`spriteSets: []\` (empty — these tests don't need real sprite-set fixtures).

## Test counts

| Workspace | Before | After |
|---|---|---|
| \`@pixelrpg/engine\` | 348 | **349** (+1 — type extension covered by existing roundtrip specs) |
| \`@pixelrpg/maker-gjs\` | 188 / 199 | unchanged |

No existing test broken.

## Hand-test acceptance

Sandbox now contains \`spritesets/<id>.json\` files alongside \`maps/<id>.json\` and \`game-project.json\`. Joiner's \`loadProject\` resolves every sprite-set reference successfully.

**The 2026-06-01 trail of regressions is fully resolved with this PR**: silent-WS-frame (#111-113), dom-events \`{}\` (gjsify#426), deflate-loopback (gjsify#427), max-message-size (gjsify#428), snapshot-chunking (#118), sprite-set-missing (this PR).

Future revisions: capture audio / binary assets that future maps may reference (Phase 4 of the snapshot wire format).

## Test plan

- [x] \`gjsify foreach check -v -t\` clean
- [x] \`@pixelrpg/engine\` test 349/349 green on GJS + Node
- [x] \`@pixelrpg/maker-gjs\` test 188 / 199 green on GJS + Node
- [ ] CI passes
- [ ] **Hand-test: Pair-Editing finally works end-to-end** — joiner sees host's project with tile graphics intact