### PR TITLE
fix(engine): embed sprite-set images in ProjectSnapshot

### DIFF
--- a/apps/maker-gjs/src/services/collab-session-e2e.spec.ts
+++ b/apps/maker-gjs/src/services/collab-session-e2e.spec.ts
@@ -184,7 +184,7 @@ const FAKE_SNAPSHOT: ProjectSnapshot = {
 function exchangeFor(
   peer: import('@pixelrpg/engine').PeerSession,
   peerId: string,
-  captureSnapshot: () => ProjectSnapshot | null,
+  captureSnapshot: () => ProjectSnapshot | null | Promise<ProjectSnapshot | null>,
 ): SnapshotExchange {
   const exchange = new SnapshotExchange({
     peerId,

--- a/apps/maker-gjs/src/services/file-io.ts
+++ b/apps/maker-gjs/src/services/file-io.ts
@@ -40,3 +40,38 @@ export function writeTextFile(path: string, contents: string): boolean {
 export function writeJsonFile(path: string, value: unknown): boolean {
   return writeTextFile(path, `${JSON.stringify(value, null, 2)}\n`)
 }
+
+/**
+ * Write raw binary bytes to an absolute filesystem path via
+ * `Gio.File.replace_contents`. Creates parent directories on
+ * demand. Returns `true` on success.
+ *
+ * Companion to {@link writeTextFile} — used by the snapshot
+ * sandbox path to land sprite-set PNGs alongside their JSON
+ * descriptors when the host bundles them into the wire snapshot.
+ *
+ * Failures are logged via `console.warn` and surface as `false`
+ * (same policy as text writes); callers decide whether to toast
+ * / retry.
+ */
+export function writeBinaryFile(path: string, bytes: Uint8Array): boolean {
+  try {
+    const dir = GLib.path_get_dirname(path)
+    const dirFile = Gio.File.new_for_path(dir)
+    if (!dirFile.query_exists(null)) {
+      dirFile.make_directory_with_parents(null)
+    }
+    const file = Gio.File.new_for_path(path)
+    const [ok] = file.replace_contents(
+      bytes,
+      null,
+      false,
+      Gio.FileCreateFlags.NONE,
+      null,
+    )
+    return ok
+  } catch (error) {
+    console.warn(`[file-io] binary write failed for ${path}:`, error)
+    return false
+  }
+}

--- a/apps/maker-gjs/src/services/sandbox-path.ts
+++ b/apps/maker-gjs/src/services/sandbox-path.ts
@@ -32,7 +32,7 @@ import GLib from '@girs/glib-2.0'
 import { applyProjectSnapshot, type ProjectSnapshot } from '@pixelrpg/engine'
 
 import { scopedLogger } from './collab-log.ts'
-import { writeTextFile } from './file-io.ts'
+import { writeBinaryFile, writeTextFile } from './file-io.ts'
 
 const log = scopedLogger('sandbox-path')
 
@@ -83,6 +83,11 @@ export async function writeSnapshotToSandbox(
       if (!ok) throw new Error(`writeSnapshotToSandbox: failed to write ${absolutePath}`)
     },
     (...segments) => GLib.build_filenamev(segments),
+    async (absolutePath, bytes) => {
+      const ok = writeBinaryFile(absolutePath, bytes)
+      if (!ok) throw new Error(`writeSnapshotToSandbox: failed to write binary ${absolutePath}`)
+    },
+    (path) => GLib.path_get_dirname(path),
   )
   return GLib.build_filenamev([dir, snapshot.projectFilename])
 }

--- a/packages/engine/src/resource/SpriteSetResource.ts
+++ b/packages/engine/src/resource/SpriteSetResource.ts
@@ -11,15 +11,7 @@ import {
 import { SpriteSetFormat } from '../format/SpriteSetFormat'
 import type { AnimationData, SpriteDataSet, SpriteSetData, SpriteSetResourceOptions } from '../types'
 import { loadTextFile, toFetchUrl } from '../utils'
-import { extractDirectoryPath, getFilename, joinPaths } from '../utils/url'
-
-/**
- * Whether `path` is already a fully-qualified URL (or data URL) that
- * should NOT be re-joined against a base directory.
- */
-function isAbsoluteOrUrl(path: string): boolean {
-  return /^(https?|file|data|blob):/i.test(path)
-}
+import { extractDirectoryPath, getFilename, isAbsoluteOrUrl, joinPaths } from '../utils/url'
 
 /**
  * Resource class for loading custom SpriteSet format into Excalibur
@@ -66,6 +58,23 @@ export class SpriteSetResource {
    */
   get path(): string {
     return joinPaths(this.basePath, this.filename)
+  }
+
+  /**
+   * Directory the sprite-set's image paths are resolved against.
+   *
+   * Exposed for the snapshot layer (`captureProjectSnapshot`) so
+   * it can read the on-disk PNG bytes and embed them in the wire
+   * snapshot — a joiner without a local copy of the project needs
+   * the binary asset to render anything.
+   *
+   * `data.image.path` may be a `data:`/`http(s)://`/`file://` URL,
+   * in which case the absolute path doesn't exist on disk and
+   * callers should detect the URL form via `isAbsoluteOrUrl` and
+   * skip the read.
+   */
+  get imageBasePath(): string {
+    return this.basePath
   }
 
   /**

--- a/packages/engine/src/sync/project-snapshot.spec.ts
+++ b/packages/engine/src/sync/project-snapshot.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@gjsify/unit'
 
 import type { GameProjectData, MapData } from '../types/index.ts'
+import { bytesToBase64 } from '../utils/base64.ts'
 
 import {
   applyProjectSnapshot,
@@ -251,6 +252,188 @@ export default async () => {
       const reparsed = JSON.parse(projectContent ?? '{}') as GameProjectData
       expect(reparsed.id).toBe('demo')
       expect(reparsed.name).toBe('Demo Project')
+    })
+  })
+
+  // ----- Binary sprite-set image transfer ---------------------------------
+
+  // 1x1 transparent PNG — the smallest valid binary asset, ideal for
+  // a wire-format round-trip test (avoids fixture bloat while still
+  // exercising the base64 + Uint8Array + writeBinaryFile path).
+  const TINY_PNG_BYTES = new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+    0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+    0x42, 0x60, 0x82,
+  ])
+  // Derive the base64 form at runtime from the canonical bytes so
+  // any hand-typed transcription error fails-fast at base64 encode,
+  // not at byte mismatch during apply.
+  const TINY_PNG_BASE64 = bytesToBase64(TINY_PNG_BYTES)
+
+  const FAKE_SPRITESET_DATA = {
+    version: '1.0.0',
+    id: 'tiles',
+    name: 'Tiles',
+    image: { id: 'main', path: 'tiles.png', type: 'image' as const },
+    spriteWidth: 16,
+    spriteHeight: 16,
+    columns: 1,
+    rows: 1,
+    margin: 0,
+    spacing: 0,
+    sprites: [{ id: 0, col: 0, row: 0 }],
+  } as unknown as ProjectSnapshot['spriteSets'][number]['data']
+
+  const SNAPSHOT_WITH_IMAGES: ProjectSnapshot = {
+    ...FAKE_SNAPSHOT,
+    spriteSets: [
+      {
+        path: 'spritesets/tiles.json',
+        data: FAKE_SPRITESET_DATA,
+        images: [{ path: 'tiles.png', base64: TINY_PNG_BASE64 }],
+      },
+    ],
+  }
+
+  await describe('parseProjectSnapshot — binary images validation', async () => {
+    await it('accepts a snapshot whose sprite-set carries one PNG', async () => {
+      const wire = serializeProjectSnapshot(SNAPSHOT_WITH_IMAGES)
+      const back = parseProjectSnapshot(wire)
+      expect(back.spriteSets[0].images?.length).toBe(1)
+      expect(back.spriteSets[0].images?.[0].path).toBe('tiles.png')
+      expect(back.spriteSets[0].images?.[0].base64).toBe(TINY_PNG_BASE64)
+    })
+
+    await it('treats omitted spriteSets[].images as []', async () => {
+      const wire = JSON.stringify({
+        ...FAKE_SNAPSHOT,
+        spriteSets: [{ path: 'spritesets/tiles.json', data: FAKE_SPRITESET_DATA }],
+      })
+      const back = parseProjectSnapshot(wire)
+      expect(back.spriteSets[0].images?.length).toBe(0)
+    })
+
+    await it('rejects spriteSets[].images that is not an array', async () => {
+      const wire = JSON.stringify({
+        ...FAKE_SNAPSHOT,
+        spriteSets: [{ path: 'spritesets/tiles.json', data: FAKE_SPRITESET_DATA, images: 'oops' }],
+      })
+      expect(() => parseProjectSnapshot(wire)).toThrow()
+    })
+
+    await it('rejects a malformed images entry', async () => {
+      const wire = JSON.stringify({
+        ...FAKE_SNAPSHOT,
+        spriteSets: [
+          { path: 'spritesets/tiles.json', data: FAKE_SPRITESET_DATA, images: [{ path: 42, base64: 'AA==' }] },
+        ],
+      })
+      expect(() => parseProjectSnapshot(wire)).toThrow()
+    })
+
+    await it('rejects a path-traversing image path', async () => {
+      const wire = JSON.stringify({
+        ...FAKE_SNAPSHOT,
+        spriteSets: [
+          {
+            path: 'spritesets/tiles.json',
+            data: FAKE_SPRITESET_DATA,
+            images: [{ path: '../../etc/passwd', base64: 'AA==' }],
+          },
+        ],
+      })
+      expect(() => parseProjectSnapshot(wire)).toThrow()
+    })
+
+    await it('rejects non-base64 alphabet in the binary payload', async () => {
+      const wire = JSON.stringify({
+        ...FAKE_SNAPSHOT,
+        spriteSets: [
+          {
+            path: 'spritesets/tiles.json',
+            data: FAKE_SPRITESET_DATA,
+            images: [{ path: 'tiles.png', base64: 'not valid base64 ❌' }],
+          },
+        ],
+      })
+      expect(() => parseProjectSnapshot(wire)).toThrow()
+    })
+  })
+
+  await describe('applyProjectSnapshot — binary sprite-set images', async () => {
+    await it('writes each image alongside its sprite-set JSON, bytes-faithful', async () => {
+      const textWrites = new Map<string, string>()
+      const binaryWrites = new Map<string, Uint8Array>()
+      await applyProjectSnapshot(
+        SNAPSHOT_WITH_IMAGES,
+        '/sandbox/room-abc',
+        async (path, contents) => {
+          textWrites.set(path, contents)
+        },
+        (...segments) => segments.join('/'),
+        async (path, bytes) => {
+          binaryWrites.set(path, bytes)
+        },
+      )
+
+      // Sprite-set JSON landed at the descriptor's path.
+      expect(textWrites.has('/sandbox/room-abc/spritesets/tiles.json')).toBeTruthy()
+      // The image landed alongside (dirname(spritesets/tiles.json) + image.path).
+      expect(binaryWrites.has('/sandbox/room-abc/spritesets/tiles.png')).toBeTruthy()
+      const written = binaryWrites.get('/sandbox/room-abc/spritesets/tiles.png')
+      expect(written?.length).toBe(TINY_PNG_BYTES.length)
+      // Compare byte-by-byte — a base64 round-trip that drops a byte
+      // would silently corrupt the PNG (libpng would refuse to render).
+      // Computing the base64 from the canonical bytes via
+      // `bytesToBase64` at fixture-build time pins the encode side
+      // too — a regression in either direction surfaces here.
+      let identical = !!written && written.length === TINY_PNG_BYTES.length
+      if (written) {
+        for (let i = 0; i < TINY_PNG_BYTES.length; i++) {
+          if (written[i] !== TINY_PNG_BYTES[i]) {
+            identical = false
+            break
+          }
+        }
+      }
+      expect(identical).toBeTruthy()
+    })
+
+    await it('throws when images are present but writeBinaryFile is omitted', async () => {
+      let caught: unknown = null
+      try {
+        await applyProjectSnapshot(
+          SNAPSHOT_WITH_IMAGES,
+          '/sandbox/x',
+          async () => {
+            /* text writer accepts */
+          },
+          (...segments) => segments.join('/'),
+          // writeBinaryFile intentionally omitted
+        )
+      } catch (err) {
+        caught = err
+      }
+      // Silent skip would resurrect the missing-PNG joiner-hang bug.
+      expect(caught).toBeTruthy()
+    })
+
+    await it('writes nothing through writeBinaryFile when no images are present', async () => {
+      let binaryCalls = 0
+      await applyProjectSnapshot(
+        FAKE_SNAPSHOT,
+        '/sandbox/y',
+        async () => {
+          /* ignore */
+        },
+        (...segments) => segments.join('/'),
+        async () => {
+          binaryCalls++
+        },
+      )
+      expect(binaryCalls).toBe(0)
     })
   })
 }

