### PR TITLE
fix(engine): broadcast tile-paint via COMMAND_EXECUTED for collab

### DIFF
--- a/packages/engine/src/systems/tile-editor.system.spec.ts
+++ b/packages/engine/src/systems/tile-editor.system.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression tests for the tile-editor system's collab-broadcast
+ * contract.
+ *
+ * The system's hot-path `dispatchCommand` applies a tile paint /
+ * erase to the active scene INLINE (skipping `Engine.executeCommand`
+ * to avoid the indirection on every click). It must mirror the
+ * engine's emit of `EngineEvent.COMMAND_EXECUTED` afterwards so the
+ * collab layer's `SessionController` can relay the paint to peers.
+ *
+ * 2026-06-01 hand-test: a host that hosted a session + painted tiles
+ * sent zero `op` frames on the WebRTC data channel — only awareness
+ * frames. The joiner saw the initial snapshot but no live edits.
+ * Trace: `dispatchCommand` was missing the COMMAND_EXECUTED emit.
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+import { Entity, EventEmitter, Scene } from 'excalibur'
+
+import type { Command } from '../commands/index.ts'
+import { TileEditorSystem } from './tile-editor.system.ts'
+import { EngineEvent, type EngineEventMap } from '../types/index.ts'
+
+/**
+ * Minimal duck-typed scene sufficient for `SessionState`. We only
+ * need an iterable `entities` collection plus a synchronous `add`
+ * that pushes onto it — SessionState reads the singleton entity by
+ * iterating + filtering by name. A full `new Scene()` from
+ * Excalibur would require an engine context the test doesn't need.
+ */
+function makeFakeScene(): Scene {
+  const entities: Entity[] = []
+  return {
+    entities,
+    add(entity: Entity) {
+      entities.push(entity)
+    },
+  } as unknown as Scene
+}
+
+function makeFakePaintCommand(): Command {
+  return {
+    kind: 'tile.paint',
+    label: 'paint',
+    payload: { tileMapId: 't', layerId: 'l', col: 1, row: 2, tile: 5 } as unknown,
+    // No-op apply/revert — dispatchCommand only needs the call to
+    // not throw; the actual paint side-effect is exercised by the
+    // command's own spec, not by this regression test.
+    apply: () => {},
+    revert: () => {},
+  } as unknown as Command
+}
+
+export default async () => {
+  await describe('TileEditorSystem.dispatchCommand — collab broadcast', async () => {
+    await it('emits COMMAND_EXECUTED so SessionController can relay the paint to peers', async () => {
+      const events = new EventEmitter<EngineEventMap>()
+      const broadcast: Command[] = []
+      events.on(EngineEvent.COMMAND_EXECUTED, ({ command }) => broadcast.push(command))
+
+      const system = new TileEditorSystem(events)
+      // Inject scene directly — initialize() needs a real engine
+      // + pointer wiring we don't care about for this contract test.
+      ;(system as unknown as { scene: Scene }).scene = makeFakeScene()
+
+      const cmd = makeFakePaintCommand()
+      ;(system as unknown as { dispatchCommand(c: Command): void }).dispatchCommand(cmd)
+
+      expect(broadcast.length).toBe(1)
+      expect(broadcast[0]).toBe(cmd)
+    })
+
+    await it('does not emit when the system has no active scene (defensive no-op)', async () => {
+      const events = new EventEmitter<EngineEventMap>()
+      const broadcast: Command[] = []
+      events.on(EngineEvent.COMMAND_EXECUTED, ({ command }) => broadcast.push(command))
+
+      const system = new TileEditorSystem(events)
+      // No scene assigned → dispatchCommand returns early.
+      ;(system as unknown as { dispatchCommand(c: Command): void }).dispatchCommand(makeFakePaintCommand())
+
+      expect(broadcast.length).toBe(0)
+    })
+
+    await it('emits exactly once per dispatch (not once per undo-stack branch)', async () => {
+      // The two branches of dispatchCommand ("first command" vs
+      // "stack already exists") run after the apply but before the
+      // emit. Verify both branches end with exactly one emit.
+      const events = new EventEmitter<EngineEventMap>()
+      const broadcast: Command[] = []
+      events.on(EngineEvent.COMMAND_EXECUTED, ({ command }) => broadcast.push(command))
+
+      const system = new TileEditorSystem(events)
+      ;(system as unknown as { scene: Scene }).scene = makeFakeScene()
+
+      ;(system as unknown as { dispatchCommand(c: Command): void }).dispatchCommand(makeFakePaintCommand())
+      ;(system as unknown as { dispatchCommand(c: Command): void }).dispatchCommand(makeFakePaintCommand())
+
+      expect(broadcast.length).toBe(2)
+    })
+  })
+}

