### PR TITLE
fix(gjs): inscription for cursor label, drop dead snapshot guard

### DIFF
--- a/packages/gjs/src/widgets/editor/floating-zoom.blp
+++ b/packages/gjs/src/widgets/editor/floating-zoom.blp
@@ -45,19 +45,32 @@ template $PixelRpgFloatingZoom : Adw.Bin {
       visible: bind template.show-cursor;
     }
 
-    Gtk.Label cursor_label {
-      label: bind template.cursor-label;
+    // Inscription, NOT Label. `Gtk.Label.set_label()` internally
+    // calls `gtk_widget_queue_resize()` whenever the new text would
+    // change the natural measure — the resize bubbles up through
+    // every ancestor and briefly zeroes their allocations, which
+    // produces both
+    //
+    //   Gtk-WARNING: Trying to snapshot PixelRpgFloatingZoom
+    //   ... without a current allocation
+    //
+    // bursts in stdout AND a visible flicker of the whole OSD pill
+    // (the parent snapshot pass walks past the zero-allocated child
+    // before the next resize completes). `Gtk.Inscription` is GTK4's
+    // dedicated fixed-size text widget — its `measure()` returns
+    // `nat-chars` regardless of text content, so a text change
+    // doesn't invalidate parent layout. `width-chars` on Label
+    // alone isn't enough: Label still re-measures when text
+    // straddles `width-chars` boundaries, and `numeric` tabular
+    // figures only fix per-glyph widths inside the string.
+    Gtk.Inscription cursor_label {
+      text: bind template.cursor-label;
       visible: bind template.show-cursor;
       styles ["caption", "numeric"]
       margin-start: 8;
       margin-end: 8;
-      // Pin width to "XXX, YYY" so the pill stays stable as the
-      // pointer crosses tiles and the digit count changes (`9, 9`
-      // → `10, 10` → `123, 45`). Without this the whole toolbar
-      // reflows per tile and visibly flickers; with `numeric`
-      // tabular figures + a fixed `width-chars` the label is a
-      // fixed-width slot.
-      width-chars: 8;
+      min-chars: 8;
+      nat-chars: 8;
       xalign: 0.0;
     }
   };

--- a/packages/gjs/src/widgets/editor/floating-zoom.ts
+++ b/packages/gjs/src/widgets/editor/floating-zoom.ts
@@ -1,6 +1,5 @@
 import Adw from '@girs/adw-1'
 import GObject from '@girs/gobject-2.0'
-import type Gtk from '@girs/gtk-4.0'
 
 import Template from './floating-zoom.blp'
 
@@ -58,17 +57,14 @@ export class FloatingZoom extends Adw.Bin {
   }
 
   /**
-   * Update the cursor caption. Dedupe-heavy by design: this is the
-   * hot path during pointer hover (the maker pipes pointermove → here
-   * at engine framerate). Without dedupe, every move queues a GTK
-   * relayout + snapshot pass, which races against the overlay's own
-   * continuous engine-canvas redraws and surfaces as
-   *
-   *   GtkWidget snapshot called without a current allocation
-   *
-   * bursts. Skipping unchanged coords + only emitting `show-cursor`
-   * when the boolean actually flips drops the notify pressure to
-   * "first move + visibility transitions only".
+   * Update the cursor caption. The engine already dedupes at the
+   * tile-transition layer (`Engine.onPointerTileChanged`), so this
+   * normally fires only once per actual tile crossing. The
+   * widget-side dedupe is kept as belt-and-braces for static
+   * callers (e.g. stories) that don't go through the engine
+   * pipeline. The bound display widget is a `Gtk.Inscription` (not
+   * `Gtk.Label`) so even repeated text changes do not queue_resize
+   * the parent — see the comment in `floating-zoom.blp`.
    */
   setCursor(x: number | null, y: number | null): void {
     if (this._cursorX === x && this._cursorY === y) return
@@ -93,31 +89,6 @@ export class FloatingZoom extends Adw.Bin {
 
   get showCursor(): boolean {
     return this._cursorX != null && this._cursorY != null
-  }
-
-  /**
-   * Defensive snapshot guard.
-   *
-   * GTK4 emits `Trying to snapshot <widget> without a current
-   * allocation` when the compositor's snapshot pass reaches a
-   * widget whose `allocated_{width,height}` are both 0. For the
-   * FloatingZoom that happens in bursts coincident with engine-
-   * canvas redraws (60 FPS): the overlay walks its children for
-   * snapshot on every GLArea render tick, and for reasons that
-   * don't reproduce in isolation (suspected interaction between
-   * Gtk.WindowHandle's internal allocation state and the
-   * overlay's snapshot iterator) FloatingZoom is sometimes
-   * walked between its size-allocate and its first draw.
-   *
-   * Short-circuiting on zero allocation is semantically correct
-   * — a zero-sized widget renders nothing visible anyway — and
-   * silences the warning spam without affecting the widget's
-   * normal lifecycle. The next valid snapshot pass (after the
-   * next size-allocate) draws the widget as usual.
-   */
-  vfunc_snapshot(snapshot: Gtk.Snapshot): void {
-    if (this.get_allocated_width() === 0 && this.get_allocated_height() === 0) return
-    super.vfunc_snapshot(snapshot)
   }
 }
 


### PR DESCRIPTION
## Summary

Two symptoms remained after #125:

1. Visible flicker of the OSD pill on every tile crossing.
2. `Gtk-WARNING: Trying to snapshot PixelRpgFloatingZoom ... without a current allocation` bursts at pointer-move rate.

**Root cause:** \`Gtk.Label.set_label()\` calls \`gtk_widget_queue_resize()\` whenever the new text changes the natural measure. The resize bubbles through every ancestor, zeroes their allocations until the next size-allocate pass, and the overlay's snapshot iterator walks the (briefly zero-sized) FloatingZoom in between — GTK logs the warning + skips the draw (= flicker). \`width-chars\` on \`Gtk.Label\` is a minimum, not a max, so it doesn't fully suppress the resize.

**Fix:** \`Gtk.Inscription\` — GTK4's dedicated fixed-size text widget. Its \`measure()\` returns \`nat-chars\` regardless of text content, so a text change never queues a parent resize. Set \`min-chars: 8\` + \`nat-chars: 8\` to fit \`XXX, YYY\`.

Also removes the \`vfunc_snapshot\` defensive guard from #124. GTK emits the warning + returns early inside \`gtk_widget_snapshot()\` *before* calling the widget vfunc (see \`gtkwidget.c\`), so the override was dead code.

## Test plan

- [ ] \`gjsify foreach build -v -t\` ✅
- [ ] \`gjsify workspace @pixelrpg/gjs check\` ✅
- [ ] Hand-test: open a scene, move pointer rapidly across the canvas → coord label updates per tile crossing without OSD-pill flicker; stdout has zero \`Trying to snapshot PixelRpgFloatingZoom\` warnings.