--- a/packages/engine/src/sync/project-snapshot.ts
+++ b/packages/engine/src/sync/project-snapshot.ts
@@ -2,14 +2,23 @@
  * Project-snapshot wire shape — what the host transmits to a joiner
  * so it can edit the same project without having a local copy.
  *
- * The snapshot is **schema-only**: it carries the JSON describing
- * the project + each map, but NOT the binary assets (sprite-set
- * PNGs, audio, etc.). v1 assumes both peers have the same baseline
- * asset bundle available (the built-in scientist sprite + any
- * standard assets shipped with the maker). When the joiner opens
- * the snapshot and a referenced asset is missing, the engine logs
- * a warning + falls back to placeholder graphics — the edit
- * session still works, only the visuals degrade.
+ * The snapshot carries the JSON describing the project + each map
+ * + each sprite-set, AND the binary sprite-set images (PNGs) the
+ * sprite-sets reference, base64-encoded inline in the JSON wire
+ * frame. `data:` / `http(s)://` / `file://` URL refs (e.g. the
+ * engine-bundled scientist starter, which uses an inline data
+ * URL) skip the on-disk read — both peers already have the value
+ * via the bundled JSON itself.
+ *
+ * Pre-2026-06-01 the snapshot was schema-only and assumed both
+ * peers shared a baseline asset bundle. For LAN Pair-Editing the
+ * assumption is wrong — the joiner has no local copy of the host's
+ * project — so the missing PNGs surfaced as: (a) silent fetch
+ * failures inside Excalibur's `ImageSource`, (b) libxml2
+ * `Entity: line 14: parser error : Extra content at the end of the
+ * document` noise on stderr (GdkPixbuf's format-detector retried
+ * the 404 body as SVG, librsvg parsed it as XML, found JSON), and
+ * (c) a hung joiner UI with no visible toast.
  *
  * Why a separate snapshot type instead of "open the project's
  * folder over the wire"? The wire shape is a plain object with
