### PR TITLE
fix: overview nav glitches (resize/phone) + Edit in the card menu

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -1237,6 +1237,10 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       // about the new project so their views can hydrate.
       this._castCtl?.setProject(project)
       this._tilesCtl?.setProject(project)
+      // A fresh project starts on the card overview, not a stale detail
+      // page left over from the previous project.
+      this._cast_view.resetToOverview()
+      this._tiles_view.resetToOverview()
       // Force the engine to reload its project on the next scene-editor entry.
       this._engineCtl.invalidateCache()
       // Record success in the recent-projects store + refresh the

--- a/apps/maker-gjs/src/widgets/cast-view.ts
+++ b/apps/maker-gjs/src/widgets/cast-view.ts
@@ -208,9 +208,6 @@ export class CastView extends Adw.Bin {
    */
   vfunc_map(): void {
     super.vfunc_map()
-    // Re-entering the Cast section (mode switch) lands on the gallery
-    // overview, not a stale detail page — the card view is the hub.
-    if (this._nav.get_visible_page()?.tag !== 'gallery') this._nav.replace_with_tags(['gallery'])
     this.signals.connect(this._mode_rail, 'mode-changed', (_v: ModeRail, mode: string) => {
       this.emit('mode-changed', mode)
     })
@@ -287,12 +284,14 @@ export class CastView extends Adw.Bin {
 
   /**
    * Drill into the detail sub-page for the active character (preview +
-   * animations + inspector). Auto-reveals the inspector on roomy
-   * layouts. No-op if already on the detail page.
+   * animations + inspector). On roomy layouts the inspector auto-opens
+   * (side-by-side); on narrow ones it stays CLOSED so the page lands on
+   * the content, not an inspector overlay (the user opens it via the
+   * toggle). No-op if already on the detail page.
    */
   private _openDetail(): void {
     if (!this._activeCharacterId) return
-    if (!this._inspectorCollapsed) this.showInspector = true
+    this.showInspector = !this._inspectorCollapsed
     if (this._nav.get_visible_page()?.tag !== 'detail') this._nav.push_by_tag('detail')
   }
 
@@ -395,6 +394,17 @@ export class CastView extends Adw.Bin {
   }
 
   /**
+   * Reset the navigation to the gallery overview. Called by the host on
+   * a project swap so a freshly-opened project starts on the card list
+   * rather than a stale detail page. (Deliberately NOT done on every
+   * re-map — that fired on window resize / sidebar overlay transitions
+   * and yanked the user out of the editor.)
+   */
+  resetToOverview(): void {
+    if (this._nav.get_visible_page()?.tag !== 'gallery') this._nav.replace_with_tags(['gallery'])
+  }
+
+  /**
    * Select a character AND open its detail page. Used after creation
    * (land on the new character to edit it) and by the `win.open-character`
    * action (tooling drill-in).
@@ -468,6 +478,10 @@ export class CastView extends Adw.Bin {
     // drills straight into the detail page there). Expanded = desktop →
     // show it. The user can still toggle it via the header button.
     this.showQuickview = !value
+    // Collapsing also closes the detail inspector so shrinking the
+    // window while editing doesn't pop an inspector overlay over the
+    // content; it stays reachable via the toggle.
+    if (value) this.showInspector = false
   }
 
   /**

--- a/apps/maker-gjs/src/widgets/tiles-view.ts
+++ b/apps/maker-gjs/src/widgets/tiles-view.ts
@@ -179,9 +179,6 @@ export class TilesView extends Adw.Bin {
    */
   vfunc_map(): void {
     super.vfunc_map()
-    // Re-entering the Tiles section (mode switch) lands on the gallery
-    // overview, not a stale detail page — the card view is the hub.
-    if (this._nav.get_visible_page()?.tag !== 'gallery') this._nav.replace_with_tags(['gallery'])
     this.signals.connect(this._mode_rail, 'mode-changed', (_v: ModeRail, mode: string) => {
       this.emit('mode-changed', mode)
     })
@@ -281,6 +278,9 @@ export class TilesView extends Adw.Bin {
     // Collapsed = narrow/phone → hide the gallery quick-view (a tap
     // drills straight into the detail page). Expanded = desktop → show.
     this.showQuickview = !value
+    // Collapsing closes the inspector so shrinking while editing doesn't
+    // pop an overlay over the palette; it stays reachable via the toggle.
+    if (value) this.showInspector = false
   }
 
   /**
@@ -346,6 +346,15 @@ export class TilesView extends Adw.Bin {
   /** Sync the ModeRail's active mode (called when the host changes view). */
   syncActiveMode(mode: EditorMode): void {
     this._mode_rail.activeMode = mode
+  }
+
+  /**
+   * Reset navigation to the gallery overview — called by the host on a
+   * project swap. Not done on every re-map (that fired on resize and
+   * yanked the user out of the editor).
+   */
+  resetToOverview(): void {
+    if (this._nav.get_visible_page()?.tag !== 'gallery') this._nav.replace_with_tags(['gallery'])
   }
 
   /** Select a tileset by id + open its detail page (host / MCP entry). */

--- a/packages/gjs/src/widgets/common/card-gallery.ts
+++ b/packages/gjs/src/widgets/common/card-gallery.ts
@@ -75,6 +75,7 @@ export class CardGallery extends Adw.Bin {
   private _emptyTitle = _('Nothing here yet')
   private _emptyIcon = 'view-grid-symbolic'
   private _deleteTooltip = _('Delete')
+  private _openLabel = _('Edit')
   private _activeId: string | null = null
   private _hoveredId: string | null = null
   /** card-button by item id, so `setActiveId` can move the selection ring. */
@@ -109,6 +110,13 @@ export class CardGallery extends Adw.Bin {
             "Label of the delete item in each card's three-dots menu",
             GObject.ParamFlags.READWRITE,
             _('Delete'),
+          ),
+          'open-label': GObject.ParamSpec.string(
+            'open-label',
+            'Open Label',
+            "Label of the open/edit item in each card's three-dots menu",
+            GObject.ParamFlags.READWRITE,
+            _('Edit'),
           ),
         },
         Signals: {
@@ -161,6 +169,16 @@ export class CardGallery extends Adw.Bin {
     if (this._deleteTooltip === value) return
     this._deleteTooltip = value
     this.notify('delete-tooltip')
+  }
+
+  get openLabel(): string {
+    return this._openLabel ?? _('Edit')
+  }
+
+  set openLabel(value: string) {
+    if (this._openLabel === value) return
+    this._openLabel = value
+    this.notify('open-label')
   }
 
   /**
@@ -309,29 +327,33 @@ export class CardGallery extends Adw.Bin {
 
     // Per-card actions live in a standard GNOME three-dots menu
     // (`Gtk.MenuButton` + `Gio.Menu`) in the corner — not a bare trash
-    // icon. Only deletable items get the menu (built-ins have no
-    // actions). The `card.delete` action drives the host's confirm +
-    // removal via `delete-requested`.
+    // icon. "Edit" (→ open the detail page) is always offered; "Delete"
+    // only for deletable items (built-ins can't be removed). The actions
+    // drive the host via `item-opened` / `delete-requested`.
+    const menu = Gio.Menu.new()
+    menu.append(this.openLabel, 'card.open')
+    if (item.deletable) menu.append(this.deleteTooltip, 'card.delete')
+    const menuButton = new Gtk.MenuButton({
+      iconName: 'view-more-symbolic',
+      tooltipText: _('More options'),
+      cssClasses: ['flat', 'circular', 'card-gallery-menu'],
+      halign: Gtk.Align.END,
+      valign: Gtk.Align.START,
+      marginTop: 6,
+      marginEnd: 6,
+      menuModel: menu,
+    })
+    const group = new Gio.SimpleActionGroup()
+    const openAction = new Gio.SimpleAction({ name: 'open' })
+    openAction.connect('activate', () => this.emit('item-opened', item.id))
+    group.add_action(openAction)
     if (item.deletable) {
-      const menu = Gio.Menu.new()
-      menu.append(this.deleteTooltip, 'card.delete')
-      const menuButton = new Gtk.MenuButton({
-        iconName: 'view-more-symbolic',
-        tooltipText: _('More options'),
-        cssClasses: ['flat', 'circular', 'card-gallery-menu'],
-        halign: Gtk.Align.END,
-        valign: Gtk.Align.START,
-        marginTop: 6,
-        marginEnd: 6,
-        menuModel: menu,
-      })
-      const group = new Gio.SimpleActionGroup()
       const deleteAction = new Gio.SimpleAction({ name: 'delete' })
       deleteAction.connect('activate', () => this.emit('delete-requested', item.id))
       group.add_action(deleteAction)
-      menuButton.insert_action_group('card', group)
-      overlay.add_overlay(menuButton)
     }
+    menuButton.insert_action_group('card', group)
+    overlay.add_overlay(menuButton)
 
     this._cardsById.set(item.id, card)
     return overlay


### PR DESCRIPTION
Fixes reported on the Cast/Tiles overviews.

## Edit in the three-dots menu
- The per-card three-dots menu now offers **Edit** (→ opens the detail/edit page) in addition to Delete. It's always shown (built-ins are editable, just not deletable).

## Navigation glitches
- **Resizing while editing dumped you back on the gallery.** The "reset to overview" was firing from `vfunc_map` on *every* re-map — including window resizes and sidebar-overlay transitions — so crossing the breakpoint mid-edit popped you out of the editor. It now runs only on a real **project swap** (the host calls `resetToOverview()` on load), so resize/collapse leave your current page alone.
- **Phone: tapping a card popped the inspector overlay instead of the page.** `_openDetail` now opens the inspector only on roomy layouts; on narrow ones it stays closed (and collapsing closes it), so a card tap lands on the detail **content** (preview + animations / palette), with the inspector reachable via its toggle. Closing it no longer bounces you to the overview.

## Validation
- `gjsify foreach check` / `build` / `check:barrels` green; engine tests pass.
- Verified live via MCP: opened a character on desktop, shrank to phone → **stayed on the detail page** (previously reset to the gallery), inspector not overlaid. (The menu's Edit item is a standard `Gio.Menu` action; menu-open isn't pointer-driveable via the bridge.)