--- a/packages/engine/src/systems/tile-editor.system.ts
+++ b/packages/engine/src/systems/tile-editor.system.ts
@@ -285,6 +285,14 @@ export class TileEditorSystem extends System {
    * works thanks to its same-instance fast path, but the explicit
    * branch is documentation about the intent and one fewer remove +
    * add to handle in the engine.
+   *
+   * Emits `COMMAND_EXECUTED` at the end so the collab layer's
+   * `SessionController` can relay the paint as an `Operation` to
+   * connected peers. Without this emit the paint applies locally
+   * but never reaches the wire — the 2026-06-01 hand-test bug
+   * (joiner sees the snapshot but no live edits) traced back to
+   * this missing call (the matching emit in `Engine.executeCommand`
+   * was correct; this inline hot-path forgot to mirror it).
    */
   private dispatchCommand(command: PaintTileCommand | EraseTileCommand): void {
     if (!this.scene) return
@@ -298,6 +306,7 @@ export class TileEditorSystem extends System {
     } else {
       SessionState.set(this.scene, new UndoStackComponent([command], 1))
     }
+    this.events.emit(EngineEvent.COMMAND_EXECUTED, { command })
   }
 
   private resolveLayerId(layerId: string | null): string | null {

--- a/packages/engine/src/test.mts
+++ b/packages/engine/src/test.mts
@@ -21,6 +21,7 @@ import projectSnapshotSuite from './sync/project-snapshot.spec.js'
 import sessionControllerSuite from './sync/session-controller.spec.js'
 import sessionProtocolSuite from './sync/session-protocol.spec.js'
 import snapshotExchangeSuite from './sync/snapshot-exchange.spec.js'
+import tileEditorSystemSuite from './systems/tile-editor.system.spec.js'
 import objectSystemSuite from './types/data/object-system.spec.js'
 import spriteSetUtilsSuite from './utils/sprite-set.utils.spec.js'
 import subscriptionRegistrySuite from './utils/subscription-registry.spec.js'
@@ -39,6 +40,7 @@ run({
   sessionControllerSuite,
   sessionProtocolSuite,
   snapshotExchangeSuite,
+  tileEditorSystemSuite,
   objectSystemSuite,
   spriteSetUtilsSuite,
   subscriptionRegistrySuite,


### PR DESCRIPTION
## Summary

- `TileEditorSystem.dispatchCommand` now emits `EngineEvent.COMMAND_EXECUTED` after applying + undo-stack-pushing, mirroring `Engine.executeCommand`
- Without this emit the host applied paints locally but never sent a single `op` frame on the WebRTC data channel — joiner saw the initial snapshot and then awareness-only forever
- 3 new regression tests pin the contract on the tile-editor side; the existing `collab-integration` spec already covered the wire side

## Why

`SessionController` subscribes to `engine.events.on(COMMAND_EXECUTED, ...)` to relay each local mutation as an `Operation` to peers. `Engine.executeCommand` emits this correctly. But `TileEditorSystem.dispatchCommand` was added later as an inline hot-path (one paint per click — skipping the engine-class indirection) and forgot to mirror the emit. Result: every paint in scene-editor was a no-op on the wire.

2026-06-01 hand-test, after the joiner had the synced project loaded, host log was:

```
[peer-session/host] → channel "op" send op (len=..., kind=__session/snapshot-chunk)
... 90+ snapshot-chunk lines ...
[peer-session/host] → channel "awareness" send awareness (len=121, kind=<no kind>)
... awareness-only from here on, no matter how many tiles the user paints ...
```

Joiner mirrored: snapshot-chunks then awareness-only.

## Fix

```ts
private dispatchCommand(command: PaintTileCommand | EraseTileCommand): void {
  if (!this.scene) return
  command.apply(this.scene)
  // ... undo-stack maintenance ...
  this.events.emit(EngineEvent.COMMAND_EXECUTED, { command })  // <-- added
}
```

## Tests

`packages/engine/src/systems/tile-editor.system.spec.ts` (new):

- emits `COMMAND_EXECUTED` after a successful dispatch (the regression itself)
- does not emit when no scene is active (defensive no-op path)
- emits exactly once per dispatch across both undo-stack branches (first-command-in-scene vs existing-stack)

Engine tests: 368 → 372 passing. `gjsify foreach build`/`check`/`test` all clean.

## Test plan
- [x] `gjsify foreach build -v -t`
- [x] `gjsify foreach test`
- [ ] Hand-test: host paints tile in scene-editor → joiner sees the paint live (and vice-versa)