@@ -28,6 +37,9 @@ import { GameProjectFormat } from '../format/GameProjectFormat.ts'
 import { MapFormat } from '../format/MapFormat.ts'
 import { SpriteSetFormat } from '../format/SpriteSetFormat.ts'
 import type { GameProjectData, MapData, SpriteSetData } from '../types/index.ts'
+import { base64ToBytes, bytesToBase64 } from '../utils/base64.ts'
+import { loadBinaryFile } from '../utils/file.ts'
+import { isAbsoluteOrUrl, joinPaths } from '../utils/url.ts'
 
 export const PROJECT_SNAPSHOT_VERSION = 1
 
@@ -50,24 +62,33 @@ export interface ProjectSnapshot {
    */
   maps: Array<{ path: string; data: MapData }>
   /**
-   * Per-sprite-set JSON payload keyed by the `path` field of the
-   * matching `SpriteSetReference` inside `project.spriteSets[]`.
-   * Caller writes each `data` to `${targetDir}/${path}`.
+   * Per-sprite-set entry: the JSON descriptor plus any binary
+   * images the descriptor references (typically the single PNG
+   * pointed at by `data.image.path`).
+   *
+   * `path` — the sprite-set JSON's location relative to the
+   * project root, matching the `SpriteSetReference.path` field
+   * inside `project.spriteSets[]`. Caller writes `data` to
+   * `${targetDir}/${path}`.
+   *
+   * `images` — base64-encoded binaries. Each entry's `path` is
+   * the on-disk path RELATIVE TO THE SPRITE-SET JSON's directory
+   * (matching `data.image.path` verbatim) so the receiver can
+   * reconstruct the same on-disk layout. Empty / absent for
+   * sprite-sets whose `data.image.path` is a `data:`/URL ref —
+   * those carry the bytes inline in the JSON itself and don't
+   * need a separate transfer.
    *
    * Optional for wire-format backwards compatibility — older hosts
-   * (pre-2026-06-01) didn't include sprite-sets in the snapshot,
-   * which left the joiner's sandbox project broken because every
-   * map references sprite-sets that the joiner couldn't load
-   * (`/spritesets/<id>.json` 404 on disk). 2026-06-01 hand-test:
-   *
-   *   [Error]: Failed to load sprite set: FetchError: request to
-   *            file:///…/shared/<roomId>/spritesets/<id>.json failed,
-   *            reason: GLib.FileError: … nicht gefunden
-   *
-   * The receiver path treats missing `spriteSets` as `[]` for
-   * old-host compatibility; the writer path always emits it.
+   * (pre-2026-06-01) didn't include sprite-sets at all, then
+   * didn't include images. A new receiver treats both missing
+   * fields as empty arrays.
    */
-  spriteSets: Array<{ path: string; data: SpriteSetData }>
+  spriteSets: Array<{
+    path: string
+    data: SpriteSetData
+    images?: Array<{ path: string; base64: string }>
+  }>
 }
 
 /**
@@ -81,7 +102,7 @@ export interface ProjectSnapshot {
  * before mutating (or `JSON.parse(JSON.stringify(...))` if a true
  * snapshot semantics is needed).
  */
