### PR TITLE
feat: desktop quick-view sidebar + animated character cards on the overviews

### DIFF
--- a/apps/maker-gjs/src/widgets/cast-view.blp
+++ b/apps/maker-gjs/src/widgets/cast-view.blp
@@ -5,9 +5,10 @@ template $CastView : Adw.Bin {
   // Outer OverlaySplitView holds the ModeRail (left navigation) for the
   // whole view's lifetime. The central content is an `Adw.NavigationView`
   // master-detail drill-down: the GALLERY page lists every character as a
-  // card; activating one PUSHES a dedicated DETAIL page (preview +
-  // animations + inspector). The two are never shown at once — the
-  // detail page is its own sub-page with a back button.
+  // card (with, on desktop, a right quick-view sidebar for the selected
+  // card); activating one DRILLS into a dedicated DETAIL page (preview +
+  // animations + full inspector). The detail page is its own sub-page
+  // with a back button.
   Adw.OverlaySplitView outer_split {
     sidebar-position: start;
     min-sidebar-width: 220;
@@ -28,79 +29,163 @@ template $CastView : Adw.Bin {
         tag: "gallery";
         title: _("Cast");
 
-        child: Adw.ToolbarView {
-          top-bar-style: flat;
+        // Desktop: cards (content) + a read-only quick-view sidebar for
+        // the selected card (right). The split collapses on narrow
+        // widths (`inspector-collapsed`), where the sidebar is hidden
+        // and a tap drills straight into the detail page instead.
+        child: Adw.OverlaySplitView gallery_split {
+          sidebar-position: end;
+          min-sidebar-width: 260;
+          max-sidebar-width: 340;
+          pin-sidebar: true;
+          collapsed: bind template.inspector-collapsed;
+          show-sidebar: bind template.show-quickview bidirectional;
 
-          [top]
-          Adw.HeaderBar {
-            show-title: false;
-            show-start-title-buttons: false;
-            show-end-title-buttons: false;
-
-            [start]
-            Gtk.ToggleButton library_toggle {
-              icon-name: "sidebar-show-symbolic";
-              tooltip-text: _("Toggle library");
-              active: bind template.show-library bidirectional;
-            }
-          }
-
-          content: Gtk.ScrolledWindow {
-            hexpand: true;
-            vexpand: true;
+          sidebar: Gtk.ScrolledWindow {
             hscrollbar-policy: never;
+            vscrollbar-policy: automatic;
 
-            child: Adw.Clamp {
-              maximum-size: 1000;
-              tightening-threshold: 600;
+            child: Gtk.Stack quick_stack {
+              Gtk.StackPage {
+                name: "empty";
+                child: Adw.StatusPage {
+                  icon-name: "people-symbolic";
+                  title: _("No selection");
+                  description: _("Select a character to see its details.");
+                };
+              }
 
-              child: Gtk.Box {
-                orientation: vertical;
-                spacing: 16;
-                margin-top: 24;
-                margin-bottom: 24;
-                margin-start: 24;
-                margin-end: 24;
+              Gtk.StackPage {
+                name: "info";
+                child: Gtk.Box {
+                  orientation: vertical;
+                  spacing: 12;
+                  margin-top: 18;
+                  margin-bottom: 18;
+                  margin-start: 18;
+                  margin-end: 18;
 
-                Gtk.Label header_label {
-                  label: _("Cast");
-                  halign: start;
-                  styles ["title-1"]
-                }
+                  $PixelRpgCharacterPreview quick_preview {
+                    frame-size: 160;
+                    halign: center;
+                  }
 
-                Gtk.Box gallery_header {
-                  orientation: horizontal;
-                  spacing: 8;
+                  Gtk.Label quick_name {
+                    halign: center;
+                    wrap: true;
+                    justify: center;
+                    styles ["title-2"]
+                  }
 
-                  Gtk.Label {
-                    label: _("Characters");
+                  Gtk.Label quick_kind {
+                    halign: center;
+                    styles ["caption", "dim-label"]
+                  }
+
+                  Gtk.Label quick_player {
+                    label: _("Player character");
+                    halign: center;
+                    visible: false;
+                    styles ["caption", "accent"]
+                  }
+
+                  Gtk.Label quick_speed {
+                    halign: center;
+                    styles ["caption", "dim-label"]
+                  }
+
+                  Gtk.Button quick_edit {
+                    label: _("Edit");
+                    halign: center;
+                    margin-top: 6;
+                    styles ["suggested-action", "pill"]
+                  }
+                };
+              }
+            };
+          };
+
+          content: Adw.ToolbarView {
+            top-bar-style: flat;
+
+            [top]
+            Adw.HeaderBar {
+              show-title: false;
+              show-start-title-buttons: false;
+              show-end-title-buttons: false;
+
+              [start]
+              Gtk.ToggleButton library_toggle {
+                icon-name: "sidebar-show-symbolic";
+                tooltip-text: _("Toggle library");
+                active: bind template.show-library bidirectional;
+              }
+
+              [end]
+              Gtk.ToggleButton quickview_toggle {
+                icon-name: "sidebar-show-right-symbolic";
+                tooltip-text: _("Toggle details");
+                active: bind template.show-quickview bidirectional;
+              }
+            }
+
+            content: Gtk.ScrolledWindow {
+              hexpand: true;
+              vexpand: true;
+              hscrollbar-policy: never;
+
+              child: Adw.Clamp {
+                maximum-size: 1000;
+                tightening-threshold: 600;
+
+                child: Gtk.Box {
+                  orientation: vertical;
+                  spacing: 16;
+                  margin-top: 24;
+                  margin-bottom: 24;
+                  margin-start: 24;
+                  margin-end: 24;
+
+                  Gtk.Label header_label {
+                    label: _("Cast");
                     halign: start;
-                    hexpand: true;
-                    styles ["heading"]
+                    styles ["title-1"]
                   }
 
-                  Gtk.Button new_character_button {
-                    icon-name: "list-add-symbolic";
-                    action-name: "win.new-character";
-                    tooltip-text: _("Add a new character");
-                    valign: center;
-                    styles ["flat", "circular"]
+                  Gtk.Box gallery_header {
+                    orientation: horizontal;
+                    spacing: 8;
+
+                    Gtk.Label {
+                      label: _("Characters");
+                      halign: start;
+                      hexpand: true;
+                      styles ["heading"]
+                    }
+
+                    Gtk.Button new_character_button {
+                      icon-name: "list-add-symbolic";
+                      action-name: "win.new-character";
+                      tooltip-text: _("Add a new character");
+                      valign: center;
+                      styles ["flat", "circular"]
+                    }
                   }
-                }
 
-                Gtk.Label gallery_description {
-                  label: _("Heroes and NPCs in this project. The character marked as player spawns at the map's player spawn-point. Select one to edit it.");
-                  halign: start;
-                  wrap: true;
-                  xalign: 0;
-                  styles ["caption", "dim-label"]
-                }
+                  Gtk.Label gallery_description {
+                    label: _("Heroes and NPCs in this project. The character marked as player spawns at the map's player spawn-point. Select one to see its details; open it to edit.");
+                    halign: start;
+                    wrap: true;
+                    xalign: 0;
+                    styles ["caption", "dim-label"]
+                  }
 
-                $PixelRpgCardGallery characters_gallery {
-                  empty-title: _("No characters yet. Add a hero or an NPC to get started.");
-                  empty-icon: "people-symbolic";
-                  delete-tooltip: _("Delete character");
-                }
+                  $PixelRpgCardGallery characters_gallery {
+                    empty-title: _("No characters yet. Add a hero or an NPC to get started.");
+                    empty-icon: "people-symbolic";
+                    delete-tooltip: _("Delete character");
+                  }
+                };
               };
             };
           };

--- a/apps/maker-gjs/src/widgets/cast-view.ts
+++ b/apps/maker-gjs/src/widgets/cast-view.ts
@@ -1,11 +1,13 @@
 import Adw from '@girs/adw-1'
 import GObject from '@girs/gobject-2.0'
+import Gtk from '@girs/gtk-4.0'
 import type { CharacterAnimation, CharacterDefinition } from '@pixelrpg/engine'
 import {
   AddAnimationDialog,
   AnimationList,
   CardGallery,
   CastInspector,
+  CharacterCardPreview,
   CharacterPreview,
   type EditorMode,
   type GalleryCardItem,
@@ -26,6 +28,7 @@ import Template from './cast-view.blp'
 // `$PixelRpgModeRail` / `$PixelRpgCharacterPreview` / … references in
 // `cast-view.blp` resolve at template-parse time.
 GObject.type_ensure(CharacterPreview.$gtype)
+GObject.type_ensure(CharacterCardPreview.$gtype)
 GObject.type_ensure(AnimationList.$gtype)
 GObject.type_ensure(CastInspector.$gtype)
 GObject.type_ensure(CardGallery.$gtype)
@@ -36,22 +39,6 @@ export namespace CastView {
     'mode-changed': [string]
     'character-changed': []
   }
-}
-
-/**
- * Pick the sprite-frame that best represents a character on its gallery
- * card: the first frame of its default animation, else `idle-down`,
- * else the first animation that has frames, else sprite 0. Keeps the
- * card preview meaningful without animating every card.
- */
-function representativeFrame(character: CharacterDefinition): number {
-  const byId = (id: string) => character.animations.find((a) => a.id === id)
-  const anim =
-    (character.defaultAnimation ? byId(character.defaultAnimation) : null) ??
-    byId('idle-down') ??
-    character.animations.find((a) => a.frames.length > 0) ??
-    character.animations[0]
-  return anim?.frames?.[0] ?? 0
 }
 
 /**
@@ -82,6 +69,14 @@ export class CastView extends Adw.Bin {
   declare _characters_gallery: CardGallery
   declare _nav: Adw.NavigationView
   declare _detail_page: Adw.NavigationPage
+  // Desktop gallery quick-view (read-only glance for the selected card).
+  declare _quick_stack: Gtk.Stack
+  declare _quick_preview: CharacterPreview
+  declare _quick_name: Gtk.Label
+  declare _quick_kind: Gtk.Label
+  declare _quick_player: Gtk.Label
+  declare _quick_speed: Gtk.Label
+  declare _quick_edit: Gtk.Button
 
   private _projectName = ''
   // Sidebar visibility starts CLOSED — the actual value is overwritten
@@ -91,6 +86,9 @@ export class CastView extends Adw.Bin {
   // open sidebar against the user's saved-closed state.
   private _showLibrary = false
   private _showInspector = false
+  // Quick-view sidebar starts shown on desktop; the `inspectorCollapsed`
+  // setter flips it off when the responsive breakpoint collapses (phone).
+  private _showQuickview = true
   private _libraryCollapsed = false
   private _inspectorCollapsed = false
 
@@ -135,6 +133,13 @@ export class CastView extends Adw.Bin {
           'characters_gallery',
           'nav',
           'detail_page',
+          'quick_stack',
+          'quick_preview',
+          'quick_name',
+          'quick_kind',
+          'quick_player',
+          'quick_speed',
+          'quick_edit',
         ],
         Properties: {
           'project-name': GObject.ParamSpec.string(
@@ -157,6 +162,13 @@ export class CastView extends Adw.Bin {
             'Whether the right inspector is shown',
             GObject.ParamFlags.READWRITE,
             false,
+          ),
+          'show-quickview': GObject.ParamSpec.boolean(
+            'show-quickview',
+            'Show Quick-view',
+            "Whether the gallery's right quick-view sidebar is shown (desktop)",
+            GObject.ParamFlags.READWRITE,
+            true,
           ),
           'library-collapsed': GObject.ParamSpec.boolean(
             'library-collapsed',
@@ -237,24 +249,29 @@ export class CastView extends Adw.Bin {
     this.signals.connect(this._anim_list, 'delete-animation-requested', (_v: AnimationList, animId: string) => {
       this._confirmDeleteAnimation(animId)
     })
-    // Character gallery — card click selects, trash button (after a
-    // confirm) removes. Selection drives the preview + animation list +
-    // inspector, same as the old action-row gallery did.
+    // Character gallery. Single-click SELECTS (desktop: populates the
+    // quick-view sidebar; phone: drills straight to detail). Double-click
+    // / the quick-view "Edit" button OPENS the full detail page. The
+    // three-dots menu's delete routes through a confirm.
     this.signals.connect(this._characters_gallery, 'item-activated', (_v: CardGallery, id: string) => {
       this._selectCharacter(id)
+    })
+    this.signals.connect(this._characters_gallery, 'item-opened', (_v: CardGallery, id: string) => {
+      this._selectCharacter(id)
+      this._openDetail()
     })
     this.signals.connect(this._characters_gallery, 'delete-requested', (_v: CardGallery, id: string) => {
       this._confirmDeleteCharacter(id)
     })
+    this.signals.connect(this._quick_edit, 'clicked', () => this._openDetail())
   }
 
   /**
-   * Select a character from the gallery: make it active, reset the
-   * active animation, refresh the detail surfaces, and DRILL INTO the
-   * dedicated detail sub-page (preview + animations + inspector). The
-   * gallery and detail are never shown at once — this pushes the detail
-   * page onto the navigation stack; its back button returns to the
-   * gallery.
+   * Select a character: make it active, refresh the quick-view + detail
+   * surfaces, and highlight the card. On a NARROW layout (no quick-view
+   * sidebar) this also drills straight into the detail page; on desktop
+   * it just updates the quick-view sidebar (the user opens the detail
+   * explicitly via double-click or the "Edit" button).
    */
   private _selectCharacter(id: string): void {
     const character = this._characters.find((c) => c.id === id)
@@ -264,9 +281,16 @@ export class CastView extends Adw.Bin {
     this._refreshActive()
     this._characters_gallery.setActiveId(id)
     this._detail_page.title = character.name
-    // Auto-reveal the inspector on roomy layouts (its name / isPlayer /
-    // speed / duration fields are the point of the detail page); leave
-    // it closed on narrow ones, where it overlays the content.
+    if (this._inspectorCollapsed) this._openDetail()
+  }
+
+  /**
+   * Drill into the detail sub-page for the active character (preview +
+   * animations + inspector). Auto-reveals the inspector on roomy
+   * layouts. No-op if already on the detail page.
+   */
+  private _openDetail(): void {
+    if (!this._activeCharacterId) return
     if (!this._inspectorCollapsed) this.showInspector = true
     if (this._nav.get_visible_page()?.tag !== 'detail') this._nav.push_by_tag('detail')
   }
@@ -369,9 +393,14 @@ export class CastView extends Adw.Bin {
     dialog.present(this)
   }
 
-  /** Select + reveal a character in the gallery (used after creation). */
+  /**
+   * Select a character AND open its detail page. Used after creation
+   * (land on the new character to edit it) and by the `win.open-character`
+   * action (tooling drill-in).
+   */
   focusCharacter(id: string): void {
     this._selectCharacter(id)
+    this._openDetail()
   }
 
   get projectName(): string {
@@ -406,6 +435,16 @@ export class CastView extends Adw.Bin {
     this.notify('show-inspector')
   }
 
+  get showQuickview(): boolean {
+    return this._showQuickview ?? true
+  }
+
+  set showQuickview(value: boolean) {
+    if (this._showQuickview === value) return
+    this._showQuickview = value
+    this.notify('show-quickview')
+  }
+
   get libraryCollapsed(): boolean {
     return this._libraryCollapsed
   }
@@ -424,6 +463,10 @@ export class CastView extends Adw.Bin {
     if (this._inspectorCollapsed === value) return
     this._inspectorCollapsed = value
     this.notify('inspector-collapsed')
+    // Collapsed = narrow/phone → hide the gallery quick-view (a card tap
+    // drills straight into the detail page there). Expanded = desktop →
+    // show it. The user can still toggle it via the header button.
+    this.showQuickview = !value
   }
 
   /**
@@ -490,30 +533,43 @@ export class CastView extends Adw.Bin {
     this._mode_rail.activeMode = mode
   }
 
-  /** Rebuild the character cards from the current data + selection. */
+  /**
+   * Rebuild the character cards. Each card's preview is a live
+   * {@link CharacterCardPreview} — the character walks in its default
+   * direction, and hovering reveals direction arrows to spin it.
+   */
   private _rebuildGallery(): void {
-    this._characters_gallery.setItems(this._characters.map((c) => this._buildCardItem(c)))
+    this._characters_gallery.setItems(
+      this._characters.map((c) => this._buildCardItem(c)),
+      (item) => this._buildCardPreview(item.id),
+    )
     this._characters_gallery.setActiveId(this._activeCharacterId)
   }
 
   /**
-   * Build the card model for one character: a representative sprite
-   * (the first frame of its default/idle-down animation) as the
-   * preview, the kind as subtitle, and a `Player` badge for the
-   * playable character. Every character is deletable.
+   * Build the card model for one character: kind as subtitle, a `Player`
+   * badge for the playable character. The preview comes from
+   * {@link _buildCardPreview} (animated), so no static paintable here.
+   * Every character is deletable.
    */
   private _buildCardItem(character: CharacterDefinition): GalleryCardItem {
-    const set = this._spriteSetsById.get(character.spriteSetId) ?? null
-    const sprite = set?.getSprite(representativeFrame(character))
     return {
       id: character.id,
       title: character.name,
       subtitle: character.kind === 'hero' ? _('Hero') : _('NPC'),
       badge: character.isPlayer ? _('Player') : null,
-      paintable: sprite?.createPaintable({ keepAspectRatio: true }) ?? null,
       fallbackIcon: 'person-symbolic',
       deletable: true,
     }
+  }
+
+  /** Build the animated, hover-steerable preview widget for a card. */
+  private _buildCardPreview(id: string): CharacterCardPreview | null {
+    const character = this._characters.find((c) => c.id === id)
+    if (!character) return null
+    const preview = new CharacterCardPreview()
+    preview.setCharacter(character, this._spriteSetsById.get(character.spriteSetId) ?? null)
+    return preview
   }
 
   /** The GTK preview resource for the active character's sprite set. */
@@ -529,12 +585,33 @@ export class CastView extends Adw.Bin {
     this._preview.setCharacter(character, spriteSet)
     this._anim_list.setCharacter(character, spriteSet)
     this._inspector.setCharacter(character)
+    this._refreshQuickView(character, spriteSet)
     // Pick up whatever the preview defaulted to (`walk-down` on a
     // fresh character) so the list highlight + inspector duration
     // line up with what's playing — without this the first row
     // would never be marked accent until the user clicked
     // something.
     this._setActiveAnimation(this._preview.activeAnimationId)
+  }
+
+  /**
+   * Populate the desktop quick-view sidebar (read-only glance) for the
+   * active character, or switch it to the empty state when nothing is
+   * selected.
+   */
+  private _refreshQuickView(character: CharacterDefinition | null, spriteSet: GdkSpriteSetResource | null): void {
+    if (!character) {
+      this._quick_stack.set_visible_child_name('empty')
+      this._quick_preview.setCharacter(null, null)
+      return
+    }
+    this._quick_stack.set_visible_child_name('info')
+    this._quick_preview.setCharacter(character, spriteSet)
+    this._quick_name.set_label(character.name)
+    this._quick_kind.set_label(character.kind === 'hero' ? _('Hero') : _('NPC'))
+    this._quick_player.set_visible(character.isPlayer === true)
+    const speed = character.speedTilesPerSec ?? 4
+    this._quick_speed.set_label(_(`${speed} tiles/second`))
   }
 
   /**

--- a/apps/maker-gjs/src/widgets/tiles-view.blp
+++ b/apps/maker-gjs/src/widgets/tiles-view.blp
@@ -4,8 +4,8 @@ using Adw 1;
 template $TilesView : Adw.Bin {
   // Same master-detail shape as cast-view: ModeRail (left) holds the
   // whole view; the central `Adw.NavigationView` drills from a tileset
-  // card GALLERY into a per-tileset DETAIL page (palette + inspector).
-  // The two are never shown at once.
+  // card GALLERY (with a desktop quick-view sidebar) into a per-tileset
+  // DETAIL page (palette + inspector). The two are never shown at once.
   Adw.OverlaySplitView outer_split {
     sidebar-position: start;
     min-sidebar-width: 220;
@@ -26,79 +26,150 @@ template $TilesView : Adw.Bin {
         tag: "gallery";
         title: _("Tiles");
 
-        child: Adw.ToolbarView {
-          top-bar-style: flat;
+        child: Adw.OverlaySplitView gallery_split {
+          sidebar-position: end;
+          min-sidebar-width: 260;
+          max-sidebar-width: 340;
+          pin-sidebar: true;
+          collapsed: bind template.inspector-collapsed;
+          show-sidebar: bind template.show-quickview bidirectional;
 
-          [top]
-          Adw.HeaderBar {
-            show-title: false;
-            show-start-title-buttons: false;
-            show-end-title-buttons: false;
-
-            [start]
-            Gtk.ToggleButton library_toggle {
-              icon-name: "sidebar-show-symbolic";
-              tooltip-text: _("Toggle library");
-              active: bind template.show-library bidirectional;
-            }
-          }
-
-          content: Gtk.ScrolledWindow {
-            hexpand: true;
-            vexpand: true;
+          sidebar: Gtk.ScrolledWindow {
             hscrollbar-policy: never;
+            vscrollbar-policy: automatic;
 
-            child: Adw.Clamp {
-              maximum-size: 1000;
-              tightening-threshold: 600;
+            child: Gtk.Stack quick_stack {
+              Gtk.StackPage {
+                name: "empty";
+                child: Adw.StatusPage {
+                  icon-name: "view-grid-symbolic";
+                  title: _("No selection");
+                  description: _("Select a tileset to see its details.");
+                };
+              }
 
-              child: Gtk.Box {
-                orientation: vertical;
-                spacing: 16;
-                margin-top: 24;
-                margin-bottom: 24;
-                margin-start: 24;
-                margin-end: 24;
+              Gtk.StackPage {
+                name: "info";
+                child: Gtk.Box {
+                  orientation: vertical;
+                  spacing: 12;
+                  margin-top: 18;
+                  margin-bottom: 18;
+                  margin-start: 18;
+                  margin-end: 18;
 
-                Gtk.Label header_label {
-                  label: _("Tiles");
-                  halign: start;
-                  styles ["title-1"]
-                }
+                  Gtk.Picture quick_thumb {
+                    content-fit: contain;
+                    can-shrink: true;
+                    halign: center;
+                    height-request: 160;
+                    styles ["card", "card-gallery-preview"]
+                  }
 
-                Gtk.Box gallery_header {
-                  orientation: horizontal;
-                  spacing: 8;
+                  Gtk.Label quick_name {
+                    halign: center;
+                    wrap: true;
+                    justify: center;
+                    styles ["title-2"]
+                  }
 
-                  Gtk.Label {
-                    label: _("Tilesets");
+                  Gtk.Label quick_count {
+                    halign: center;
+                    styles ["caption", "dim-label"]
+                  }
+
+                  Gtk.Button quick_edit {
+                    label: _("Edit");
+                    halign: center;
+                    margin-top: 6;
+                    styles ["suggested-action", "pill"]
+                  }
+                };
+              }
+            };
+          };
+
+          content: Adw.ToolbarView {
+            top-bar-style: flat;
+
+            [top]
+            Adw.HeaderBar {
+              show-title: false;
+              show-start-title-buttons: false;
+              show-end-title-buttons: false;
+
+              [start]
+              Gtk.ToggleButton library_toggle {
+                icon-name: "sidebar-show-symbolic";
+                tooltip-text: _("Toggle library");
+                active: bind template.show-library bidirectional;
+              }
+
+              [end]
+              Gtk.ToggleButton quickview_toggle {
+                icon-name: "sidebar-show-right-symbolic";
+                tooltip-text: _("Toggle details");
+                active: bind template.show-quickview bidirectional;
+              }
+            }
+
+            content: Gtk.ScrolledWindow {
+              hexpand: true;
+              vexpand: true;
+              hscrollbar-policy: never;
+
+              child: Adw.Clamp {
+                maximum-size: 1000;
+                tightening-threshold: 600;
+
+                child: Gtk.Box {
+                  orientation: vertical;
+                  spacing: 16;
+                  margin-top: 24;
+                  margin-bottom: 24;
+                  margin-start: 24;
+                  margin-end: 24;
+
+                  Gtk.Label header_label {
+                    label: _("Tiles");
                     halign: start;
-                    hexpand: true;
-                    styles ["heading"]
+                    styles ["title-1"]
                   }
 
-                  Gtk.Button new_tileset_button {
-                    icon-name: "list-add-symbolic";
-                    action-name: "win.new-tileset";
-                    tooltip-text: _("Import a new tileset");
-                    valign: center;
-                    styles ["flat", "circular"]
+                  Gtk.Box gallery_header {
+                    orientation: horizontal;
+                    spacing: 8;
+
+                    Gtk.Label {
+                      label: _("Tilesets");
+                      halign: start;
+                      hexpand: true;
+                      styles ["heading"]
+                    }
+
+                    Gtk.Button new_tileset_button {
+                      icon-name: "list-add-symbolic";
+                      action-name: "win.new-tileset";
+                      tooltip-text: _("Import a new tileset");
+                      valign: center;
+                      styles ["flat", "circular"]
+                    }
                   }
-                }
 
-                Gtk.Label gallery_description {
-                  label: _("Select a tileset to configure its tiles in the inspector, or import a new one.");
-                  halign: start;
-                  wrap: true;
-                  xalign: 0;
-                  styles ["caption", "dim-label"]
-                }
+                  Gtk.Label gallery_description {
+                    label: _("Select a tileset to see its details; open it to configure its tiles. Or import a new one.");
+                    halign: start;
+                    wrap: true;
+                    xalign: 0;
+                    styles ["caption", "dim-label"]
+                  }
 
-                $PixelRpgCardGallery tilesets_gallery {
-                  empty-title: _("No tilesets yet. Import one to start painting maps.");
-                  empty-icon: "view-grid-symbolic";
-                  delete-tooltip: _("Delete tileset");
-                }
+                  $PixelRpgCardGallery tilesets_gallery {
+                    empty-title: _("No tilesets yet. Import one to start painting maps.");
+                    empty-icon: "view-grid-symbolic";
+                    delete-tooltip: _("Delete tileset");
+                  }
+                };
               };
             };
           };

--- a/apps/maker-gjs/src/widgets/tiles-view.ts
+++ b/apps/maker-gjs/src/widgets/tiles-view.ts
@@ -60,6 +60,12 @@ export class TilesView extends Adw.Bin {
   declare _tilesets_gallery: CardGallery
   declare _nav: Adw.NavigationView
   declare _detail_page: Adw.NavigationPage
+  // Desktop gallery quick-view (read-only glance for the selected tileset).
+  declare _quick_stack: Gtk.Stack
+  declare _quick_thumb: Gtk.Picture
+  declare _quick_name: Gtk.Label
+  declare _quick_count: Gtk.Label
+  declare _quick_edit: Gtk.Button
 
   private _projectName = ''
   // Sidebar visibility starts CLOSED — overwritten on window
@@ -68,6 +74,8 @@ export class TilesView extends Adw.Bin {
   // the user last left it across views.
   private _showLibrary = false
   private _showInspector = false
+  // Quick-view shown on desktop; flipped off when the breakpoint collapses.
+  private _showQuickview = true
   private _libraryCollapsed = false
   private _inspectorCollapsed = false
 
@@ -84,7 +92,19 @@ export class TilesView extends Adw.Bin {
       {
         GTypeName: 'TilesView',
         Template,
-        InternalChildren: ['mode_rail', 'inspector', 'palette', 'tilesets_gallery', 'nav', 'detail_page'],
+        InternalChildren: [
+          'mode_rail',
+          'inspector',
+          'palette',
+          'tilesets_gallery',
+          'nav',
+          'detail_page',
+          'quick_stack',
+          'quick_thumb',
+          'quick_name',
+          'quick_count',
+          'quick_edit',
+        ],
         Properties: {
           'project-name': GObject.ParamSpec.string(
             'project-name',
@@ -106,6 +126,13 @@ export class TilesView extends Adw.Bin {
             'Whether the right inspector is shown',
             GObject.ParamFlags.READWRITE,
             false,
+          ),
+          'show-quickview': GObject.ParamSpec.boolean(
+            'show-quickview',
+            'Show Quick-view',
+            "Whether the gallery's right quick-view sidebar is shown (desktop)",
+            GObject.ParamFlags.READWRITE,
+            true,
           ),
           'library-collapsed': GObject.ParamSpec.boolean(
             'library-collapsed',
@@ -161,9 +188,14 @@ export class TilesView extends Adw.Bin {
     this.signals.connect(this._tilesets_gallery, 'item-activated', (_v: CardGallery, id: string) => {
       this._setActiveSpriteSet(id)
     })
+    this.signals.connect(this._tilesets_gallery, 'item-opened', (_v: CardGallery, id: string) => {
+      this._setActiveSpriteSet(id)
+      this._openDetail()
+    })
     this.signals.connect(this._tilesets_gallery, 'delete-requested', (_v: CardGallery, id: string) => {
       this._confirmDeleteTileset(id)
     })
+    this.signals.connect(this._quick_edit, 'clicked', () => this._openDetail())
     this.signals.connect(this._palette, 'tile-selected', (_p: TilePalette, tileId: number) => {
       this._selectedSpriteId = tileId
       this._refreshInspector()
@@ -218,6 +250,16 @@ export class TilesView extends Adw.Bin {
     this.notify('show-inspector')
   }
 
+  get showQuickview(): boolean {
+    return this._showQuickview ?? true
+  }
+
+  set showQuickview(value: boolean) {
+    if (this._showQuickview === value) return
+    this._showQuickview = value
+    this.notify('show-quickview')
+  }
+
   get libraryCollapsed(): boolean {
     return this._libraryCollapsed
   }
@@ -236,6 +278,9 @@ export class TilesView extends Adw.Bin {
     if (this._inspectorCollapsed === value) return
     this._inspectorCollapsed = value
     this.notify('inspector-collapsed')
+    // Collapsed = narrow/phone → hide the gallery quick-view (a tap
+    // drills straight into the detail page). Expanded = desktop → show.
+    this.showQuickview = !value
   }
 
   /**
@@ -268,6 +313,7 @@ export class TilesView extends Adw.Bin {
       this._tilesets_gallery.setItems([])
       this._palette.setTiles([])
       this._inspector.setSprite(null, null)
+      this._refreshQuickView()
       return
     }
 
@@ -293,6 +339,7 @@ export class TilesView extends Adw.Bin {
       this._activeSpriteSetId = items[0]?.id ?? null
     }
     this._rebuildGallery()
+    this._refreshQuickView()
     await this._loadActivePalette()
   }
 
@@ -301,9 +348,10 @@ export class TilesView extends Adw.Bin {
     this._mode_rail.activeMode = mode
   }
 
-  /** Select a tileset by id + drill into its detail page (host / MCP entry). */
+  /** Select a tileset by id + open its detail page (host / MCP entry). */
   focusTileset(id: string): void {
     this._setActiveSpriteSet(id)
+    this._openDetail()
   }
 
   /**
@@ -345,12 +393,11 @@ export class TilesView extends Adw.Bin {
   }
 
   /**
-   * Select a tileset from the gallery and DRILL INTO its detail page
-   * (the tile palette + inspector). Mirrors the Cast view's card →
-   * detail navigation; the back button returns to the gallery. The
-   * inspector stays closed until the user picks a tile (it has nothing
-   * to show for a whole set), matching the palette's tile-selected
-   * auto-open.
+   * Select a tileset: make it active, refresh the quick-view + (lazily)
+   * the palette, and highlight the card. On a NARROW layout (no
+   * quick-view sidebar) this also drills into the detail page; on
+   * desktop it just updates the quick-view (the user opens the detail
+   * explicitly via double-click or the "Edit" button).
    */
   private _setActiveSpriteSet(id: string): void {
     const entry = this._spriteSets.find((s) => s.id === id)
@@ -359,8 +406,38 @@ export class TilesView extends Adw.Bin {
     this._selectedSpriteId = null
     this._tilesets_gallery.setActiveId(id)
     this._detail_page.title = entry.resource.data?.name ?? id
+    this._refreshQuickView()
     void this._loadActivePalette()
+    if (this._inspectorCollapsed) this._openDetail()
+  }
+
+  /**
+   * Drill into the detail sub-page (tile palette + inspector) for the
+   * active tileset. No-op if already there. The inspector stays closed
+   * until the user picks a tile (it has nothing to show for a whole
+   * set), matching the palette's tile-selected auto-open.
+   */
+  private _openDetail(): void {
+    if (!this._activeSpriteSetId) return
     if (this._nav.get_visible_page()?.tag !== 'detail') this._nav.push_by_tag('detail')
+  }
+
+  /**
+   * Populate the desktop quick-view sidebar (read-only glance) for the
+   * active tileset, or switch it to the empty state when none is active.
+   */
+  private _refreshQuickView(): void {
+    const active = this._activeSpriteSet()
+    if (!active) {
+      this._quick_stack.set_visible_child_name('empty')
+      this._quick_thumb.set_paintable(null)
+      return
+    }
+    this._quick_stack.set_visible_child_name('info')
+    this._quick_thumb.set_paintable(active.gdk?.createSheetThumbnail(240) ?? null)
+    this._quick_name.set_label(active.resource.data?.name ?? active.id)
+    const count = active.resource.data?.sprites?.length ?? 0
+    this._quick_count.set_label(count === 1 ? _('1 tile') : _(`${count} tiles`))
   }
 
   private _activeSpriteSet(): TilesetEntry | null {

--- a/packages/gjs/src/widgets/cast/character-card-preview.ts
+++ b/packages/gjs/src/widgets/cast/character-card-preview.ts
@@ -1,0 +1,206 @@
+import Adw from '@girs/adw-1'
+import GLib from '@girs/glib-2.0'
+import GObject from '@girs/gobject-2.0'
+import Gtk from '@girs/gtk-4.0'
+import type { CharacterAnimation, CharacterDefinition } from '@pixelrpg/engine'
+import { gettext as _ } from 'gettext'
+
+import type { GdkSpriteSetResource } from '../../sprite/index.ts'
+
+type DirectionRole = 'up' | 'down' | 'left' | 'right'
+
+/** Default per-card preview edge length (px). */
+const DEFAULT_SIZE = 88
+
+const ARROWS: ReadonlyArray<{ dir: DirectionRole; icon: string; halign: Gtk.Align; valign: Gtk.Align; tip: string }> = [
+  { dir: 'up', icon: 'go-up-symbolic', halign: Gtk.Align.CENTER, valign: Gtk.Align.START, tip: _('Face up') },
+  { dir: 'down', icon: 'go-down-symbolic', halign: Gtk.Align.CENTER, valign: Gtk.Align.END, tip: _('Face down') },
+  { dir: 'left', icon: 'go-previous-symbolic', halign: Gtk.Align.START, valign: Gtk.Align.CENTER, tip: _('Face left') },
+  { dir: 'right', icon: 'go-next-symbolic', halign: Gtk.Align.END, valign: Gtk.Align.CENTER, tip: _('Face right') },
+]
+
+/**
+ * Compact, self-animating character preview for a gallery card. Plays
+ * the character's `walk-<direction>` cycle continuously (default: down)
+ * so the cast overview shows characters already in motion. On
+ * pointer-hover, four directional arrows fade in over the sprite; each
+ * sets the walk direction so the user can spin the character on the
+ * card without opening the detail page.
+ *
+ * Distinct from {@link CharacterPreview} (the detail-page widget with an
+ * always-visible direction pad + pause): this is a small, pad-free,
+ * hover-driven variant tuned for a dense card grid.
+ */
+export class CharacterCardPreview extends Adw.Bin {
+  private _picture: Gtk.Picture
+  private _arrows = new Map<DirectionRole, Gtk.Button>()
+  private _character: CharacterDefinition | null = null
+  private _spriteSet: GdkSpriteSetResource | null = null
+  private _direction: DirectionRole = 'down'
+  private _frameIndex = 0
+  private _timeoutId = 0
+  private _size = DEFAULT_SIZE
+
+  static {
+    GObject.registerClass(
+      {
+        GTypeName: 'PixelRpgCharacterCardPreview',
+        Properties: {
+          'preview-size': GObject.ParamSpec.int(
+            'preview-size',
+            'Preview size',
+            'Edge length of the square preview in pixels',
+            GObject.ParamFlags.READWRITE,
+            32,
+            256,
+            DEFAULT_SIZE,
+          ),
+        },
+      },
+      CharacterCardPreview,
+    )
+  }
+
+  constructor() {
+    super()
+    this.add_css_class('card-gallery-preview')
+    this.add_css_class('character-card-preview')
+
+    const overlay = new Gtk.Overlay()
+    this._picture = new Gtk.Picture({
+      contentFit: Gtk.ContentFit.CONTAIN,
+      canShrink: true,
+      hexpand: true,
+      vexpand: true,
+    })
+    overlay.set_child(this._picture)
+
+    for (const spec of ARROWS) {
+      const button = new Gtk.Button({
+        iconName: spec.icon,
+        tooltipText: spec.tip,
+        cssClasses: ['osd', 'circular', 'card-arrow'],
+        halign: spec.halign,
+        valign: spec.valign,
+        // Hidden until hover; can't be tabbed/clicked while invisible.
+        opacity: 0,
+        canTarget: false,
+        canFocus: false,
+      })
+      button.connect('clicked', () => this._setDirection(spec.dir))
+      this._arrows.set(spec.dir, button)
+      overlay.add_overlay(button)
+    }
+    this.set_child(overlay)
+    this._applySize()
+
+    // Reveal the arrows on hover. A motion controller toggles their
+    // opacity + targetability so they don't intercept clicks (or steal
+    // the card's hit area) while hidden.
+    const motion = new Gtk.EventControllerMotion()
+    motion.connect('enter', () => this._setArrowsRevealed(true))
+    motion.connect('leave', () => this._setArrowsRevealed(false))
+    this.add_controller(motion)
+  }
+
+  get previewSize(): number {
+    return this._size ?? DEFAULT_SIZE
+  }
+
+  set previewSize(value: number) {
+    if (this._size === value) return
+    this._size = value
+    this._applySize()
+    this.notify('preview-size')
+  }
+
+  /** Show this character. Resets to the default (down) walk + restarts playback. */
+  setCharacter(character: CharacterDefinition | null, spriteSet: GdkSpriteSetResource | null): void {
+    this._character = character
+    this._spriteSet = spriteSet
+    this._direction = 'down'
+    this._frameIndex = 0
+    this._restart()
+  }
+
+  vfunc_map(): void {
+    super.vfunc_map()
+    this._restart()
+  }
+
+  vfunc_unmap(): void {
+    this._stopTimer()
+    super.vfunc_unmap()
+  }
+
+  private _applySize(): void {
+    this.set_size_request(this._size, this._size)
+  }
+
+  private _setArrowsRevealed(revealed: boolean): void {
+    for (const button of this._arrows.values()) {
+      button.opacity = revealed ? 1 : 0
+      button.set_can_target(revealed)
+    }
+  }
+
+  private _setDirection(dir: DirectionRole): void {
+    if (this._direction === dir) return
+    this._direction = dir
+    this._frameIndex = 0
+    this._restart()
+  }
+
+  /**
+   * Resolve the animation to play: `walk-<dir>` with an `idle-<dir>`
+   * fallback (a character with only idle frames still previews), then
+   * any first animation. Null clears the picture.
+   */
+  private _activeAnimation(): CharacterAnimation | null {
+    const character = this._character
+    if (!character) return null
+    return (
+      character.animations.find((a) => a.id === `walk-${this._direction}`) ??
+      character.animations.find((a) => a.id === `idle-${this._direction}`) ??
+      character.animations.find((a) => a.frames.length > 0) ??
+      null
+    )
+  }
+
+  private _restart(): void {
+    this._stopTimer()
+    this._applyFrame()
+    this._scheduleNext()
+  }
+
+  private _stopTimer(): void {
+    if (this._timeoutId !== 0) {
+      GLib.Source.remove(this._timeoutId)
+      this._timeoutId = 0
+    }
+  }
+
+  private _applyFrame(): void {
+    const anim = this._activeAnimation()
+    if (!anim || anim.frames.length === 0 || !this._spriteSet) {
+      this._picture.set_paintable(null)
+      return
+    }
+    const spriteId = anim.frames[this._frameIndex % anim.frames.length]
+    const sprite = this._spriteSet.getSprite(spriteId)
+    this._picture.set_paintable(sprite?.createPaintable({ keepAspectRatio: true }) ?? null)
+  }
+
+  private _scheduleNext(): void {
+    const anim = this._activeAnimation()
+    if (!anim || anim.frames.length <= 1) return
+    const duration = Math.max(50, anim.durationMs)
+    this._timeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, duration, () => {
+      this._frameIndex = (this._frameIndex + 1) % anim.frames.length
+      this._applyFrame()
+      return GLib.SOURCE_CONTINUE
+    })
+  }
+}
+
+GObject.type_ensure(CharacterCardPreview.$gtype)

--- a/packages/gjs/src/widgets/cast/index.ts
+++ b/packages/gjs/src/widgets/cast/index.ts
@@ -1,6 +1,7 @@
 export * from './add-animation-dialog'
 export * from './animation-list'
 export * from './cast-inspector'
+export * from './character-card-preview'
 export * from './character-preview'
 export * from './collision-preview'
 export * from './new-character-dialog'

--- a/packages/gjs/src/widgets/common/card-gallery.css
+++ b/packages/gjs/src/widgets/common/card-gallery.css
@@ -24,19 +24,28 @@
   background-color: alpha(currentColor, 0.06);
 }
 
-/* Corner delete button: quiet by default (it must not compete with the
- * card's own content), destructive-red on hover/focus so the intent is
- * unmistakable once the user reaches for it. */
-.card-gallery-delete {
+/* Corner three-dots menu button: quiet by default (it must not compete
+ * with the card's own content), full-strength on hover/focus/open. */
+.card-gallery-menu {
   min-width: 24px;
   min-height: 24px;
   padding: 2px;
   opacity: 0.7;
 }
 
-.card-gallery-delete:hover,
-.card-gallery-delete:focus {
+.card-gallery-menu:hover,
+.card-gallery-menu:focus,
+.card-gallery-menu:checked {
   opacity: 1;
-  background-color: @destructive_bg_color;
-  color: @destructive_fg_color;
+}
+
+/* Hover-revealed direction arrows on an animated character card. The
+ * widget toggles each arrow's opacity + targetability in code; this
+ * just keeps them compact + crossfading. */
+.character-card-preview .card-arrow {
+  min-width: 22px;
+  min-height: 22px;
+  padding: 2px;
+  margin: 2px;
+  transition: opacity 120ms ease-in-out;
 }

--- a/packages/gjs/src/widgets/common/card-gallery.ts
+++ b/packages/gjs/src/widgets/common/card-gallery.ts
@@ -1,5 +1,6 @@
 import Adw from '@girs/adw-1'
 import type Gdk from '@girs/gdk-4.0'
+import Gio from '@girs/gio-2.0'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
 import Pango from '@girs/pango-1.0'
@@ -87,14 +88,20 @@ export class CardGallery extends Adw.Bin {
           ),
           'delete-tooltip': GObject.ParamSpec.string(
             'delete-tooltip',
-            'Delete Tooltip',
-            'Tooltip on each card delete button',
+            'Delete Label',
+            "Label of the delete item in each card's three-dots menu",
             GObject.ParamFlags.READWRITE,
             _('Delete'),
           ),
         },
         Signals: {
+          // A card was clicked (select it).
           'item-activated': { param_types: [GObject.TYPE_STRING] },
+          // A card was double-clicked or its menu's "open" chosen — open
+          // the full detail view for it.
+          'item-opened': { param_types: [GObject.TYPE_STRING] },
+          // The card's three-dots menu → delete was chosen. The host
+          // owns the confirm dialog + the actual removal.
           'delete-requested': { param_types: [GObject.TYPE_STRING] },
         },
       },
@@ -143,11 +150,18 @@ export class CardGallery extends Adw.Bin {
    * Replace every card. Items are rendered in array order. Switches to
    * the empty state when the list is empty. The active selection ring
    * is preserved if the active id is still present.
+   *
+   * `buildPreview`, when given, supplies a custom preview WIDGET for a
+   * card (e.g. an animated character preview) instead of the static
+   * {@link GalleryCardItem.paintable}; returning `null` falls back to the
+   * paintable/icon. The gallery owns the returned widget's lifecycle
+   * (it's destroyed when the card is cleared), so the factory should
+   * return a fresh widget per call.
    */
-  setItems(items: GalleryCardItem[]): void {
+  setItems(items: GalleryCardItem[], buildPreview?: (item: GalleryCardItem) => Gtk.Widget | null): void {
     this._clear()
     for (const item of items) {
-      const child = this._buildCard(item)
+      const child = this._buildCard(item, buildPreview)
       this._flow.append(child)
     }
     this._stack.set_visible_child_name(items.length === 0 ? 'empty' : 'grid')
@@ -190,9 +204,18 @@ export class CardGallery extends Adw.Bin {
    * above the card button, so clicking trash never also activates the
    * card underneath.
    */
-  private _buildCard(item: GalleryCardItem): Gtk.Overlay {
+  private _buildCard(item: GalleryCardItem, buildPreview?: (item: GalleryCardItem) => Gtk.Widget | null): Gtk.Overlay {
     const card = new Gtk.Button({ cssClasses: ['card', 'card-gallery-card'] })
     card.connect('clicked', () => this.emit('item-activated', item.id))
+    // Double-click opens the detail view. A capture-phase gesture sees
+    // the press before the button's own click gesture; we don't claim
+    // it, so the single-click `item-activated` still fires.
+    const dbl = new Gtk.GestureClick()
+    dbl.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
+    dbl.connect('pressed', (_g: Gtk.GestureClick, nPress: number) => {
+      if (nPress === 2) this.emit('item-opened', item.id)
+    })
+    card.add_controller(dbl)
 
     const box = new Gtk.Box({
       orientation: Gtk.Orientation.VERTICAL,
@@ -203,7 +226,7 @@ export class CardGallery extends Adw.Bin {
       marginEnd: 10,
     })
 
-    box.append(this._buildPreview(item))
+    box.append(buildPreview?.(item) ?? this._buildPreview(item))
 
     const title = new Gtk.Label({
       label: item.title,
@@ -238,18 +261,30 @@ export class CardGallery extends Adw.Bin {
     const overlay = new Gtk.Overlay()
     overlay.set_child(card)
 
+    // Per-card actions live in a standard GNOME three-dots menu
+    // (`Gtk.MenuButton` + `Gio.Menu`) in the corner — not a bare trash
+    // icon. Only deletable items get the menu (built-ins have no
+    // actions). The `card.delete` action drives the host's confirm +
+    // removal via `delete-requested`.
     if (item.deletable) {
-      const trash = new Gtk.Button({
-        iconName: 'user-trash-symbolic',
-        tooltipText: this.deleteTooltip,
-        cssClasses: ['flat', 'circular', 'card-gallery-delete'],
+      const menu = Gio.Menu.new()
+      menu.append(this.deleteTooltip, 'card.delete')
+      const menuButton = new Gtk.MenuButton({
+        iconName: 'view-more-symbolic',
+        tooltipText: _('More options'),
+        cssClasses: ['flat', 'circular', 'card-gallery-menu'],
         halign: Gtk.Align.END,
         valign: Gtk.Align.START,
         marginTop: 6,
         marginEnd: 6,
+        menuModel: menu,
       })
-      trash.connect('clicked', () => this.emit('delete-requested', item.id))
-      overlay.add_overlay(trash)
+      const group = new Gio.SimpleActionGroup()
+      const deleteAction = new Gio.SimpleAction({ name: 'delete' })
+      deleteAction.connect('activate', () => this.emit('delete-requested', item.id))
+      group.add_action(deleteAction)
+      menuButton.insert_action_group('card', group)
+      overlay.add_overlay(menuButton)
     }
 
     this._cardsById.set(item.id, card)


### PR DESCRIPTION
Follow-up to #137, per user feedback on the Cast + Tiles **overview** pages.

## Desktop quick-view sidebar
- The gallery page gains a right **quick-view sidebar** (read-only glance) for the *selected* card, kept visible on desktop and collapsed on phone.
- **Cast**: animated preview + name + Hero/NPC + Player badge + speed + an **Edit** button.
- **Tiles**: sheet thumbnail + name + tile count + **Edit** button.
- **Interaction**: single-click *selects* (desktop → quick-view; phone → drills straight to the detail page since there's no room for a sidebar); double-click or the **Edit** button *opens* the full detail page. `Adw.OverlaySplitView` collapses the sidebar at the same breakpoint the inspector uses.

## Animated character cards + hover steering
- Character cards now show the character **walking** (default: down) via a new compact `CharacterCardPreview` (animation core like `CharacterPreview`, but pad-free).
- **Hovering** a card fades in four **direction arrows** (up/down/left/right) over the sprite; clicking one spins the character to walk that way — without opening the detail page.

## Three-dots menu (GNOME HIG)
- The per-card delete **trash icon is replaced by a standard `Gtk.MenuButton` (view-more-symbolic) + `Gio.Menu`** with a "Delete …" item — the conventional Adwaita/GTK4 per-item menu. Built-ins still get no menu (nothing to delete).

## Plumbing
- `CardGallery.setItems` takes an optional `buildPreview` factory (custom preview widget per card; falls back to the static paintable) and gains an `item-opened` signal for double-click.

## Validation
- `gjsify foreach check` / `build` / `check:barrels` green; engine tests pass.
- Verified live via the MCP bridge: desktop Cast + Tiles quick-view sidebars (selected-card info + Edit), animated walk frame on the cards, the three-dots menu in the corner, and phone collapsing the sidebar to a single-column card list. (Hover arrows / menu-open / double-click use standard GTK widgets and aren't pointer-driveable via the MCP bridge.)