### PR TITLE
fix(gjs): defensive vfunc_snapshot in FloatingZoom

### DIFF
--- a/packages/gjs/src/widgets/editor/floating-zoom.ts
+++ b/packages/gjs/src/widgets/editor/floating-zoom.ts
@@ -1,5 +1,6 @@
 import Adw from '@girs/adw-1'
 import GObject from '@girs/gobject-2.0'
+import type Gtk from '@girs/gtk-4.0'
 
 import Template from './floating-zoom.blp'
 
@@ -92,6 +93,31 @@ export class FloatingZoom extends Adw.Bin {
 
   get showCursor(): boolean {
     return this._cursorX != null && this._cursorY != null
+  }
+
+  /**
+   * Defensive snapshot guard.
+   *
+   * GTK4 emits `Trying to snapshot <widget> without a current
+   * allocation` when the compositor's snapshot pass reaches a
+   * widget whose `allocated_{width,height}` are both 0. For the
+   * FloatingZoom that happens in bursts coincident with engine-
+   * canvas redraws (60 FPS): the overlay walks its children for
+   * snapshot on every GLArea render tick, and for reasons that
+   * don't reproduce in isolation (suspected interaction between
+   * Gtk.WindowHandle's internal allocation state and the
+   * overlay's snapshot iterator) FloatingZoom is sometimes
+   * walked between its size-allocate and its first draw.
+   *
+   * Short-circuiting on zero allocation is semantically correct
+   * — a zero-sized widget renders nothing visible anyway — and
+   * silences the warning spam without affecting the widget's
+   * normal lifecycle. The next valid snapshot pass (after the
+   * next size-allocate) draws the widget as usual.
+   */
+  vfunc_snapshot(snapshot: Gtk.Snapshot): void {
+    if (this.get_allocated_width() === 0 && this.get_allocated_height() === 0) return
+    super.vfunc_snapshot(snapshot)
   }
 }
 


### PR DESCRIPTION
## Summary

PR #123's `setCursor`/`show-cursor` dedupe didn't silence the bursts of `Trying to snapshot PixelRpgFloatingZoom without a current allocation` warnings. Re-read of call-sites confirms `setCursor` is only invoked once per scene-load (`scene-editor-view.ts:228`) and `setZoom` is already deduped on exact-equality — so the notify pressure I was guarding against in PR #123 doesn't actually exist in production.

The real trigger is the engine canvas: `GLArea` queues a render ~60 FPS, the overlay walks its children for snapshot every render tick, and for reasons that don't reproduce in isolation (suspected `Gtk.WindowHandle` internal allocation state interacting with the overlay's snapshot iterator order) `FloatingZoom` is sometimes walked between its size-allocate and its first draw.

GTK4 emits the warning when both `allocated_width` and `allocated_height` are 0. Short-circuiting `vfunc_snapshot` on zero allocation is semantically correct — a zero-sized widget renders nothing visible — and silences the warning without affecting normal-lifecycle rendering. The next snapshot after the next size-allocate draws as usual.

## Why not just suppress the GTK warning?

Suppression via `g_log_set_handler` would hide ALL `Gtk-WARNING` messages, including ones that actually flag real bugs (the GtkPicture min/natural=1 we fixed in PR #123 was a real GTK4 invariant violation). The `vfunc_snapshot` guard is targeted — it only neutralises the snapshot path for THIS widget when its allocation is zero, which is provably a no-op visually.

## Why not on ContextChip + FloatingPlay too?

They sit in the same overlay stack but don't show the warning in the hand-test logs. Adding a speculative guard would mask future real bugs in those widgets. If they start showing the warning later, lifting the guard pattern to a shared mixin or `Adw.Bin` subclass is the right move.

## Tests

`gjsify foreach build` clean. The fix is a defensive snapshot guard; the existing widget rendering test suite (storybook) exercises the normal-allocation path, which is unchanged.

## Test plan
- [x] `gjsify foreach build -v -t`
- [x] `gjsify foreach check -v -t`
- [ ] Hand-test:
  - Connect host + joiner, navigate joiner to scene-editor
  - Move mouse for 30+ seconds over the canvas
  - Expect ZERO `Trying to snapshot PixelRpgFloatingZoom without a current allocation` warnings
  - Confirm the zoom OSD pill still renders correctly (zoom %, cursor coord "0, 0")