-export function captureProjectSnapshot(engine: Engine): ProjectSnapshot | null {
+export async function captureProjectSnapshot(engine: Engine): Promise<ProjectSnapshot | null> {
   const resource = engine.gameProjectResource
   if (!resource) return null
   const project = resource.data
@@ -102,19 +123,27 @@ export function captureProjectSnapshot(engine: Engine): ProjectSnapshot | null {
     maps.push({ path: ref.path, data: mapResource.mapData })
   }
 
-  // Per-spriteset JSON. Every entry from `project.spriteSets[]`
-  // MUST resolve through the resource map — a missing entry means
-  // the host hasn't loaded its own project yet (sprite-sets are
-  // loaded eagerly at project-open time) and shipping the snapshot
-  // would leave the joiner with broken sandbox references. The
-  // 2026-06-01 hand-test failed exactly here: snapshot arrived
-  // without sprite-sets, joiner's `loadProject` choked on a
-  // `FetchError: spritesets/<id>.json … nicht gefunden`.
+  // Per-spriteset JSON + binary images. Every entry from
+  // `project.spriteSets[]` MUST resolve through the resource map
+  // — a missing entry means the host hasn't loaded its own
+  // project yet (sprite-sets are loaded eagerly at project-open
+  // time) and shipping the snapshot would leave the joiner with
+  // broken sandbox references.
+  //
+  // For each loaded sprite-set we ALSO read the referenced PNG
+  // off disk and base64-encode it inline. Without the binary the
+  // joiner's sandbox has the JSON descriptor but no pixels — the
+  // 2026-06-01 hand-test surfaced this as a hang on the joiner
+  // (Excalibur's `ImageSource.load()` plus GdkPixbuf's SVG-fallback
+  // path on the 404 body).
+  //
+  // `data:`/`http(s)://`/`file://` URLs in `data.image.path` are
+  // skipped — the bytes are already inside the JSON (engine-
+  // bundled scientist sprite via data URL) or reachable over the
+  // network from any peer.
   //
   // `engine.gameProjectResource.spriteSets` is the in-memory
-  // Map<id, SpriteSetResource> populated by `loadProject`. Use
-  // its sync access (the `getSpriteSet(id)` async wrapper exists
-  // for callers that want a Promise — we already have the Map).
+  // Map<id, SpriteSetResource> populated by `loadProject`.
   const spriteSets: ProjectSnapshot['spriteSets'] = []
   for (const ref of project.spriteSets) {
     const spriteSetResource = resource.spriteSets.get(ref.id)
@@ -124,7 +153,27 @@ export function captureProjectSnapshot(engine: Engine): ProjectSnapshot | null {
           `call engine.loadProject(...) first or check the project file for stale references.`,
       )
     }
-    spriteSets.push({ path: ref.path, data: spriteSetResource.data })
+    const data = spriteSetResource.data
+    const images: Array<{ path: string; base64: string }> = []
+    if (data.image && !isAbsoluteOrUrl(data.image.path)) {
+      const imageDiskPath = joinPaths(spriteSetResource.imageBasePath, data.image.path)
+      try {
+        const bytes = await loadBinaryFile(imageDiskPath)
+        images.push({ path: data.image.path, base64: bytesToBase64(bytes) })
+      } catch (err) {
+        // Failure here is fatal for the snapshot — the joiner cannot
+        // render this sprite-set without the bytes. Surface a typed
+        // error so the host-side `respondToRequest` can decline the
+        // request cleanly (timeout on the joiner) rather than ship
+        // a half-state snapshot.
+        const msg = err instanceof Error ? err.message : String(err)
+        throw new Error(
+          `captureProjectSnapshot: failed to read sprite-set image "${imageDiskPath}" ` +
+            `for sprite-set "${ref.id}": ${msg}`,
+        )
+      }
+    }
+    spriteSets.push({ path: ref.path, data, images })
   }
 
   return {
@@ -268,6 +317,31 @@ export function parseProjectSnapshot(raw: string): ProjectSnapshot {
         throw new Error('parseProjectSnapshot: malformed spriteSets entry')
       }
       assertSafeRelativePath(s.path, `spriteSets[].path`)
+      // Binary images: optional. Validate shape + path safety + that
+      // base64 looks like base64 (cheap surface check — full decode
+      // happens at apply time). Receiver-side strictness keeps a
+      // malicious or buggy host from smuggling absolute paths or
+      // non-base64 garbage through.
+      if (s.images === undefined) {
+        s.images = []
+      } else if (!Array.isArray(s.images)) {
+        throw new Error('parseProjectSnapshot: spriteSets[].images must be an array (or omitted)')
+      } else {
+        for (const img of s.images) {
+          if (!img || typeof img !== 'object' || typeof img.path !== 'string' || typeof img.base64 !== 'string') {
+            throw new Error('parseProjectSnapshot: malformed spriteSets[].images entry')
+          }
+          assertSafeRelativePath(img.path, `spriteSets[].images[].path`)
+          // base64 alphabet check — RFC 4648 standard `[A-Za-z0-9+/=]`.
+          // An empty string is allowed (corner case: a zero-byte
+          // image), but any other invalid character fails fast.
+          if (img.base64.length > 0 && !/^[A-Za-z0-9+/=]+$/.test(img.base64)) {
+            throw new Error(
+              `parseProjectSnapshot: spriteSets[].images[].base64 contains non-base64 characters`,
+            )
+          }
+        }
+      }
     }
   }
   return obj as ProjectSnapshot
