### PR TITLE
fix(engine,maker): live tile coords in floating-zoom osd

### DIFF
--- a/apps/maker-gjs/src/services/engine-controller.ts
+++ b/apps/maker-gjs/src/services/engine-controller.ts
@@ -41,6 +41,10 @@ export class EngineController {
   private _undoListener: ((state: { canUndo: boolean; canRedo: boolean }) => void) | null = null
   private _tilePickedHookAttached = false
   private _tilePickedListener: ((payload: TilePickedPayload) => void) | null = null
+  private _pointerTileHookAttached = false
+  private _pointerTileListener:
+    | ((payload: { sceneId: string; tileX: number; tileY: number }) => void)
+    | null = null
 
   constructor(private readonly slot: EngineSlot) {}
 
@@ -91,6 +95,20 @@ export class EngineController {
   }
 
   /**
+   * Register a listener fired once per pointer tile-transition over
+   * the active map. The host uses this to drive the floating-zoom
+   * OSD's coord readout (the label that reads e.g. `12, 7` next to
+   * the zoom buttons). Mirrors {@link onZoomChanged} — listener is
+   * stored once and re-attached lazily after each `ensureForMap`
+   * via {@link _attachPointerTileHook}.
+   */
+  onPointerTileChanged(
+    listener: (payload: { sceneId: string; tileX: number; tileY: number }) => void,
+  ): void {
+    this._pointerTileListener = listener
+  }
+
+  /**
    * Ensure the engine is alive, attached to the host slot, and has the
    * requested project + map loaded. Recreates the engine if the
    * cached wrapper has lost its Excalibur instance.
@@ -128,6 +146,7 @@ export class EngineController {
     this._attachZoomHook()
     this._attachUndoHook()
     this._attachTilePickedHook()
+    this._attachPointerTileHook()
   }
 
   /**
@@ -160,6 +179,7 @@ export class EngineController {
     this._zoomHookAttached = false
     this._undoHookAttached = false
     this._tilePickedHookAttached = false
+    this._pointerTileHookAttached = false
     // Drop the cached undo state on the host side too — without an
     // engine, both actions should be disabled regardless of what the
     // last loaded scene reported.
@@ -214,5 +234,12 @@ export class EngineController {
       this._tilePickedListener?.(payload)
     })
     this._tilePickedHookAttached = true
+  }
+
+  private _attachPointerTileHook(): void {
+    if (this._pointerTileHookAttached || !this._engine) return
+    this._pointerTileHookAttached = this._engine.onPointerTileChanged((payload) => {
+      this._pointerTileListener?.(payload)
+    })
   }
 }

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -140,6 +140,13 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     this._installActions()
     // Mirror engine-driven zoom (scroll-wheel + Ctrl+= etc.) into the OSD label.
     this._engineCtl.onZoomChanged((zoom) => this._scene_editor_view.setZoom(zoom))
+    // Same idea for the cursor coord readout on the OSD pill —
+    // each tile-crossing of the pointer over the canvas updates the
+    // `12, 7`-style label next to the zoom buttons. Engine handles
+    // screen → world → tile + per-tile dedupe; we just forward.
+    this._engineCtl.onPointerTileChanged(({ tileX, tileY }) => {
+      this._scene_editor_view.setCursorTile(tileX, tileY)
+    })
   }
 
   vfunc_map(): void {

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -225,7 +225,21 @@ export class SceneEditorView extends Adw.Bin {
     this._editor.contextChip.tileName = 'Tile 0'
     this._editor.contextChip.layerName = 'Background'
     this._editor.zoomOsd.setZoom(1)
-    this._editor.zoomOsd.setCursor(0, 0)
+    // Cursor is hidden until the first pointer-move arrives over the
+    // canvas — see `setCursorTile`. Calling `setCursor(0, 0)` here
+    // would stick a misleading `0, 0` readout on the OSD before the
+    // user has even moved the mouse.
+    this._editor.zoomOsd.setCursor(null, null)
+  }
+
+  /**
+   * Push the tile under the pointer to the floating-zoom OSD's coord
+   * label. Pass `null, null` to clear the readout (pointer left the
+   * canvas / map switched). The OSD widget itself dedupes consecutive
+   * identical values — this is just the forwarder.
+   */
+  setCursorTile(tileX: number | null, tileY: number | null): void {
+    this._editor.zoomOsd.setCursor(tileX, tileY)
   }
 
   /**

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -743,6 +743,69 @@ export class Engine {
     }
   }
 
+  /**
+   * Subscribe to the primary pointer's tile-space position over the
+   * active map.
+   *
+   * Like {@link onPointerMoved} but deduped at tile granularity: the
+   * callback fires only when the pointer crosses a tile boundary
+   * (`floor(world/tileSize)` change), which is the right cadence for
+   * the OSD coord readout — once per actual tile transition rather
+   * than once per pixel of motion.
+   *
+   * Payload carries `{ sceneId, tileX, tileY }`. `tileX/tileY` can be
+   * negative or beyond `mapData.columns/rows`: we do **not** clamp,
+   * because the editor sometimes wants to know the pointer is just
+   * past the map's edge (cursor-clearing on out-of-canvas is handled
+   * by the caller).
+   *
+   * Rebinds across `MAP_LOADED` (same lifecycle as
+   * {@link onPointerMoved}). Disposer detaches the pointer + map
+   * listeners.
+   */
+  onPointerTileChanged(
+    cb: (event: { sceneId: string; tileX: number; tileY: number }) => void,
+  ): () => void {
+    let disposeMove: (() => void) | null = null
+    let lastTileX: number | null = null
+    let lastTileY: number | null = null
+    const rebind = () => {
+      disposeMove?.()
+      disposeMove = null
+      lastTileX = null
+      lastTileY = null
+      const pointer = this.excalibur?.input?.pointers?.primary
+      if (!pointer) return
+      const handler = (event: { screenPos: { x: number; y: number } }) => {
+        const scene = this._activeMapScene()
+        if (!scene) return
+        const mapData = scene.mapResource?.mapData
+        if (!mapData) return
+        const sceneId = mapData.id
+        if (!sceneId) return
+        const tileWidth = mapData.tileWidth || 16
+        const tileHeight = mapData.tileHeight || 16
+        const world = this.excalibur.screen.screenToWorldCoordinates(
+          new Vector(event.screenPos.x, event.screenPos.y),
+        )
+        const tileX = Math.floor(world.x / tileWidth)
+        const tileY = Math.floor(world.y / tileHeight)
+        if (tileX === lastTileX && tileY === lastTileY) return
+        lastTileX = tileX
+        lastTileY = tileY
+        cb({ sceneId, tileX, tileY })
+      }
+      pointer.on('move', handler)
+      disposeMove = () => pointer.off('move', handler)
+    }
+    rebind()
+    const mapSub = this.events.on(EngineEvent.MAP_LOADED, () => rebind())
+    return () => {
+      disposeMove?.()
+      mapSub.close()
+    }
+  }
+
   private setStatus(status: EngineStatus): void {
     if (this.status === status) return
     this.logger.info(`Engine status changed from ${this.status} to ${status}`)

--- a/packages/gjs/src/widgets/editor/floating-zoom.blp
+++ b/packages/gjs/src/widgets/editor/floating-zoom.blp
@@ -51,6 +51,14 @@ template $PixelRpgFloatingZoom : Adw.Bin {
       styles ["caption", "numeric"]
       margin-start: 8;
       margin-end: 8;
+      // Pin width to "XXX, YYY" so the pill stays stable as the
+      // pointer crosses tiles and the digit count changes (`9, 9`
+      // → `10, 10` → `123, 45`). Without this the whole toolbar
+      // reflows per tile and visibly flickers; with `numeric`
+      // tabular figures + a fixed `width-chars` the label is a
+      // fixed-width slot.
+      width-chars: 8;
+      xalign: 0.0;
     }
   };
   }

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -277,6 +277,23 @@ export class Engine extends Adw.Bin {
   }
 
   /**
+   * Subscribe to tile-granular pointer-position changes. Fires once
+   * per tile crossing — see {@link ExcaliburEngine.onPointerTileChanged}
+   * for semantics. Returns `true` if subscribed, `false` if the engine
+   * hasn't started yet. Auto-cleaned alongside the other engine
+   * subscriptions.
+   */
+  public onPointerTileChanged(
+    cb: (event: { sceneId: string; tileX: number; tileY: number }) => void,
+  ): boolean {
+    const excalibur = this._excalibur
+    if (!excalibur) return false
+    const dispose = excalibur.onPointerTileChanged(cb)
+    this._excaliburSubscriptions.push({ close: dispose })
+    return true
+  }
+
+  /**
    * Repaint the Excalibur clear colour to match the current Adwaita
    * dark / light setting. Listens for `notify::dark` on the global
    * `Adw.StyleManager` so flipping the OS theme updates the canvas


### PR DESCRIPTION
## Summary

- `FloatingZoom` OSD's cursor label was stuck at `0, 0` because `scene-editor-view.ts:228` called `setCursor(0, 0)` once at scene-load and nothing ever updated it afterwards.
- New `Engine.onPointerTileChanged({ sceneId, tileX, tileY })` — same screen→world conversion as `onPointerMoved` plus `Math.floor(world/tileSize)` and per-tile dedupe (fires once per tile crossing, not once per pixel of motion).
- Forwarded through `EngineController.onPointerTileChanged` → `ApplicationWindow` constructor → `SceneEditorView.setCursorTile` → `FloatingZoom.setCursor`.
- Initial seed in `SceneEditorView.setScene` changed from `setCursor(0, 0)` to `setCursor(null, null)` — the OSD now hides the readout until the first real pointer-move arrives.

## Test plan

- [ ] `gjsify foreach check -v -t` clean ✅
- [ ] `gjsify foreach build -v -t` clean ✅
- [ ] `gjsify workspace @pixelrpg/engine test` clean (372 tests) ✅
- [ ] Hand-test: open a project, navigate to scene-editor, move mouse over canvas → OSD shows tile coords that update as you cross tiles; move off canvas → coords stay at the last visible tile (clearing on-leave is a future cherry).