### PR TITLE
fix(gjs): declare Paintable.compute_concrete_size

### DIFF
--- a/packages/gjs/src/sprite/objects/GdkSpritePaintable.ts
+++ b/packages/gjs/src/sprite/objects/GdkSpritePaintable.ts
@@ -54,6 +54,11 @@ export class GdkSpritePaintable extends GObject.Object implements Gdk.Paintable.
   declare snapshot: Gdk.Paintable['snapshot']
   declare invalidate_contents: Gdk.Paintable['invalidate_contents']
   declare invalidate_size: Gdk.Paintable['invalidate_size']
+  // Declared (not overridden) so the type satisfies `Gdk.Paintable` —
+  // GTK provides the default C-side `compute_concrete_size`. We cannot
+  // override its vfunc from JS (see the note on `vfunc_compute_concrete_size`
+  // below), but the inherited method exists at runtime.
+  declare compute_concrete_size: Gdk.Paintable['compute_concrete_size']
 
   static {
     GObject.registerClass(


### PR DESCRIPTION
## Problem

`main` CI has been red since the `@girs/gdk-4.0` bump added `compute_concrete_size` to the `Gdk.Paintable` interface. `GdkSpritePaintable` no longer satisfied the interface, so `tsc` failed in `@pixelrpg/gjs`:

```
src/sprite/objects/GdkSprite.ts:69:7 - error TS2741: Property 'compute_concrete_size' is missing in type 'GdkSpritePaintable' but required in type 'Paintable'.
src/sprite/objects/GdkSprite.ts:74:5 - error TS2741: ...
src/sprite/objects/GdkSpritePaintable.ts:187:5 - error TS2322: Type 'this' is not assignable to type 'Paintable'.
```

## Fix

GJS can't override the `compute_concrete_size` vfunc from JS (its interface-vfunc dispatch table has no slot for it — see the long-standing note in the file), but GTK ships a default C-side implementation. So we just **declare** the inherited method on the class — exactly the pattern the class already uses for `get_current_image`, `snapshot`, `invalidate_size`, etc. Type-only `declare`, no runtime change.

## Verification

`gjsify workspace @pixelrpg/gjs check` (= `build:barrels && tsc`) passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)