@@ -281,12 +355,43 @@ export function parseProjectSnapshot(raw: string): ProjectSnapshot {
 export type SnapshotWriteFile = (absolutePath: string, contents: string) => Promise<void>
 
 /**
+ * Function the caller supplies for writing a binary file. Used by
+ * the sprite-set image transfer path — applyProjectSnapshot
+ * decodes the base64 payload and hands the raw bytes here. Caller
+ * is responsible for creating parent directories.
+ *
+ * Optional on {@link applyProjectSnapshot}: a snapshot with no
+ * `images` entries (older host, or all sprite-sets use
+ * `data:`/URL refs) can be applied with text-only writers. When
+ * `images` ARE present and `writeBinaryFile` is omitted,
+ * applyProjectSnapshot throws — silent skip would leave the
+ * joiner with the same missing-PNG state that motivated this
+ * field in the first place.
+ */
+export type SnapshotWriteBinaryFile = (absolutePath: string, bytes: Uint8Array) => Promise<void>
+
+/**
  * Path-joiner the caller supplies. Decoupled from a specific I/O
  * binding so this module stays platform-agnostic — the maker (GJS)
  * passes `Gio.File`-based composition; tests pass a POSIX
  * stringifier.
  */
 export type SnapshotPathJoin = (...segments: string[]) => string
+
+/**
+ * Path-dirname the caller supplies. Used to resolve a sprite-set
+ * image's on-disk location: the image's `path` field is relative
+ * to the sprite-set JSON's directory, so we need `dirname(spriteSetPath)`
+ * plus `image.path` to get the absolute target. Default
+ * implementation strips the last `/`-separated segment — sufficient
+ * for the snapshot's normalised wire paths (always `/`).
+ */
+export type SnapshotPathDirname = (path: string) => string
+
+function defaultDirname(path: string): string {
+  const idx = path.replace(/\\/g, '/').lastIndexOf('/')
+  return idx === -1 ? '' : path.slice(0, idx)
+}
 
 /**
  * Write every file in the snapshot to `targetDir`. Mutates nothing
@@ -310,6 +415,8 @@ export async function applyProjectSnapshot(
   targetDir: string,
   writeFile: SnapshotWriteFile,
   joinPath: SnapshotPathJoin,
+  writeBinaryFile?: SnapshotWriteBinaryFile,
+  dirname: SnapshotPathDirname = defaultDirname,
 ): Promise<void> {
   // Pre-flight: the snapshot may have been constructed locally
   // (parseProjectSnapshot wouldn't have run), so re-assert every
@@ -320,6 +427,18 @@ export async function applyProjectSnapshot(
   }
   for (const entry of snapshot.spriteSets ?? []) {
     assertSafeRelativePath(entry.path, 'spriteSets[].path')
+    for (const img of entry.images ?? []) {
+      assertSafeRelativePath(img.path, 'spriteSets[].images[].path')
+    }
+  }
+  // Fail fast if the snapshot carries binary payloads but no
+  // binary writer was provided — silently skipping would
+  // reproduce the pre-fix "joiner has JSON but no PNG" bug.
+  const needsBinary = (snapshot.spriteSets ?? []).some((s) => (s.images ?? []).length > 0)
+  if (needsBinary && !writeBinaryFile) {
+    throw new Error(
+      'applyProjectSnapshot: snapshot has binary images but no writeBinaryFile callback was supplied',
+    )
   }
 
   // Project descriptor first — it's the entry point the engine
@@ -347,6 +466,24 @@ export async function applyProjectSnapshot(
     const spriteSetPath = joinPath(targetDir, entry.path)
     assertStaysInside(targetDir, spriteSetPath, `spriteSets[${entry.path}]`)
     await writeFile(spriteSetPath, SpriteSetFormat.serialize(entry.data))
+
+    // Binary images sit alongside the sprite-set JSON; the path
+    // recorded in `images[].path` is RELATIVE to the JSON's
+    // directory (mirrors `data.image.path`), so join with the
+    // JSON's dirname rather than `targetDir` directly.
+    const spriteSetDir = dirname(spriteSetPath)
+    for (const img of entry.images ?? []) {
+      const imagePath = joinPath(spriteSetDir, img.path)
+      assertStaysInside(targetDir, imagePath, `spriteSets[${entry.path}].images[${img.path}]`)
+      // base64 decode happens at apply time; parseProjectSnapshot
+      // already validated the alphabet, but a base64 with the
+      // right characters can still mis-decode (e.g. wrong padding)
+      // — let any throw bubble up so the joiner aborts the open.
+      const bytes = base64ToBytes(img.base64)
+      // The needsBinary precheck above guarantees writeBinaryFile
+      // is defined when images.length > 0.
+      await writeBinaryFile!(imagePath, bytes)
+    }
   }
 }
 

--- a/packages/engine/src/sync/snapshot-exchange.spec.ts
+++ b/packages/engine/src/sync/snapshot-exchange.spec.ts
@@ -68,7 +68,7 @@ const FAKE_SNAPSHOT: ProjectSnapshot = {
 function exchangeFor(
   peer: import('./peer-session.ts').PeerSession,
   peerId: string,
-  captureSnapshot: () => ProjectSnapshot | null,
+  captureSnapshot: () => ProjectSnapshot | null | Promise<ProjectSnapshot | null>,
 ): SnapshotExchange {
   const exchange = new SnapshotExchange({
     peerId,
@@ -426,6 +426,90 @@ export default async () => {
         // Single chunk: totalChunks === 1
         expect(chunks.length).toBe(1)
         expect((chunks[0] as { payload: { totalChunks: number } }).payload.totalChunks).toBe(1)
+
+        hostExchange.dispose()
+        joinerExchange.dispose()
+      } finally {
+        sessions.close()
+      }
+    })
+  })
+
+  await describe('SnapshotExchange — async captureSnapshot (binary asset path)', async () => {
+    // captureSnapshot may return a Promise — covers the production
+    // path where the host reads sprite-set PNGs off disk + base64-
+    // encodes them inside `captureProjectSnapshot`. The host's
+    // chunking + send wiring must wait for the promise to resolve
+    // before any wire frames go out.
+
+    await it('host awaits an async capture before chunking + sending', async () => {
+      const sessions = await createConnectedSessionPair()
+      try {
+        let captureCalls = 0
+        let resolvedFirst = false
+        const hostExchange = exchangeFor(sessions.host, 'host-async', async () => {
+          captureCalls++
+          // Yield to the microtask queue so the wire is provably
+          // empty before we resolve — a sync-only code path
+          // would send chunks before this `await` returns.
+          await Promise.resolve()
+          resolvedFirst = true
+          return FAKE_SNAPSHOT
+        })
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-async', () => null)
+
+        const received = await joinerExchange.request('room-async', 2_000)
+        expect(captureCalls).toBe(1)
+        expect(resolvedFirst).toBeTruthy()
+        expect(received.project.id).toBe('shared')
+
+        hostExchange.dispose()
+        joinerExchange.dispose()
+      } finally {
+        sessions.close()
+      }
+    })
+
+    await it('joiner times out when the host async captureSnapshot resolves to null', async () => {
+      const sessions = await createConnectedSessionPair()
+      try {
+        const hostExchange = exchangeFor(sessions.host, 'host-async-null', async () => null)
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-async-null', () => null)
+
+        let thrown: Error | null = null
+        try {
+          await joinerExchange.request('room-async-null', 50)
+        } catch (err) {
+          thrown = err as Error
+        }
+        expect(thrown?.message).toContain('timed out')
+
+        hostExchange.dispose()
+        joinerExchange.dispose()
+      } finally {
+        sessions.close()
+      }
+    })
+
+    await it('joiner times out when async captureSnapshot rejects', async () => {
+      // A real-world cause: the host's sprite-set PNG was deleted
+      // mid-session, so `loadBinaryFile` throws inside
+      // `captureProjectSnapshot`. SnapshotExchange swallows + logs
+      // — joiner sees a timeout rather than a half-snapshot.
+      const sessions = await createConnectedSessionPair()
+      try {
+        const hostExchange = exchangeFor(sessions.host, 'host-async-rej', async () => {
+          throw new Error('synthetic: image read failed')
+        })
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-async-rej', () => null)
+
+        let thrown: Error | null = null
+        try {
+          await joinerExchange.request('room-async-rej', 50)
+        } catch (err) {
+          thrown = err as Error
+        }
+        expect(thrown?.message).toContain('timed out')
 
         hostExchange.dispose()
         joinerExchange.dispose()

--- a/packages/engine/src/sync/snapshot-exchange.ts
+++ b/packages/engine/src/sync/snapshot-exchange.ts
@@ -80,10 +80,17 @@ export interface SnapshotExchangeOptions {
    * Producer for the local project state. Called when the peer
    * sends a snapshot-request. Return `null` to refuse (the
    * requester will see a timeout). Hosts pass
-   * `() => captureProjectSnapshot(engine)`; joiners typically
-   * return null (they don't host their own state).
+   * `() => captureProjectSnapshot(engine)` (async — reads
+   * sprite-set PNGs off disk for the binary-asset transfer);
+   * joiners typically return null synchronously (they don't host
+   * their own state).
+   *
+   * Supports both sync (`ProjectSnapshot | null`) and async
+   * (`Promise<ProjectSnapshot | null>`) return values so test
+   * callers can pass a literal without juggling promises while
+   * production callers can do I/O during capture.
    */
-  captureSnapshot: () => ProjectSnapshot | null
+  captureSnapshot: () => ProjectSnapshot | null | Promise<ProjectSnapshot | null>
   /**
    * Default timeout for an outgoing request, ms. Defaults to
    * 10 s. Tests pass a small value to cover the timeout path
@@ -121,7 +128,7 @@ interface ChunkBuffer {
 export class SnapshotExchange {
   private readonly peerId: string
   private readonly send: (op: SessionProtocolOp) => void
-  private readonly captureSnapshot: () => ProjectSnapshot | null
+  private readonly captureSnapshot: () => ProjectSnapshot | null | Promise<ProjectSnapshot | null>
   private readonly defaultTimeoutMs: number
   private readonly chunkSizeBytes: number
   private pending: PendingRequest | null = null
@@ -222,40 +229,62 @@ export class SnapshotExchange {
   }
 
   private respondToRequest(roomId: string): void {
-    const snapshot = this.captureSnapshot()
-    if (!snapshot) {
-      // Nothing to send — let the requester time out. Logging
-      // here would be noisy in tests; production callers can
-      // surface "host has no project loaded yet" through the UI
-      // layer via the awareness presence channel.
+    // Resolve `captureSnapshot` as a promise so the same code-path
+    // handles both sync (`return literal`) and async (`async () =>
+    // captureProjectSnapshot(engine)`) producers. Errors during
+    // capture (e.g. a sprite-set PNG missing on the host's disk)
+    // are logged but otherwise swallowed — the requester sees a
+    // request timeout and retries / surfaces an error. We don't
+    // have a wire-level "request rejected" op yet.
+    let resolved: Promise<ProjectSnapshot | null>
+    try {
+      const result = this.captureSnapshot()
+      resolved = Promise.resolve(result)
+    } catch (err) {
+      console.warn('[SnapshotExchange] captureSnapshot threw synchronously:', err)
       return
     }
-    // roomId echoed for diagnostics; not load-bearing in v1.
-    void roomId
+    void resolved
+      .then((snapshot) => {
+        if (this.disposed) return
+        if (!snapshot) {
+          // Nothing to send — let the requester time out. Logging
+          // here would be noisy in tests; production callers can
+          // surface "host has no project loaded yet" through the
+          // UI layer via the awareness presence channel.
+          return
+        }
+        // roomId echoed for diagnostics; not load-bearing in v1.
+        void roomId
 
-    // Serialise once, then chunk by configured byte boundary. We
-    // always chunk (even for tiny snapshots that fit in 1 chunk)
-    // so the receiver has a single code-path to handle. Sending
-    // as a sequence of `SNAPSHOT_CHUNK_KIND` ops keeps every wire
-    // frame below the WebRTC SCTP `max-message-size` ceiling —
-    // the 2026-06-01 hand-test bug was that single-message sends
-    // larger than 64 KiB were silently dropped by GStreamer
-    // webrtcbin (RFC 8841 default).
-    const json = JSON.stringify(snapshot)
-    const totalChunks = Math.max(1, Math.ceil(json.length / this.chunkSizeBytes))
-    for (let i = 0; i < totalChunks; i++) {
-      const start = i * this.chunkSizeBytes
-      const end = Math.min(start + this.chunkSizeBytes, json.length)
-      this.send(
-        createSnapshotChunkOp({
-          peerId: this.peerId,
-          seq: this.nextSeq(),
-          chunkIndex: i,
-          totalChunks,
-          data: json.slice(start, end),
-        }),
-      )
-    }
+        // Serialise once, then chunk by configured byte boundary.
+        // We always chunk (even for tiny snapshots that fit in 1
+        // chunk) so the receiver has a single code-path to
+        // handle. Sending as a sequence of `SNAPSHOT_CHUNK_KIND`
+        // ops keeps every wire frame below the WebRTC SCTP
+        // `max-message-size` ceiling — the 2026-06-01 hand-test
+        // bug was that single-message sends larger than 64 KiB
+        // were silently dropped by GStreamer webrtcbin (RFC 8841
+        // default).
+        const json = JSON.stringify(snapshot)
+        const totalChunks = Math.max(1, Math.ceil(json.length / this.chunkSizeBytes))
+        for (let i = 0; i < totalChunks; i++) {
+          const start = i * this.chunkSizeBytes
+          const end = Math.min(start + this.chunkSizeBytes, json.length)
+          this.send(
+            createSnapshotChunkOp({
+              peerId: this.peerId,
+              seq: this.nextSeq(),
+              chunkIndex: i,
+              totalChunks,
+              data: json.slice(start, end),
+            }),
+          )
+        }
+      })
+      .catch((err) => {
+        console.warn('[SnapshotExchange] captureSnapshot rejected:', err)
+      })
   }
 
   private handleChunk(payload: { chunkIndex: number; totalChunks: number; data: string }): void {

--- a/packages/engine/src/utils/base64.ts
+++ b/packages/engine/src/utils/base64.ts
@@ -1,0 +1,49 @@
+/**
+ * Base64 encode/decode helpers for the snapshot wire format.
+ *
+ * The {@link ProjectSnapshot} embeds binary sprite-set images
+ * (PNGs) as base64 strings so a remote joiner can rehydrate the
+ * full project without a local asset bundle. JSON has no native
+ * binary type — base64 is the standard escape hatch (RFC 4648).
+ *
+ * Why hand-rolled instead of `Buffer.from(...).toString('base64')`?
+ * The engine is cross-runtime — same code path runs under GJS,
+ * Node, and the browser. `btoa`/`atob` are available everywhere
+ * (`@gjsify/buffer` registers them on GJS); `Buffer` is Node-only.
+ *
+ * The 32 KiB chunking on the encode side avoids
+ * `RangeError: too many arguments` from `String.fromCharCode.apply`
+ * with very large arrays — for the 70 KiB sprite-sheets we ship
+ * today it's not strictly needed, but the call-site doesn't know
+ * the upper bound and we'd rather be safe than tune-by-asset.
+ */
+
+const CHUNK_SIZE = 32 * 1024
+
+/**
+ * Encode a Uint8Array as a standard base64 string (RFC 4648
+ * alphabet, `+/`, `=` padding). Output is suitable for embedding
+ * inside JSON.
+ */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += CHUNK_SIZE) {
+    const slice = bytes.subarray(i, Math.min(i + CHUNK_SIZE, bytes.length))
+    binary += String.fromCharCode.apply(null, slice as unknown as number[])
+  }
+  return btoa(binary)
+}
+
+/**
+ * Decode a base64 string back into a Uint8Array. Throws if the
+ * string contains characters outside the standard alphabet —
+ * callers feeding wire-data should wrap in try/catch and
+ * surface a `parseProjectSnapshot: malformed images entry`
+ * style error.
+ */
+export function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64)
+  const out = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i)
+  return out
+}

