### PR TITLE
fix: inline the detail inspector (one back button) + auto-close the overlay rail

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -1060,6 +1060,13 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     }
     this._stack.set_visible_child_name(name)
 
+    // When the mode rail is an overlay (narrow widths, `library-collapsed`),
+    // selecting a page through it should dismiss it so the chosen view
+    // isn't left covered. On wide layouts the rail is pinned and stays.
+    if (name !== 'welcome' && this._cast_view.libraryCollapsed) {
+      this.set_property('show-library', false)
+    }
+
     // Keep `win.mode` in sync with the visible view so the mode rail's
     // active row matches what's on screen. `welcome` doesn't have a
     // mode — leave the action where it was so going welcome → back-to-

--- a/apps/maker-gjs/src/widgets/cast-view.blp
+++ b/apps/maker-gjs/src/widgets/cast-view.blp
@@ -195,80 +195,74 @@ template $CastView : Adw.Bin {
       }
 
       // ── Detail (drill-down) ───────────────────────────────────────
+      // ONE page, ONE header (the NavigationView back button). The
+      // inspector is INLINED into the content flow — not an overlay
+      // sidebar with its own header — so there's no second back/close
+      // button and no overlay to dismiss. Desktop lays preview +
+      // animations beside the inspector; phone stacks them.
       Adw.NavigationPage detail_page {
         tag: "detail";
         title: _("Character");
 
-        child: Adw.OverlaySplitView inner_split {
-          sidebar-position: end;
-          min-sidebar-width: 280;
-          max-sidebar-width: 360;
-          pin-sidebar: true;
-          collapsed: bind template.inspector-collapsed;
-          show-sidebar: bind template.show-inspector bidirectional;
+        child: Adw.ToolbarView {
+          top-bar-style: flat;
 
-          sidebar: $PixelRpgCastInspector inspector {
-            collapsed: bind template.inspector-collapsed;
-          };
+          [top]
+          Adw.HeaderBar {
+            show-start-title-buttons: false;
+            show-end-title-buttons: false;
+          }
 
-          content: Adw.ToolbarView {
-            top-bar-style: flat;
+          content: Gtk.ScrolledWindow {
+            hexpand: true;
+            vexpand: true;
+            hscrollbar-policy: never;
 
-            [top]
-            Adw.HeaderBar {
-              show-start-title-buttons: false;
-              show-end-title-buttons: false;
+            child: Adw.Clamp {
+              maximum-size: 900;
+              tightening-threshold: 600;
 
-              [end]
-              Gtk.ToggleButton inspector_toggle {
-                icon-name: "sidebar-show-right-symbolic";
-                tooltip-text: _("Toggle inspector");
-                active: bind template.show-inspector bidirectional;
-              }
-            }
+              child: Adw.BreakpointBin {
+                width-request: 1;
+                height-request: 1;
 
-            content: Gtk.ScrolledWindow {
-              hexpand: true;
-              vexpand: true;
-              hscrollbar-policy: never;
+                // Desktop / tablet: the preview + animations column sits
+                // beside the inspector. Below the breakpoint everything
+                // stacks in one column (phone).
+                Adw.Breakpoint {
+                  condition ("min-width: 680sp")
 
-              child: Adw.Clamp {
-                maximum-size: 960;
-                tightening-threshold: 480;
-
-                child: Adw.BreakpointBin {
-                  width-request: 1;
-                  height-request: 1;
-
-                  // Desktop / large tablet: preview sits to the left of
-                  // the animations list. Below the breakpoint they stack
-                  // in a single column (phone).
-                  Adw.Breakpoint {
-                    condition ("min-width: 800sp")
-
-                    setters {
-                      detail_box.orientation: horizontal;
-                      detail_box.spacing: 24;
-                      preview.frame-size: 240;
-                      preview.halign: start;
-                      preview.valign: start;
-                    }
+                  setters {
+                    detail_box.orientation: horizontal;
+                    detail_box.spacing: 24;
+                    main_col.hexpand: true;
+                    inspector.valign: start;
+                    inspector.width-request: 320;
                   }
+                }
 
-                  child: Gtk.Box detail_box {
+                child: Gtk.Box detail_box {
+                  orientation: vertical;
+                  spacing: 24;
+                  margin-top: 24;
+                  margin-bottom: 24;
+                  margin-start: 24;
+                  margin-end: 24;
+
+                  Gtk.Box main_col {
                     orientation: vertical;
                     spacing: 16;
-                    margin-top: 24;
-                    margin-bottom: 24;
-                    margin-start: 24;
-                    margin-end: 24;
 
-                    $PixelRpgCharacterPreview preview {}
+                    $PixelRpgCharacterPreview preview {
+                      halign: center;
+                    }
 
                     $PixelRpgAnimationList anim_list {
                       hexpand: true;
                     }
-                  };
+                  }
+
+                  $PixelRpgCastInspector inspector {}
                 };
               };
             };

--- a/apps/maker-gjs/src/widgets/cast-view.ts
+++ b/apps/maker-gjs/src/widgets/cast-view.ts
@@ -283,15 +283,14 @@ export class CastView extends Adw.Bin {
   }
 
   /**
-   * Drill into the detail sub-page for the active character (preview +
-   * animations + inspector). On roomy layouts the inspector auto-opens
-   * (side-by-side); on narrow ones it stays CLOSED so the page lands on
-   * the content, not an inspector overlay (the user opens it via the
-   * toggle). No-op if already on the detail page.
+   * Drill into the detail sub-page for the active character. The detail
+   * page is a single scrolling column (preview + animations + the
+   * inlined inspector), responsive via its own breakpoint — no overlay
+   * sidebar, so there's just the one NavigationView back button. No-op
+   * if already on the detail page.
    */
   private _openDetail(): void {
     if (!this._activeCharacterId) return
-    this.showInspector = !this._inspectorCollapsed
     if (this._nav.get_visible_page()?.tag !== 'detail') this._nav.push_by_tag('detail')
   }
 
@@ -478,10 +477,6 @@ export class CastView extends Adw.Bin {
     // drills straight into the detail page there). Expanded = desktop →
     // show it. The user can still toggle it via the header button.
     this.showQuickview = !value
-    // Collapsing also closes the detail inspector so shrinking the
-    // window while editing doesn't pop an inspector overlay over the
-    // content; it stays reachable via the toggle.
-    if (value) this.showInspector = false
   }
 
   /**

--- a/apps/maker-gjs/src/widgets/tiles-view.blp
+++ b/apps/maker-gjs/src/widgets/tiles-view.blp
@@ -177,59 +177,75 @@ template $TilesView : Adw.Bin {
       }
 
       // ── Detail (drill-down) ───────────────────────────────────────
+      // ONE page, ONE header (the NavigationView back button). The tile
+      // inspector is INLINED beside the palette (desktop) / below it
+      // (phone) — not an overlay sidebar with its own header.
       Adw.NavigationPage detail_page {
         tag: "detail";
         title: _("Tileset");
 
-        child: Adw.OverlaySplitView inner_split {
-          sidebar-position: end;
-          min-sidebar-width: 280;
-          max-sidebar-width: 360;
-          pin-sidebar: true;
-          collapsed: bind template.inspector-collapsed;
-          show-sidebar: bind template.show-inspector bidirectional;
+        child: Adw.ToolbarView {
+          top-bar-style: flat;
 
-          sidebar: $PixelRpgTileInspector inspector {
-            collapsed: bind template.inspector-collapsed;
-          };
+          [top]
+          Adw.HeaderBar {
+            show-start-title-buttons: false;
+            show-end-title-buttons: false;
+          }
 
-          content: Adw.ToolbarView {
-            top-bar-style: flat;
+          content: Adw.BreakpointBin {
+            width-request: 1;
+            height-request: 1;
 
-            [top]
-            Adw.HeaderBar {
-              show-start-title-buttons: false;
-              show-end-title-buttons: false;
+            Adw.Breakpoint {
+              condition ("min-width: 680sp")
 
-              [end]
-              Gtk.ToggleButton inspector_toggle {
-                icon-name: "sidebar-show-right-symbolic";
-                tooltip-text: _("Toggle inspector");
-                active: bind template.show-inspector bidirectional;
+              setters {
+                detail_box.orientation: horizontal;
+                inspector_scroller.hexpand: false;
+                inspector_scroller.width-request: 320;
+                inspector_scroller.vexpand: true;
               }
             }
 
-            // Dedicated ScrolledWindow around the palette so it scrolls
-            // vertically once the grid has more rows than fit. `wrap`
-            // lets the FlowBox flow against the available width.
-            content: Gtk.ScrolledWindow palette_scroller {
-              hexpand: true;
-              vexpand: true;
-              hscrollbar-policy: never;
-              vscrollbar-policy: automatic;
+            child: Gtk.Box detail_box {
+              orientation: vertical;
 
-              child: $PixelRpgTilePalette palette {
-                wrap: true;
-                halign: fill;
-                valign: start;
+              // Dedicated ScrolledWindow around the palette so it scrolls
+              // vertically once the grid has more rows than fit. `wrap`
+              // lets the FlowBox flow against the available width.
+              Gtk.ScrolledWindow palette_scroller {
                 hexpand: true;
-                vexpand: false;
-                tile-size: 32;
-                margin-top: 16;
-                margin-bottom: 16;
-                margin-start: 16;
-                margin-end: 16;
-              };
+                vexpand: true;
+                hscrollbar-policy: never;
+                vscrollbar-policy: automatic;
+
+                child: $PixelRpgTilePalette palette {
+                  wrap: true;
+                  halign: fill;
+                  valign: start;
+                  hexpand: true;
+                  vexpand: false;
+                  tile-size: 32;
+                  margin-top: 16;
+                  margin-bottom: 16;
+                  margin-start: 16;
+                  margin-end: 16;
+                };
+              }
+
+              Gtk.ScrolledWindow inspector_scroller {
+                hscrollbar-policy: never;
+                vscrollbar-policy: automatic;
+                propagate-natural-height: true;
+
+                child: $PixelRpgTileInspector inspector {
+                  margin-top: 16;
+                  margin-bottom: 16;
+                  margin-start: 16;
+                  margin-end: 16;
+                };
+              }
             };
           };
         };

--- a/apps/maker-gjs/src/widgets/tiles-view.ts
+++ b/apps/maker-gjs/src/widgets/tiles-view.ts
@@ -194,15 +194,10 @@ export class TilesView extends Adw.Bin {
     })
     this.signals.connect(this._quick_edit, 'clicked', () => this._openDetail())
     this.signals.connect(this._palette, 'tile-selected', (_p: TilePalette, tileId: number) => {
+      // The inspector is inlined into the detail page (beside / below the
+      // palette), so picking a tile just refreshes it — no overlay to open.
       this._selectedSpriteId = tileId
       this._refreshInspector()
-      // Auto-open the right inspector when the user picks a tile —
-      // see [right-inspector auto-open policy] in
-      // `docs/concepts/responsive-chrome.md`. The inspector now has
-      // content to show (Solid switch + Surface combo for the picked
-      // sprite); leaving it closed hides the only configuration
-      // surface the click produced.
-      this.showInspector = true
     })
     this.signals.connect(this._inspector, 'solid-changed', (_v: TileInspector, solid: boolean) => {
       const active = this._activeSpriteSet()
@@ -278,9 +273,6 @@ export class TilesView extends Adw.Bin {
     // Collapsed = narrow/phone → hide the gallery quick-view (a tap
     // drills straight into the detail page). Expanded = desktop → show.
     this.showQuickview = !value
-    // Collapsing closes the inspector so shrinking while editing doesn't
-    // pop an overlay over the palette; it stays reachable via the toggle.
-    if (value) this.showInspector = false
   }
 
   /**

--- a/packages/gjs/src/widgets/cast/cast-inspector.blp
+++ b/packages/gjs/src/widgets/cast/cast-inspector.blp
@@ -1,93 +1,59 @@
 using Gtk 4.0;
 using Adw 1;
 
+// Header-less inspector — embedded directly into the Cast detail page's
+// content flow (NOT an overlay sidebar). One back button on the page
+// owns navigation; the inspector is just the editable property groups.
 template $PixelRpgCastInspector : Adw.Bin {
   styles ["cast-inspector"]
 
-  Adw.ToolbarView {
-    top-bar-style: flat;
+  Gtk.Box {
+    orientation: vertical;
+    spacing: 12;
 
-    // Flat header for window-drag — the window-close X is gone
-    // (quitting lives in the mode-rail's primary menu now).
-    // `[start]` close only shows in overlay-drawer mode; see
-    // `right-inspector.blp` for the rationale.
-    [top]
-    Adw.HeaderBar {
-      show-title: false;
-      show-start-title-buttons: false;
-      show-end-title-buttons: false;
-      styles ["flat"]
+    Adw.PreferencesGroup props_group {
+      title: _("Character");
 
-      [start]
-      Gtk.Button {
-        visible: bind template.collapsed;
-        icon-name: "window-close-symbolic";
-        action-name: "win.toggle-inspector";
-        tooltip-text: _("Close inspector");
-        styles ["flat", "circular"]
+      Adw.EntryRow name_row {
+        title: _("Name");
+      }
+
+      Adw.SwitchRow player_row {
+        title: _("Player character");
+        subtitle: _("Spawns at the map's player spawn-point and obeys keyboard input.");
+      }
+
+      Adw.SpinRow speed_row {
+        title: _("Movement speed");
+        subtitle: _("Tiles per second");
+        adjustment: Gtk.Adjustment {
+          lower: 1;
+          upper: 16;
+          step-increment: 1;
+          value: 6;
+        };
       }
     }
 
-    content: Gtk.WindowHandle {
-      child: Gtk.ScrolledWindow {
-        hexpand: true;
-        vexpand: true;
-        hscrollbar-policy: never;
+    Adw.PreferencesGroup duration_group {
+      title: _("Selected animation");
+      description: _("Edit duration; frame editing lands in the next pass.");
 
-        child: Gtk.Box {
-          orientation: vertical;
-          margin-top: 12;
-          margin-bottom: 12;
-          margin-start: 12;
-          margin-end: 12;
-          spacing: 12;
+      Adw.ActionRow selected_anim_row {
+        title: _("Animation");
+        subtitle: _("(none selected)");
+      }
 
-          Adw.PreferencesGroup props_group {
-            title: _("Character");
-
-            Adw.EntryRow name_row {
-              title: _("Name");
-            }
-
-            Adw.SwitchRow player_row {
-              title: _("Player character");
-              subtitle: _("Spawns at the map's player spawn-point and obeys keyboard input.");
-            }
-
-            Adw.SpinRow speed_row {
-              title: _("Movement speed");
-              subtitle: _("Tiles per second");
-              adjustment: Gtk.Adjustment {
-                lower: 1;
-                upper: 16;
-                step-increment: 1;
-                value: 6;
-              };
-            }
-          }
-
-          Adw.PreferencesGroup duration_group {
-            title: _("Selected animation");
-            description: _("Edit duration; frame editing lands in the next pass.");
-
-            Adw.ActionRow selected_anim_row {
-              title: _("Animation");
-              subtitle: _("(none selected)");
-            }
-
-            Adw.SpinRow duration_row {
-              title: _("Frame duration");
-              subtitle: _("Milliseconds");
-              adjustment: Gtk.Adjustment {
-                lower: 30;
-                upper: 2000;
-                step-increment: 10;
-                value: 200;
-              };
-            }
-          }
+      Adw.SpinRow duration_row {
+        title: _("Frame duration");
+        subtitle: _("Milliseconds");
+        adjustment: Gtk.Adjustment {
+          lower: 30;
+          upper: 2000;
+          step-increment: 10;
+          value: 200;
         };
-      };
-    };
+      }
+    }
   }
 }

--- a/packages/gjs/src/widgets/cast/cast-inspector.ts
+++ b/packages/gjs/src/widgets/cast/cast-inspector.ts
@@ -27,7 +27,6 @@ export class CastInspector extends Adw.Bin {
   private _animation: CharacterAnimation | null = null
   /** Set during host-driven refresh so input changes don't loop back. */
   private _silentUpdate = false
-  private _collapsed = false
 
   static {
     GObject.registerClass(
@@ -35,19 +34,6 @@ export class CastInspector extends Adw.Bin {
         GTypeName: 'PixelRpgCastInspector',
         Template,
         InternalChildren: ['name_row', 'player_row', 'speed_row', 'selected_anim_row', 'duration_row'],
-        Properties: {
-          // Mirrors the parent view's `inspector-collapsed` — drives
-          // the in-overlay close button. See
-          // `docs/concepts/responsive-chrome.md` § "In-overlay close
-          // affordance".
-          collapsed: GObject.ParamSpec.boolean(
-            'collapsed',
-            'Collapsed',
-            'Whether the inspector is in overlay-drawer mode (narrow widths)',
-            GObject.ParamFlags.READWRITE,
-            false,
-          ),
-        },
         Signals: {
           'name-changed': { param_types: [GObject.TYPE_STRING] },
           'player-changed': { param_types: [GObject.TYPE_BOOLEAN] },
@@ -57,16 +43,6 @@ export class CastInspector extends Adw.Bin {
       },
       CastInspector,
     )
-  }
-
-  get collapsed(): boolean {
-    return this._collapsed
-  }
-
-  set collapsed(value: boolean) {
-    if (this._collapsed === value) return
-    this._collapsed = value
-    this.notify('collapsed')
   }
 
   constructor() {

--- a/packages/gjs/src/widgets/tiles/tile-inspector.blp
+++ b/packages/gjs/src/widgets/tiles/tile-inspector.blp
@@ -1,99 +1,65 @@
 using Gtk 4.0;
 using Adw 1;
 
+// Header-less inspector — embedded directly into the Tiles detail page's
+// content flow (NOT an overlay sidebar). The detail page owns navigation
+// via its single back button; this is just the selected-tile properties.
 template $PixelRpgTileInspector : Adw.Bin {
   styles ["tile-inspector"]
 
-  Adw.ToolbarView {
-    top-bar-style: flat;
+  Gtk.Box {
+    orientation: vertical;
+    spacing: 12;
 
-    // Flat header for window-drag — the window-close X is gone
-    // (quitting lives in the mode-rail's primary menu now).
-    // `[start]` close only shows in overlay-drawer mode; see
-    // `right-inspector.blp` for the rationale.
-    [top]
-    Adw.HeaderBar {
-      show-title: false;
-      show-start-title-buttons: false;
-      show-end-title-buttons: false;
-      styles ["flat"]
+    Gtk.Frame preview_frame {
+      halign: center;
+      width-request: 96;
+      height-request: 96;
+      styles ["card"]
 
-      [start]
-      Gtk.Button {
-        visible: bind template.collapsed;
-        icon-name: "window-close-symbolic";
-        action-name: "win.toggle-inspector";
-        tooltip-text: _("Close inspector");
-        styles ["flat", "circular"]
+      child: Gtk.Picture preview {
+        content-fit: fill;
+        halign: center;
+        valign: center;
+        can-shrink: false;
+        width-request: 80;
+        height-request: 80;
+        margin-top: 8;
+        margin-bottom: 8;
+        margin-start: 8;
+        margin-end: 8;
+      };
+    }
+
+    Gtk.Label title_label {
+      label: _("No tile selected");
+      halign: center;
+      styles ["title-4"]
+    }
+
+    Adw.PreferencesGroup collision_group {
+      title: _("Collision");
+      description: _("How the player interacts with this tile during playtest.");
+
+      Adw.SwitchRow solid_row {
+        title: _("Solid");
+        subtitle: _("Blocks the player. Every placement of this tile on every map inherits the flag.");
+        sensitive: false;
       }
     }
 
-    content: Gtk.WindowHandle {
-      child: Gtk.ScrolledWindow {
-        hexpand: true;
-        vexpand: true;
-        hscrollbar-policy: never;
+    Adw.PreferencesGroup properties_group {
+      title: _("Tile properties");
+      description: _("Semantic metadata consumed by gameplay systems (audio, encounters, surface effects).");
 
-        child: Gtk.Box {
-          orientation: vertical;
-          margin-top: 12;
-          margin-bottom: 12;
-          margin-start: 12;
-          margin-end: 12;
-          spacing: 12;
-
-          Gtk.Frame preview_frame {
-            halign: center;
-            width-request: 96;
-            height-request: 96;
-            styles ["card"]
-
-            child: Gtk.Picture preview {
-              content-fit: fill;
-              halign: center;
-              valign: center;
-              can-shrink: false;
-              width-request: 80;
-              height-request: 80;
-              margin-top: 8;
-              margin-bottom: 8;
-              margin-start: 8;
-              margin-end: 8;
-            };
-          }
-
-          Gtk.Label title_label {
-            label: _("No tile selected");
-            halign: center;
-            styles ["title-4"]
-          }
-
-          Adw.PreferencesGroup collision_group {
-            title: _("Collision");
-            description: _("How the player interacts with this tile during playtest.");
-
-            Adw.SwitchRow solid_row {
-              title: _("Solid");
-              subtitle: _("Blocks the player. Every placement of this tile on every map inherits the flag.");
-              sensitive: false;
-            }
-          }
-
-          Adw.PreferencesGroup properties_group {
-            title: _("Tile properties");
-            description: _("Semantic metadata consumed by gameplay systems (audio, encounters, surface effects).");
-
-            Adw.ComboRow surface_row {
-              title: _("Surface");
-              subtitle: _("Influences footstep sounds + encounter tables.");
-              sensitive: false;
-              model: Gtk.StringList {
-                strings [_("None"), _("Grass"), _("Dirt"), _("Stone"), _("Wood"), _("Water"), _("Sand"), _("Snow")]
-              };
-            }
-          }
+      Adw.ComboRow surface_row {
+        title: _("Surface");
+        subtitle: _("Influences footstep sounds + encounter tables.");
+        sensitive: false;
+        model: Gtk.StringList {
+          strings [_("None"), _("Grass"), _("Dirt"), _("Stone"), _("Wood"), _("Water"), _("Sand"), _("Snow")]
         };
-      };
-    };
+      }
+    }
   }
 }

--- a/packages/gjs/src/widgets/tiles/tile-inspector.ts
+++ b/packages/gjs/src/widgets/tiles/tile-inspector.ts
@@ -31,7 +31,6 @@ export class TileInspector extends Adw.Bin {
   private _sprite: SpriteDataSet | null = null
   /** Set during host-driven refresh so input changes don't loop back. */
   private _silentUpdate = false
-  private _collapsed = false
 
   static {
     GObject.registerClass(
@@ -39,19 +38,6 @@ export class TileInspector extends Adw.Bin {
         GTypeName: 'PixelRpgTileInspector',
         Template,
         InternalChildren: ['preview', 'title_label', 'solid_row', 'surface_row'],
-        Properties: {
-          // Mirrors the parent view's `inspector-collapsed` — drives
-          // the in-overlay close button. See
-          // `docs/concepts/responsive-chrome.md` § "In-overlay close
-          // affordance".
-          collapsed: GObject.ParamSpec.boolean(
-            'collapsed',
-            'Collapsed',
-            'Whether the inspector is in overlay-drawer mode (narrow widths)',
-            GObject.ParamFlags.READWRITE,
-            false,
-          ),
-        },
         Signals: {
           'solid-changed': { param_types: [GObject.TYPE_BOOLEAN] },
           'surface-changed': { param_types: [GObject.TYPE_STRING] },
@@ -59,16 +45,6 @@ export class TileInspector extends Adw.Bin {
       },
       TileInspector,
     )
-  }
-
-  get collapsed(): boolean {
-    return this._collapsed
-  }
-
-  set collapsed(value: boolean) {
-    if (this._collapsed === value) return
-    this._collapsed = value
-    this.notify('collapsed')
   }
 
   constructor() {


### PR DESCRIPTION
Fixes the confusing phone detail-page navigation + a sidebar dismissal request.

## One back button on the detail page (was two: back + dead close)
On phone the inspector was an `Adw.OverlaySplitView` overlay with its **own** `Adw.HeaderBar`. Because that header lives inside the detail `NavigationPage`, `Adw.NavigationView` *also* injected its back arrow into it — so the inspector showed both a `<` and a `×`, and the `×` (`win.toggle-inspector`) never handled cast/tiles, so it did nothing. Pressing `<` there popped to the gallery, not the content.

Fix: the inspectors are now **header-less** and **inlined into the detail content** (no inner split). Desktop lays the inspector beside the preview/animations (cast) or palette (tiles); phone stacks it below. Each detail page now has exactly **one** back button, no overlay, no dead close.

## Left mode rail auto-closes on selection (overlay only)
When the mode rail is an overlay (narrow widths), selecting a page through it now dismisses it so the chosen view isn't left covered. Pinned (desktop) rails stay put.

## Validation
- `gjsify foreach check` / `build` / `check:barrels` green; engine tests pass.
- Verified live via MCP: phone detail page now shows a single back button with the inspector inlined below the content; desktop detail is a clean 2-column (preview+animations | inspector); resizing between them keeps the current page; and selecting a mode through the overlay rail on phone closes the rail.