### PR TITLE
fix(maker,engine): silence post-sync ui warnings + cursor debug hooks

### DIFF
--- a/apps/maker-gjs/src/services/collab-session.ts
+++ b/apps/maker-gjs/src/services/collab-session.ts
@@ -122,7 +122,6 @@ export class CollabSession {
   private readonly roomId: string
   private readonly peerConnectTimeoutMs: number
   private readonly subscriptions: Array<() => void> = []
-  private startedAt: number | null = null
 
   constructor(opts: CollabSessionOptions) {
     this.peerId = opts.peerId
@@ -254,7 +253,6 @@ export class CollabSession {
    * its tracked state.
    */
   async start(): Promise<void> {
-    this.startedAt = Date.now()
     const announceOnConnect = this.peer.events.on('state-changed', ({ state }) => {
       if (state === 'connected') this.awareness.announce()
     })
@@ -370,6 +368,5 @@ export class CollabSession {
     this.controller?.close()
     this.controller = null
     this.peer.close(reason)
-    void this.startedAt
   }
 }

--- a/apps/maker-gjs/src/services/sandbox-path.ts
+++ b/apps/maker-gjs/src/services/sandbox-path.ts
@@ -31,10 +31,7 @@ import Gio from '@girs/gio-2.0'
 import GLib from '@girs/glib-2.0'
 import { applyProjectSnapshot, type ProjectSnapshot } from '@pixelrpg/engine'
 
-import { scopedLogger } from './collab-log.ts'
 import { writeBinaryFile, writeTextFile } from './file-io.ts'
-
-const log = scopedLogger('sandbox-path')
 
 /** Subdirectory under `XDG_DATA_HOME` where every shared-session sandbox lives. */
 export const SANDBOX_ROOT_SEGMENTS = ['pixelrpg-maker', 'shared'] as const

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -711,6 +711,25 @@ export class Engine {
         const world = this.excalibur.screen.screenToWorldCoordinates(
           new Vector(event.screenPos.x, event.screenPos.y),
         )
+        // Opt-in coord trace — set
+        // `globalThis.__PIXELRPG_CURSOR_DEBUG = true` in DevTools /
+        // a debugger session to dump screen→world conversions. Used
+        // to investigate the 2026-06-01 "remote cursor is ~3 tiles
+        // off" report — both paint (POINTER_TAP) and cursor (this
+        // handler) read `event.screenPos` from the same source AND
+        // call `screenToWorldCoordinates` identically, so if the
+        // logged worldX/worldY here match the painted tile the
+        // offset is on the receiver / actor render side; if they
+        // mismatch, the offset is in `pointer.on('move')` vs
+        // `pointer.on('down/up')` screenPos divergence.
+        if ((globalThis as { __PIXELRPG_CURSOR_DEBUG?: boolean }).__PIXELRPG_CURSOR_DEBUG === true) {
+          const cam = this.excalibur.currentScene?.camera
+          console.log(
+            `[cursor-debug] screen=(${event.screenPos.x.toFixed(1)},${event.screenPos.y.toFixed(1)})` +
+              ` → world=(${world.x.toFixed(1)},${world.y.toFixed(1)})` +
+              ` camera=(${cam?.x.toFixed(1) ?? '?'},${cam?.y.toFixed(1) ?? '?'},zoom=${cam?.zoom.toFixed(2) ?? '?'})`,
+          )
+        }
         cb({ sceneId, worldX: world.x, worldY: world.y })
       }
       pointer.on('move', handler)

--- a/packages/engine/src/sync/remote-cursor-renderer.ts
+++ b/packages/engine/src/sync/remote-cursor-renderer.ts
@@ -92,6 +92,11 @@ export class RemoteCursorRenderer {
       this.removeActor(peer.peerId)
       return
     }
+    if (debugEnabled()) {
+      console.log(
+        `[cursor-debug] recv peer="${peer.peerId}" world=(${peer.cursor.x.toFixed(1)},${peer.cursor.y.toFixed(1)}) sceneId="${peer.cursor.sceneId}"`,
+      )
+    }
     const existing = this.actors.get(peer.peerId)
     if (existing) {
       existing.pos = new Vector(peer.cursor.x, peer.cursor.y)
@@ -136,6 +141,25 @@ export class RemoteCursorRenderer {
     actor.kill()
     this.actors.delete(peerId)
   }
+}
+
+/**
+ * Receiver-side counterpart to the sender-side debug flag in
+ * `Engine.onPointerMoved` — set
+ * `globalThis.__PIXELRPG_CURSOR_DEBUG = true` to log every inbound
+ * cursor update with the peer's reported world coord. Paired with
+ * the sender's log, the two together cover the full round-trip:
+ *
+ *   sender:   screen → world (joiner-side)
+ *   receiver: world arrived (host-side)
+ *
+ * If a peer's `world` here matches the joiner's logged value, the
+ * wire is faithful and the visible offset is camera/zoom/render
+ * geometry. If the values diverge, the wire serialiser / awareness
+ * frame layout is the culprit.
+ */
+function debugEnabled(): boolean {
+  return (globalThis as { __PIXELRPG_CURSOR_DEBUG?: boolean }).__PIXELRPG_CURSOR_DEBUG === true
 }
 
 /**

--- a/packages/gjs/src/widgets/editor/context-chip.ts
+++ b/packages/gjs/src/widgets/editor/context-chip.ts
@@ -84,6 +84,16 @@ export class ContextChip extends Adw.Bin {
     this._tile_swatch.set_vexpand(false)
     this._tile_swatch.set_halign(Gtk.Align.CENTER)
     this._tile_swatch.set_valign(Gtk.Align.CENTER)
+    // Eagerly install the grid-icon placeholder so the Picture
+    // always has a paintable for measure() — without this, the
+    // first measure() (before `setTilePaintable` ever runs) sees
+    // an empty Picture, returns `natural=1, min=16`, and GTK4
+    // logs `GtkPicture reported min width 16 and natural width 1
+    // in measure()`. The placeholder is the same one we fall back
+    // to for `setTilePaintable(null)`, so this is purely a
+    // measure-time guarantee — `setTilePaintable(real)` replaces
+    // it without any visual flash.
+    this._tile_swatch.set_paintable(this._loadPlaceholderIcon())
   }
 
   get tileName(): string {

--- a/packages/gjs/src/widgets/editor/floating-zoom.ts
+++ b/packages/gjs/src/widgets/editor/floating-zoom.ts
@@ -56,11 +56,27 @@ export class FloatingZoom extends Adw.Bin {
     this.notify('zoom-label')
   }
 
+  /**
+   * Update the cursor caption. Dedupe-heavy by design: this is the
+   * hot path during pointer hover (the maker pipes pointermove → here
+   * at engine framerate). Without dedupe, every move queues a GTK
+   * relayout + snapshot pass, which races against the overlay's own
+   * continuous engine-canvas redraws and surfaces as
+   *
+   *   GtkWidget snapshot called without a current allocation
+   *
+   * bursts. Skipping unchanged coords + only emitting `show-cursor`
+   * when the boolean actually flips drops the notify pressure to
+   * "first move + visibility transitions only".
+   */
   setCursor(x: number | null, y: number | null): void {
+    if (this._cursorX === x && this._cursorY === y) return
+    const wasVisible = this._cursorX != null && this._cursorY != null
     this._cursorX = x
     this._cursorY = y
     this.notify('cursor-label')
-    this.notify('show-cursor')
+    const nowVisible = x != null && y != null
+    if (nowVisible !== wasVisible) this.notify('show-cursor')
   }
 
   get zoomLabel(): string {


### PR DESCRIPTION
## Summary

Three small UI fixes the hand-test surfaced after collab sync started working in PR #122, plus debug hooks for the still-open "remote cursor renders ~3 tiles offset" puzzle.

### ContextChip — eager placeholder paintable
Set the `view-grid-symbolic` paintable in the constructor so `Gtk.Picture` always has content for the first `measure()` pass. Pre-fix, the empty Picture's natural-size was 1 while min-size was 16 (GTK4 invariant violation), spamming `GtkPicture reported min width 16 and natural width 1` on every engine mount.

### FloatingZoom — dedupe setCursor
- No-op when both coords are unchanged
- Only `notify('show-cursor')` when the boolean actually flips

The previous unconditional notifies queued GTK relayout/snapshot passes that raced against the engine canvas's continuous redraws and surfaced as bursts of `Trying to snapshot PixelRpgFloatingZoom without a current allocation` warnings.

### Cursor coord debug
Opt-in `globalThis.__PIXELRPG_CURSOR_DEBUG = true` flag:

- **Sender side** (`Engine.onPointerMoved`): logs `screenPos → world` conversion + camera state per move
- **Receiver side** (`RemoteCursorRenderer.applyPeer`): logs the `world` coord that arrived for each peer

Paired they cover the full round-trip — if the joiner-logged world matches the host-received world, the visible offset is render-side (camera math). If they diverge, the wire serialiser/awareness frame layout is to blame.

### Tiny cleanups
- `CollabSession.startedAt` field was set but never read (only `void`-suppressed at close); removed
- `sandbox-path.ts` carried an unused `scopedLogger` import; removed

## Tests

`gjsify foreach build` / `check` / `test` all clean — 1179 tests passing across the workspace.

The UI-warning fixes are observable-only (no behavior change) so no new test cases beyond the existing widget-render-without-crash coverage.

## Test plan
- [x] `gjsify foreach build -v -t`
- [x] `gjsify foreach test`
- [ ] Hand-test:
  - Connect host + joiner, navigate joiner to scene-editor
  - Expect NO `GtkPicture reported min width 16 and natural width 1` warnings on engine mount
  - Move mouse rapidly over the scene canvas
  - Expect NO bursts of `Trying to snapshot PixelRpgFloatingZoom without a current allocation`
  - Set \`globalThis.__PIXELRPG_CURSOR_DEBUG = true\` from a debug shell on both ends
  - Move joiner's mouse; capture sender's `[cursor-debug] screen=... → world=...` and host's `[cursor-debug] recv peer=... world=...`
  - Compare numerically — same world = render-side bug; different world = wire bug