### PR TITLE
fix(maker): defer joiner engine-attach to scene-editor open

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -279,26 +279,62 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
   }
 
   /**
-   * Load a shared-session sandbox project at the given path and,
-   * once the engine has booted, attach it to the active
-   * CollabSession. Triggered by the SessionService's
-   * `sandbox-project-ready` event.
+   * Load a shared-session sandbox project at the given path. Engine
+   * attachment is **deferred** — `_hydrateSceneEditor`'s post-
+   * `ensureForMap` hook (see {@link _maybeAttachEngineToSession})
+   * actually wires the `CollabSession` to the engine once the user
+   * navigates to a scene.
    *
-   * On failure the session stays in the `awaiting-engine` state —
-   * the user can leave the session via the existing controls.
+   * Triggered by the SessionService's `sandbox-project-ready` event.
+   *
+   * Why deferred? The atlas view loads BEFORE any scene-editor
+   * navigation, so `engineCtl.engine` is `null` at this point on the
+   * joiner's first session. Pre-fix code attempted to attach here
+   * and silently bailed when the engine was null — that left the
+   * `SessionController` un-attached, so the joiner's own paints
+   * never fired `COMMAND_EXECUTED`-driven `op` sends AND incoming
+   * `tile.paint` ops from the host had no `applyInbound` to route
+   * through. Bidirectional sync was structurally dead from the
+   * joiner's perspective, even when the wire transport worked.
+   *
+   * On failure (project-load throws) the session stays in the
+   * `awaiting-engine` state — the user can leave the session via
+   * the existing controls.
    */
   private async _loadSandboxProject(projectPath: string): Promise<void> {
     try {
       await this._loadProjectFromPath(projectPath)
-      const engine = this._engineCtl.engine?.excalibur
-      if (!engine) {
-        this._showToast(_('Sandbox project loaded but engine is not ready — try Play to open it.'))
-        return
-      }
-      this._sessionSvc?.attachEngineToCurrentSession(engine)
-      this._showToast(_('Joined shared session — editing the synced copy.'))
+      this._showToast(_('Joined shared session — open a scene to start editing.'))
     } catch (err) {
       this._showToast(_(`Could not open shared session: ${(err as Error).message}`))
+    }
+  }
+
+  /**
+   * Attach the active engine to the current `CollabSession` if (and
+   * only if) the session is waiting for one. Called from
+   * `_hydrateSceneEditor` immediately after `ensureForMap` resolves,
+   * which guarantees `_engineCtl.engine?.excalibur` is non-null.
+   *
+   * Idempotent / safe to call on every scene-editor entry:
+   *   - no session              → no-op (`_sessionSvc` is undefined or state ≠ awaiting-engine)
+   *   - host / already attached → no-op (state is `connected`, not `awaiting-engine`)
+   *   - joiner waiting          → attach + flip state to `connected`
+   *
+   * Failures are toasted but don't reset the session — the user can
+   * leave via the existing controls.
+   */
+  private _maybeAttachEngineToSession(): void {
+    if (!this._sessionSvc) return
+    if (this._sessionSvc.getState().kind !== 'awaiting-engine') return
+    const engine = this._engineCtl.engine?.excalibur
+    if (!engine) return
+    try {
+      this._sessionSvc.attachEngineToCurrentSession(engine)
+      this._showToast(_('Live editing — your changes sync with the host.'))
+    } catch (err) {
+      console.warn('[ApplicationWindow] attachEngineToCurrentSession failed:', err)
+      this._showToast(_('Could not start live sync — see logs.'))
     }
   }
 
@@ -799,6 +835,13 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     if (toolState) {
       this._engineCtl.engine?.setActiveTool(toolState.get_string()[0] as EditorTool)
     }
+
+    // If we joined a shared session before any scene was open, the
+    // engine was null at `_loadSandboxProject` time and the collab
+    // wiring was deferred. Now that `ensureForMap` has booted the
+    // engine, attach it so commands start flowing both ways.
+    // No-op when there's no awaiting-engine session.
+    this._maybeAttachEngineToSession()
 
     try {
       await this._scene_editor_view.populateFromProject(project, sceneId)


### PR DESCRIPTION
## Summary

- `_loadSandboxProject` no longer tries to attach an engine that doesn't exist yet (atlas-view load happens BEFORE the user opens scene-editor)
- New `_maybeAttachEngineToSession` runs after `ensureForMap` inside `_hydrateSceneEditor`, the first guaranteed moment the engine is non-null
- Idempotent — safe to call on every scene-editor entry; only attaches when the session is in `awaiting-engine` state

## Why

PR #121 confirmed the wire path now carries `tile.paint` ops correctly: 2026-06-01 hand-test logs showed `→ channel "op" send op (kind=tile.paint)` from the host and matching `← channel "op" recv frame (kind=tile.paint)` on the joiner. But the joiner's UI didn't reflect the host's paints, AND joiner-side paints never produced any wire send.

Trace: `_loadSandboxProject` fires on `sandbox-project-ready`, right after the snapshot lands on disk. At that point the user is still on the atlas view — `engineCtl.engine?.excalibur` is `null`, so the old code silently bailed:

```ts
const engine = this._engineCtl.engine?.excalibur
if (!engine) {
  this._showToast(_('Sandbox project loaded but engine is not ready — try Play to open it.'))
  return   // <-- attach never happens
}
this._sessionSvc?.attachEngineToCurrentSession(engine)
```

Without the attach, `CollabSession` never builds a `SessionController`, so the joiner is fully unwired from the engine event bus:
- Joiner paint → `COMMAND_EXECUTED` fires with no listener → no `peer.sendOp(tile.paint)` → host never sees joiner edits
- Host paint → arrives at joiner's peer-session, delivered to the listener set; but only `SnapshotExchange` is a listener (and it ignores non-session-protocol ops) → joiner doesn't paint the host's change either

Bidirectional sync was structurally dead from the joiner's perspective, even though the wire transport, signalling, snapshot transfer, and binary-asset embedding all worked.

## Fix

Split the two responsibilities:

1. `_loadSandboxProject` only loads the project (atlas view) + toasts "open a scene to start editing"
2. New `_maybeAttachEngineToSession` runs after `ensureForMap` inside `_hydrateSceneEditor` — first guaranteed moment the engine is non-null

The helper is idempotent: no-op when there's no session, no-op when already attached (state is `connected`), attach when session is in `awaiting-engine`. Hosts and re-entries to scene-editor naturally hit the no-op paths.

## Tests

`gjsify foreach build` / `check` / `test` all clean — 199 + 188 + 22 + 26 + 372 + 372 = 1179 tests passing.

The existing `session-service-e2e` already covers the `attachEngineToCurrentSession` contract (state transition `awaiting-engine` → `connected`); this PR's deferred-call behaviour is UI-layer and not directly unit-testable without a GTK runtime — covered by hand-test instead.

## Test plan
- [x] `gjsify foreach build -v -t`
- [x] `gjsify foreach test`
- [ ] Hand-test:
  - Host shares + opens scene-editor + paints → joiner sees the paint live (after opening the same scene)
  - Joiner opens scene-editor → toast "Live editing — your changes sync with the host." appears
  - Joiner paints → host sees the paint live