### PR TITLE
fix(engine): late-join snapshot + peer undo replication (re-target to main)

### DIFF
--- a/packages/engine/src/commands/types.ts
+++ b/packages/engine/src/commands/types.ts
@@ -50,6 +50,16 @@ export interface Command<P = unknown> {
  * + payload + the host-assigned sequence number used by the future
  * collab op-log. For local-only solo editing, `peerId === 'self'`
  * and `seq` is locally monotonic.
+ *
+ * `direction` is the apply/revert discriminator used by the
+ * undo/redo replication path:
+ *   - `'apply'` (default when missing) — receiver runs `command.apply`.
+ *     Emitted by initial command execution + redo.
+ *   - `'revert'` — receiver runs `command.revert`. Emitted by undo.
+ *
+ * Older peers (pre-direction-field) sent operations without the
+ * field; receivers default to `'apply'` so existing wire traffic
+ * continues to work unchanged.
  */
 export interface Operation<K extends string = string, P = unknown> {
   kind: K
@@ -57,6 +67,7 @@ export interface Operation<K extends string = string, P = unknown> {
   peerId: string
   seq: number
   localId?: string
+  direction?: 'apply' | 'revert'
 }
 
 /**

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -328,6 +328,23 @@ export class Engine {
   }
 
   /**
+   * Revert a command that arrived from a remote peer (with
+   * `Operation.direction === 'revert'`). Mirrors
+   * {@link applyRemoteCommand}'s shape — same no-stack-push +
+   * no-emit guarantees — but routes to the command's `revert`
+   * method instead of `apply`. The originating peer already
+   * popped its local undo cursor and emitted `COMMAND_REVERTED`,
+   * which the collab `SessionController` relayed here.
+   *
+   * No-op when no `MapScene` is active.
+   */
+  applyRemoteRevert(command: Command): void {
+    const scene = this._activeMapScene()
+    if (!scene) return
+    command.revert(scene)
+  }
+
+  /**
    * Resolve `(scene, stack)` for the active map, or `null` when there
    * is no active map scene or no undo stack on it. Callers gate on a
    * single tuple lookup instead of duplicating the scene + component
@@ -345,6 +362,12 @@ export class Engine {
    * Undo the most recent applied command. Reverts the command, drops
    * the cursor by one, fires the `notifyMutation` so subscribers
    * refresh button enabled-states. No-op when `!canUndo()`.
+   *
+   * Emits `COMMAND_REVERTED` so the collab `SessionController` can
+   * relay the revert to peers (with `Operation.direction = 'revert'`),
+   * mirroring the local undo on every connected peer. Without this
+   * emit, a peer's undo of their own paint would leave the host
+   * showing the paint forever.
    */
   undo(): boolean {
     const ctx = this._undoContext()
@@ -354,12 +377,18 @@ export class Engine {
     command.revert(ctx.scene)
     ctx.stack.cursor -= 1
     SessionState.notifyMutation(ctx.scene, ctx.stack)
+    this.events.emit(EngineEvent.COMMAND_REVERTED, { command })
     return true
   }
 
   /**
    * Redo the next command in the stack (if any). Re-applies the
    * command and advances the cursor. No-op when `!canRedo()`.
+   *
+   * Emits `COMMAND_EXECUTED` so peers re-apply the command too.
+   * Bypasses `executeCommandOnScene` because the command is already
+   * in the local undo stack — we only need the apply + relay halves,
+   * not the stack push.
    */
   redo(): boolean {
     const ctx = this._undoContext()
@@ -369,6 +398,7 @@ export class Engine {
     command.apply(ctx.scene)
     ctx.stack.cursor += 1
     SessionState.notifyMutation(ctx.scene, ctx.stack)
+    this.events.emit(EngineEvent.COMMAND_EXECUTED, { command })
     return true
   }
 

--- a/packages/engine/src/resource/MapResource.ts
+++ b/packages/engine/src/resource/MapResource.ts
@@ -10,7 +10,7 @@ import {
   setInitialSprites,
   shadowCoordKey,
 } from '../services/map-editor-shadow.service.ts'
-import type { LayerData, LayerTier, MapData, MapResourceOptions } from '../types'
+import type { LayerData, LayerTier, MapData, MapResourceOptions, SpriteDataMap } from '../types'
 import { DEFAULT_LAYER_TIER, LAYER_TIERS } from '../types/data/LayerData.ts'
 import { loadTextFile } from '../utils'
 import { extractDirectoryPath, getFilename, joinPaths } from '../utils/url'
@@ -340,6 +340,66 @@ export class MapResource implements Loadable<TileMap> {
    * until save. Anchoring on the shadow keeps Tiles-tab toggles and
    * runtime paints consistent.
    */
+  /**
+   * Fold the live editor shadow (`MapEditorComponent.sprites`) on
+   * every tier's tilemap back into `mapData.layers[].sprites[]`.
+   *
+   * Paints mutate the shadow only — `mapData.layers` stays at the
+   * load-time snapshot until something explicitly syncs it. Callers
+   * that need a current view of the map (disk persist, project
+   * snapshot for a late-joining peer) MUST call this first.
+   *
+   * Per-layer sprite arrays are rebuilt deterministically from the
+   * shadow (sorted by `(y, x, zIndex)`) so wire bytes are stable
+   * across runs of the host and friendly to diff tools when the
+   * file lands on disk.
+   *
+   * Per-placement `properties` + `solid` overrides on
+   * `SpriteDataMap` entries are lost during this fold — the shadow
+   * tracks only the gameplay-loaded fields (spriteSetId, spriteId,
+   * animationId, zIndex, layerId). This matches the pre-existing
+   * limitation called out by `_isSolidRef`: live edits already
+   * dropped the per-placement `solid` override. Same caveat applies
+   * now to the persisted shape.
+   *
+   * Returns true when at least one layer was updated, false when
+   * `mapData` is unloaded (no-op safe to call mid-load).
+   */
+  syncShadowToMapData(): boolean {
+    if (!this._mapData) return false
+
+    const spritesPerLayer = new Map<string, SpriteDataMap[]>()
+    for (const tileMap of this.tileMapsByTier.values()) {
+      const editor = tileMap.get(MapEditorComponent)
+      if (!editor) continue
+      for (const [key, refs] of Object.entries(editor.sprites)) {
+        const comma = key.indexOf(',')
+        const tileX = Number(key.slice(0, comma))
+        const tileY = Number(key.slice(comma + 1))
+        for (const ref of refs) {
+          const list = spritesPerLayer.get(ref.layerId) ?? []
+          const entry: SpriteDataMap = {
+            x: tileX,
+            y: tileY,
+            spriteSetId: ref.spriteSetId,
+            spriteId: ref.spriteId,
+          }
+          if (ref.animationId !== undefined) entry.animationId = ref.animationId
+          if (ref.zIndex !== undefined) entry.zIndex = ref.zIndex
+          list.push(entry)
+          spritesPerLayer.set(ref.layerId, list)
+        }
+      }
+    }
+
+    for (const layer of this._mapData.layers) {
+      const sprites = spritesPerLayer.get(layer.id) ?? []
+      sprites.sort((a, b) => a.y - b.y || a.x - b.x || (a.zIndex ?? 0) - (b.zIndex ?? 0))
+      layer.sprites = sprites
+    }
+    return true
+  }
+
   refreshTileSolidsForSprite(spriteSetId: string, spriteId: number): void {
     for (const tilemap of this.tileMapsByTier.values()) {
       const editor = tilemap.get(MapEditorComponent)

--- a/packages/engine/src/sync/project-snapshot.ts
+++ b/packages/engine/src/sync/project-snapshot.ts
@@ -120,6 +120,13 @@ export async function captureProjectSnapshot(engine: Engine): Promise<ProjectSna
           `call engine.loadMap(id) first or check the project file for stale references.`,
       )
     }
+    // Fold the live editor shadow (MapEditorComponent.sprites) on
+    // every tier's tilemap back into mapData.layers[].sprites[].
+    // Paints mutate the shadow only — without this sync, the
+    // snapshot would ship the load-time state and a late-joining
+    // peer would see the map as it was when the host opened it,
+    // missing every paint applied since.
+    mapResource.syncShadowToMapData()
     maps.push({ path: ref.path, data: mapResource.mapData })
   }
 

--- a/packages/engine/src/sync/session-controller.spec.ts
+++ b/packages/engine/src/sync/session-controller.spec.ts
@@ -8,9 +8,14 @@ import type { PeerSessionEventMap } from './types.ts'
 import { SessionController } from './session-controller.ts'
 
 interface MockEngine {
-  events: ExEventEmitter<{ 'command-executed': { command: Command } }>
+  events: ExEventEmitter<{
+    'command-executed': { command: Command }
+    'command-reverted': { command: Command }
+  }>
   applyRemoteCommand: (command: Command) => void
+  applyRemoteRevert: (command: Command) => void
   applied: Command[]
+  reverted: Command[]
 }
 
 interface MockSession {
@@ -21,12 +26,17 @@ interface MockSession {
 
 function makeMockEngine(): MockEngine {
   const applied: Command[] = []
+  const reverted: Command[] = []
   return {
     events: new ExEventEmitter(),
     applyRemoteCommand(command) {
       applied.push(command)
     },
+    applyRemoteRevert(command) {
+      reverted.push(command)
+    },
     applied,
+    reverted,
   }
 }
 
@@ -88,6 +98,63 @@ export default async () => {
       expect((op.payload as { value: number }).value).toBe(7)
       expect(op.peerId).toBe('alice')
       expect(op.seq).toBe(0)
+      expect(op.direction).toBe('apply')
+    })
+
+    await it("relays a local 'command-reverted' as an Operation with direction='revert'", async () => {
+      const engine = makeMockEngine()
+      const session = makeMockSession()
+      new SessionController({
+        engine: engine as unknown as Engine,
+        session: session as unknown as PeerSession,
+        peerId: 'alice',
+        registry: FAKE_REGISTRY,
+      })
+
+      engine.events.emit('command-reverted', { command: new FakeCommand({ value: 9 }) })
+
+      expect(session.sent).toHaveLength(1)
+      const op = session.sent[0] as Operation
+      expect(op.kind).toBe('test.fake')
+      expect(op.direction).toBe('revert')
+      expect((op.payload as { value: number }).value).toBe(9)
+    })
+
+    await it("routes inbound op with direction='revert' to applyRemoteRevert (not applyRemoteCommand)", async () => {
+      const engine = makeMockEngine()
+      const session = makeMockSession()
+      new SessionController({
+        engine: engine as unknown as Engine,
+        session: session as unknown as PeerSession,
+        peerId: 'alice',
+        registry: FAKE_REGISTRY,
+      })
+
+      session.events.emit('op-received', {
+        op: { kind: 'test.fake', payload: { value: 11 }, peerId: 'bob', seq: 0, direction: 'revert' },
+      })
+
+      expect(engine.applied).toHaveLength(0)
+      expect(engine.reverted).toHaveLength(1)
+      expect((engine.reverted[0]?.payload as { value: number }).value).toBe(11)
+    })
+
+    await it("defaults to 'apply' when inbound op omits direction (backward compat)", async () => {
+      const engine = makeMockEngine()
+      const session = makeMockSession()
+      new SessionController({
+        engine: engine as unknown as Engine,
+        session: session as unknown as PeerSession,
+        peerId: 'alice',
+        registry: FAKE_REGISTRY,
+      })
+
+      session.events.emit('op-received', {
+        op: { kind: 'test.fake', payload: { value: 13 }, peerId: 'bob', seq: 0 },
+      })
+
+      expect(engine.applied).toHaveLength(1)
+      expect(engine.reverted).toHaveLength(0)
     })
 
     await it('stamps a monotonically increasing seq per emit', async () => {
@@ -190,10 +257,15 @@ export default async () => {
       ctrl.close() // idempotent
 
       engine.events.emit('command-executed', { command: new FakeCommand({ value: 1 }) })
-      session.events.emit('op-received', { op: { kind: 'test.fake', payload: { value: 2 }, peerId: 'bob', seq: 0 } })
+      engine.events.emit('command-reverted', { command: new FakeCommand({ value: 2 }) })
+      session.events.emit('op-received', { op: { kind: 'test.fake', payload: { value: 3 }, peerId: 'bob', seq: 0 } })
+      session.events.emit('op-received', {
+        op: { kind: 'test.fake', payload: { value: 4 }, peerId: 'bob', seq: 1, direction: 'revert' },
+      })
 
       expect(session.sent).toHaveLength(0)
       expect(engine.applied).toHaveLength(0)
+      expect(engine.reverted).toHaveLength(0)
     })
   })
 }

--- a/packages/engine/src/sync/session-controller.ts
+++ b/packages/engine/src/sync/session-controller.ts
@@ -54,6 +54,7 @@ export class SessionController {
   private readonly onSessionProtocol: ((op: SessionProtocolOp) => void) | null
   private localSeq = 0
   private commandSub: { close(): void } | null = null
+  private revertSub: { close(): void } | null = null
   private sessionSub: { close(): void } | null = null
   private closed = false
 
@@ -64,10 +65,19 @@ export class SessionController {
     this.registry = opts.registry ?? BUILT_IN_COMMANDS
     this.onSessionProtocol = opts.onSessionProtocol ?? null
 
-    // Local → wire
+    // Local → wire (apply path: initial execute + redo)
     this.commandSub = this.engine.events.on(EngineEvent.COMMAND_EXECUTED, ({ command }) => {
       if (this.closed) return
-      this.session.sendOp(this.toOperation(command))
+      this.session.sendOp(this.toOperation(command, 'apply'))
+    })
+
+    // Local → wire (revert path: undo). Relayed with
+    // `Operation.direction = 'revert'` so the receiving peer
+    // runs `command.revert` instead of `apply`. Without this hook
+    // a peer's undo of their own paint would never reach peers.
+    this.revertSub = this.engine.events.on(EngineEvent.COMMAND_REVERTED, ({ command }) => {
+      if (this.closed) return
+      this.session.sendOp(this.toOperation(command, 'revert'))
     })
 
     // Wire → local
@@ -104,16 +114,19 @@ export class SessionController {
     this.closed = true
     this.commandSub?.close()
     this.commandSub = null
+    this.revertSub?.close()
+    this.revertSub = null
     this.sessionSub?.close()
     this.sessionSub = null
   }
 
-  private toOperation(command: Command): Operation {
+  private toOperation(command: Command, direction: 'apply' | 'revert'): Operation {
     return {
       kind: command.kind,
       payload: command.payload,
       peerId: this.peerId,
       seq: this.localSeq++,
+      direction,
     }
   }
 
@@ -143,6 +156,15 @@ export class SessionController {
       return
     }
     const command = factory(op.payload)
-    this.engine.applyRemoteCommand(command)
+    // `direction` defaults to 'apply' for backward compat with
+    // older peers that didn't ship the field. A 'revert' direction
+    // routes to the symmetric `applyRemoteRevert` so peer-A's undo
+    // of their own paint reverts on every connected peer (the
+    // bug this field was introduced to close).
+    if (op.direction === 'revert') {
+      this.engine.applyRemoteRevert(command)
+    } else {
+      this.engine.applyRemoteCommand(command)
+    }
   }
 }

--- a/packages/engine/src/types/engine-events.ts
+++ b/packages/engine/src/types/engine-events.ts
@@ -26,6 +26,7 @@ export enum EngineEvent {
   POINTER_DRAG_MOVE = 'pointer-drag-move',
   POINTER_DRAG_END = 'pointer-drag-end',
   COMMAND_EXECUTED = 'command-executed',
+  COMMAND_REVERTED = 'command-reverted',
 }
 
 export interface EngineEventMap {
@@ -156,10 +157,21 @@ export interface EngineEventMap {
   [EngineEvent.POINTER_DRAG_END]: { screenPos: { x: number; y: number } }
   /**
    * Fired by `Engine.executeCommand` after a local command applies
-   * + lands on the undo stack. The {@link SessionController} listens
+   * + lands on the undo stack, AND by `Engine.redo` after the local
+   * apply + cursor advance. The {@link SessionController} listens
    * here to relay the command as an `Operation` over the active
-   * peer session. **Not** fired for remote commands applied via
-   * `Engine.applyRemoteCommand` — that would create a feedback loop.
+   * peer session (direction `'apply'`). **Not** fired for remote
+   * commands applied via `Engine.applyRemoteCommand` — that would
+   * create a feedback loop.
    */
   [EngineEvent.COMMAND_EXECUTED]: { command: Command }
+  /**
+   * Fired by `Engine.undo` after the local command reverts + cursor
+   * decrement. The {@link SessionController} relays the command as
+   * an `Operation` with `direction: 'revert'` so the receiving peer
+   * runs `command.revert` (mirroring the originator's undo).
+   * **Not** fired for remote reverts applied via
+   * `Engine.revertRemoteCommand`.
+   */
+  [EngineEvent.COMMAND_REVERTED]: { command: Command }
 }


### PR DESCRIPTION
## Why this PR exists

PR #128 was opened against \`refactor/ecs-hygiene\` (its stacked base). When you merged #127 to \`main\` via squash, the branch label moved on but the stacked PR's merge target stayed at \`refactor/ecs-hygiene\` — so when you merged #128 it landed on the now-orphaned base branch instead of \`main\`. The collab bug fixes never made it to \`main\`.

This PR is the same content as #128, cherry-picked onto current \`main\` so the bug fixes actually ship.

## What's in it

Identical to the merged #128 — see that PR's description for the full design rationale. Quick recap:

### Bug 1 — late-joiner snapshot
\`MapResource.syncShadowToMapData()\` folds the live \`MapEditorComponent\` shadow back into \`mapData.layers[].sprites[]\` before \`captureProjectSnapshot\` serialises. Late-joining peers see every paint the host made before they joined.

### Bug 2 — peer undo replication
Symmetric revert relay via \`Operation.direction\`:
- New \`COMMAND_REVERTED\` event; \`Engine.undo\` emits it after the local revert.
- \`Engine.redo\` now emits \`COMMAND_EXECUTED\` too (bypasses the stack-push since the command is already on the stack).
- New \`Engine.applyRemoteRevert\` mirrors \`applyRemoteCommand\` for inbound reverts.
- \`SessionController\` listens to both events, serialises with the right \`direction\`, and routes inbound by direction.
- \`direction\` defaults to \`'apply'\` for backward compat.

3 new specs in \`session-controller.spec.ts\` (now 383 total, up from 372).

## Test plan

- [x] Cherry-picked cleanly onto current \`main\`
- [x] \`gjsify foreach check -v -t\` — all 7 packages typecheck
- [x] \`gjsify workspace @pixelrpg/engine test\` — 383 tests pass on gjs + node
- [x] User already smoke-tested the same content during #128 review and confirmed both bugs are fixed