### PR TITLE
fix: opaque tile sheet + Character-under-preview cast layout

### DIFF
--- a/apps/maker-gjs/src/application.css
+++ b/apps/maker-gjs/src/application.css
@@ -1,3 +1,4 @@
 @import "@pixelrpg/gjs/index.css";
 @import "./widgets/application-window.css";
 @import "./widgets/atlas-view.css";
+@import "./widgets/tiles-view.css";

--- a/apps/maker-gjs/src/widgets/cast-view.blp
+++ b/apps/maker-gjs/src/widgets/cast-view.blp
@@ -213,57 +213,65 @@ template $CastView : Adw.Bin {
             show-end-title-buttons: false;
           }
 
-          // No outer ScrolledWindow: the page fills the window so the
-          // animation list (inside `anim_list`) can scroll on its OWN —
-          // only its rows move, the heading + "Add custom animation…"
-          // button stay put. The clamp only constrains width.
-          content: Adw.Clamp {
-            maximum-size: 900;
-            tightening-threshold: 600;
+          // The whole page scrolls (the animation list shows all its
+          // rows inline, no nested scroll). Left column / top: preview +
+          // Character properties. Right column / below: the Animations
+          // list. So Character sits under the preview on both layouts,
+          // and the properties come ABOVE the animations on phone.
+          //
+          // The BreakpointBin wraps the ScrolledWindow (NOT the other way
+          // round): it needs a fixed size from the content area to switch
+          // layouts — inside a scroller it gets unbounded height and the
+          // page then refuses to scroll.
+          content: Adw.BreakpointBin {
+            width-request: 1;
+            height-request: 1;
 
-            child: Adw.BreakpointBin {
-              width-request: 1;
-              height-request: 1;
+            Adw.Breakpoint {
+              condition ("min-width: 680sp")
 
-              // Desktop / tablet: the preview + animations column sits
-              // beside the inspector. Below the breakpoint everything
-              // stacks in one column (phone).
-              Adw.Breakpoint {
-                condition ("min-width: 680sp")
-
-                setters {
-                  detail_box.orientation: horizontal;
-                  detail_box.spacing: 24;
-                  main_col.hexpand: true;
-                  inspector.valign: start;
-                  inspector.width-request: 320;
-                }
+              setters {
+                detail_box.orientation: horizontal;
+                detail_box.spacing: 24;
+                main_col.width-request: 320;
+                main_col.valign: start;
+                anim_list.hexpand: true;
+                anim_list.valign: start;
               }
+            }
 
-              child: Gtk.Box detail_box {
-                orientation: vertical;
-                spacing: 24;
-                margin-top: 24;
-                margin-bottom: 24;
-                margin-start: 24;
-                margin-end: 24;
+            child: Gtk.ScrolledWindow {
+              hexpand: true;
+              vexpand: true;
+              hscrollbar-policy: never;
 
-                Gtk.Box main_col {
+              child: Adw.Clamp {
+                maximum-size: 900;
+                tightening-threshold: 600;
+
+                child: Gtk.Box detail_box {
                   orientation: vertical;
-                  spacing: 16;
-                  vexpand: true;
+                  spacing: 24;
+                  margin-top: 24;
+                  margin-bottom: 24;
+                  margin-start: 24;
+                  margin-end: 24;
 
-                  $PixelRpgCharacterPreview preview {
-                    halign: center;
+                  Gtk.Box main_col {
+                    orientation: vertical;
+                    spacing: 16;
+
+                    $PixelRpgCharacterPreview preview {
+                      halign: center;
+                    }
+
+                    $PixelRpgCastInspector inspector {}
                   }
 
                   $PixelRpgAnimationList anim_list {
                     hexpand: true;
-                    vexpand: true;
                   }
-                }
-
-                $PixelRpgCastInspector inspector {}
+                };
               };
             };
           };

--- a/apps/maker-gjs/src/widgets/tiles-view.css
+++ b/apps/maker-gjs/src/widgets/tiles-view.css
@@ -1,0 +1,12 @@
+/*
+ * Tile-edit bottom sheet (Tiles view). The sheet is a `Gtk.Revealer`
+ * overlaid on the palette via `Gtk.Overlay`, so it needs an OPAQUE
+ * background: Adwaita's `.card` background (`@card_bg_color`) is
+ * translucent — designed to sit on a solid surface — and let the tiles
+ * underneath bleed through. Override it with the opaque popover colour
+ * and a lift shadow so it reads as a proper sheet floating over the grid.
+ */
+.tile-sheet {
+  background-color: @popover_bg_color;
+  box-shadow: 0 2px 10px 2px rgba(0, 0, 0, 0.35);
+}

--- a/packages/gjs/src/widgets/cast/animation-list.blp
+++ b/packages/gjs/src/widgets/cast/animation-list.blp
@@ -6,7 +6,6 @@ template $PixelRpgAnimationList : Adw.Bin {
     orientation: vertical;
     spacing: 12;
 
-    // Fixed header — stays put while the list scrolls.
     Gtk.Box {
       orientation: vertical;
       spacing: 2;
@@ -26,21 +25,14 @@ template $PixelRpgAnimationList : Adw.Bin {
       }
     }
 
-    // ONLY this scrolls — not the header above or the button below.
-    Gtk.ScrolledWindow {
-      hexpand: true;
-      vexpand: true;
-      hscrollbar-policy: never;
-      vscrollbar-policy: automatic;
-
-      child: Gtk.ListBox list {
-        selection-mode: none;
-        valign: start;
-        styles ["boxed-list"]
-      };
+    // Natural height — the rows are NOT in their own scroller, so the
+    // detail page's outer scroll shows them all inline (mobile + desktop).
+    Gtk.ListBox list {
+      selection-mode: none;
+      valign: start;
+      styles ["boxed-list"]
     }
 
-    // Fixed footer — opens `AddAnimationDialog`.
     Gtk.Box {
       orientation: horizontal;
       halign: center;


### PR DESCRIPTION
Two detail-view refinements from feedback.

## Opaque tile bottom sheet
The tile-edit sheet (a `Gtk.Revealer` overlaid on the palette) used Adwaita's `.card`, whose `@card_bg_color` is **translucent** — designed to sit on a solid surface, so the tile grid bled through it. Overridden with the opaque `@popover_bg_color` + a lift shadow so it reads as a proper sheet.

## Cast detail: Character under the preview, page-scroll
- Swapped the detail columns: the **Character + Selected-animation properties now sit under the preview** (left on desktop / top on phone) and the **Animations list is the other column**.
- The whole page scrolls again (one outer `ScrolledWindow`) and the animation list shows **all its rows inline** — no nested scroll. On phone the properties come **above** the animations; the desktop two-column layout stays.

## Validation
- `gjsify foreach build` / `check` / `check:barrels` green; engine tests pass.
- Verified live via MCP: desktop = preview + Character (left) | Animations (right); phone = preview → Character → Selected animation → Animations (all rows, one page scroll). (The tile sheet's open state is a palette-click not driveable via the bridge; the opacity fix is a CSS override that loaded without warnings.)