--- a/packages/engine/src/utils/file.ts
+++ b/packages/engine/src/utils/file.ts
@@ -36,3 +36,24 @@ export async function loadJsonFile<T>(path: string): Promise<T> {
   const content = await loadTextFile(path)
   return JSON.parse(content) as T
 }
+
+/**
+ * Load a binary file as a Uint8Array via fetch — used by the
+ * snapshot layer to embed sprite-set PNGs (and other binary
+ * assets) inside the wire snapshot so a joiner without a local
+ * project copy can still render the host's scene.
+ *
+ * Counterpart to {@link loadTextFile}: same `toFetchUrl`
+ * normalisation, same error semantics (throws on non-2xx). Uses
+ * `response.arrayBuffer()` so it stays cross-runtime (browser /
+ * Node / GJS via `@gjsify/fetch`).
+ */
+export async function loadBinaryFile(path: string): Promise<Uint8Array> {
+  const url = toFetchUrl(path)
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to load file: ${url} (${response.status})`)
+  }
+  const buf = await response.arrayBuffer()
+  return new Uint8Array(buf)
+}

--- a/packages/engine/src/utils/index.ts
+++ b/packages/engine/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './base64.ts'
 export * from './constants.ts'
 export * from './file.ts'
 export * from './session-state.ts'

--- a/packages/engine/src/utils/url.ts
+++ b/packages/engine/src/utils/url.ts
@@ -1,4 +1,20 @@
 /**
+ * Whether `path` is already a fully-qualified URL (or `data:` URL)
+ * that should NOT be re-joined against a base directory or read
+ * from local disk. Matches `http(s)://`, `file://`, `data:`, and
+ * `blob:` prefixes case-insensitively.
+ *
+ * Used by `SpriteSetResource.loadImages` to decide whether to
+ * `joinPaths` a sprite-set's `image.path` against its base
+ * directory, and by `captureProjectSnapshot` to skip the on-disk
+ * read for engine-bundled data-URL assets (e.g. the scientist
+ * starter sprite).
+ */
+export function isAbsoluteOrUrl(path: string): boolean {
+  return /^(https?|file|data|blob):/i.test(path)
+}
+
+/**
  * Extracts the directory path from a file path.
  * Validates input and handles edge cases properly.
  *


### PR DESCRIPTION
## Summary

- Snapshot now carries the sprite-set PNG bytes inline (base64) so the joiner's sandbox is renderable end-to-end, not just JSON-shaped
- `captureProjectSnapshot` becomes async + reads bytes via `loadBinaryFile`; `SnapshotExchange.captureSnapshot` accepts both sync and async producers
- New `writeBinaryFile` callback on `applyProjectSnapshot` (plus a `Gio.File.replace_contents`-backed sandbox writer); silent skip is refused with a typed error

## Why

PR #119 shipped the sprite-set JSON descriptors but not the PNGs they reference. 2026-06-01 hand-test:

```
[session-service] joiner: sandbox written to /home/jumplink/.local/share/pixelrpg-maker/shared/x9t58niz/game-project.json
Entity: line 14: parser error : Extra content at the end of the document
Entity: line 14: parser error : Extra content at the end of the document
```

The sandbox had `spritesets/water.json` pointing at `water.png` paths that 404'd. GdkPixbuf's format-detector retried each 404 body as SVG via librsvg, which printed the two `Entity: line 14` lines on stderr (line 14 of `water.json` is benign JSON content). Excalibur's `ImageSource.load()` resolved silently with no texture, so the joiner UI hung at "sandbox written" with no toast.

## What changed

- `ProjectSnapshot.spriteSets[i]` gains an optional `images: Array<{ path, base64 }>` field. Receiver treats missing as `[]` for pre-2026-06-02 hosts
- `captureProjectSnapshot` is async; reads each sprite-set's referenced PNG (skipping `data:`/`http(s)://`/`file://` URLs — the engine-bundled scientist starter uses an inline data URL and needs no separate transfer)
- `parseProjectSnapshot` validates the images array, path-traversal rules, and base64 alphabet
- `applyProjectSnapshot` writes binaries via a new optional `writeBinaryFile` callback. When `images` are present and no binary writer is supplied, it throws — silent skip would resurrect this exact bug
- `@gjsify/file-io` gets `writeBinaryFile(path, bytes)`; `writeSnapshotToSandbox` wires it
- New `utils/base64.ts` (cross-runtime `bytesToBase64` / `base64ToBytes` via `btoa`/`atob`); new `utils/file.ts:loadBinaryFile` mirrors `loadTextFile` with `response.arrayBuffer()`
- `isAbsoluteOrUrl` lifted from `SpriteSetResource.ts` into `utils/url.ts` so the snapshot layer can share it

## Tests

Engine: 365 → 368 passing.

New test cases:
- `parseProjectSnapshot — binary images validation`: accepts a sprite-set with one PNG, treats omitted `images` as `[]`, rejects non-array `images`, rejects malformed entries, rejects path-traversing image paths, rejects non-base64 payloads
- `applyProjectSnapshot — binary sprite-set images`: byte-faithful round-trip through `bytesToBase64` → JSON → parse → apply → `base64ToBytes`; throws when images are present but `writeBinaryFile` is omitted; doesn't call `writeBinaryFile` when no images present
- `SnapshotExchange — async captureSnapshot`: host awaits the promise before sending; joiner times out when capture rejects or resolves to null

## Test plan
- [x] `gjsify foreach build -v -t`
- [x] `gjsify foreach check -v -t`
- [x] `gjsify foreach test` — 368 engine + 387 maker + 48 + 736 = no regressions
- [ ] Hand-test: host shares "Pixel RPG Adventure", joiner connects on the same machine, joiner UI opens the synced project with the actual map rendered (not empty sprites)