### PR TITLE
fix: tiles don't stretch + responsive tile inspector (desktop sidebar / phone sheet)

### DIFF
--- a/apps/maker-gjs/src/widgets/tiles-view.blp
+++ b/apps/maker-gjs/src/widgets/tiles-view.blp
@@ -177,11 +177,13 @@ template $TilesView : Adw.Bin {
       }
 
       // ── Detail (drill-down) ───────────────────────────────────────
-      // ONE page, ONE header (the NavigationView back button). The
-      // palette fills the page; picking a tile slides its properties up
-      // in an `Adw.BottomSheet` (non-modal, so the palette stays live —
-      // clicking another tile just updates the sheet). The drag handle
-      // dismisses it.
+      // ONE page, ONE header (the NavigationView back button). The tile
+      // inspector is RESPONSIVE: on desktop it's a pinned right sidebar
+      // (`side_panel`); on phone it's a bottom sheet (`tile_sheet`, a
+      // slide-up `Gtk.Revealer` — the libadwaita baseline predates
+      // `Adw.BottomSheet`). The single `inspector` widget is reparented
+      // between `side_slot` and `sheet_slot` by `tiles-view.ts` based on
+      // the responsive `inspector-collapsed` state.
       Adw.NavigationPage detail_page {
         tag: "detail";
         title: _("Tileset");
@@ -195,87 +197,111 @@ template $TilesView : Adw.Bin {
             show-end-title-buttons: false;
           }
 
-          // A `Gtk.Revealer` plays the role of a bottom sheet (the
-          // libadwaita on the build/runtime baseline predates
-          // `Adw.BottomSheet`): it overlays the bottom of the palette and
-          // slides up when a tile is picked. Non-modal — the palette
-          // above stays clickable, so picking another tile just updates
-          // the sheet.
-          content: Gtk.Overlay {
-            // Dedicated ScrolledWindow around the palette so it scrolls
-            // vertically once the grid has more rows than fit. `wrap`
-            // lets the FlowBox flow against the available width.
-            child: Gtk.ScrolledWindow palette_scroller {
-              hexpand: true;
-              vexpand: true;
+          // Desktop: a pinned right sidebar holds the inspector — an
+          // `Adw.OverlaySplitView` because its `min/max-sidebar-width`
+          // reliably caps the panel to a phone-ish width (a plain Box +
+          // width-request either collapses or stretches next to the
+          // hexpanding palette). Phone: the split is collapsed + the
+          // sidebar hidden, and the inspector is reparented into the
+          // bottom-sheet revealer instead (see tiles-view.ts).
+          content: Adw.OverlaySplitView tile_split {
+            sidebar-position: end;
+            min-sidebar-width: 300;
+            max-sidebar-width: 360;
+            pin-sidebar: true;
+            collapsed: bind template.inspector-collapsed;
+
+            sidebar: Gtk.ScrolledWindow {
               hscrollbar-policy: never;
               vscrollbar-policy: automatic;
 
-              child: $PixelRpgTilePalette palette {
-                wrap: true;
-                halign: fill;
-                valign: start;
-                hexpand: true;
-                vexpand: false;
-                tile-size: 32;
+              child: Gtk.Box side_slot {
                 margin-top: 16;
                 margin-bottom: 16;
                 margin-start: 16;
                 margin-end: 16;
+
+                // Initial parent (desktop is the default layout).
+                $PixelRpgTileInspector inspector {
+                  hexpand: true;
+                }
               };
             };
 
-            [overlay]
-            Gtk.Revealer tile_sheet {
-              valign: end;
-              halign: fill;
-              transition-type: slide_up;
-              reveal-child: false;
+            content: Gtk.Overlay {
+              // Dedicated ScrolledWindow around the palette so it scrolls
+              // vertically once the grid has more rows than fit. `wrap`
+              // lets the FlowBox flow against the available width.
+              child: Gtk.ScrolledWindow palette_scroller {
+                hexpand: true;
+                vexpand: true;
+                hscrollbar-policy: never;
+                vscrollbar-policy: automatic;
 
-              child: Gtk.Box {
-                orientation: vertical;
-                margin-top: 8;
-                margin-bottom: 12;
-                margin-start: 12;
-                margin-end: 12;
-                styles ["card", "tile-sheet"]
-
-                Gtk.Box {
-                  orientation: horizontal;
-                  margin-top: 6;
-                  margin-start: 12;
-                  margin-end: 6;
-
-                  Gtk.Label {
-                    label: _("Tile");
-                    halign: start;
-                    hexpand: true;
-                    styles ["heading"]
-                  }
-
-                  Gtk.Button sheet_close {
-                    icon-name: "window-close-symbolic";
-                    tooltip-text: _("Close");
-                    valign: center;
-                    styles ["flat", "circular"]
-                  }
-                }
-
-                Gtk.ScrolledWindow {
-                  hscrollbar-policy: never;
-                  vscrollbar-policy: automatic;
-                  propagate-natural-height: true;
-                  max-content-height: 360;
-
-                  child: $PixelRpgTileInspector inspector {
-                    margin-top: 0;
-                    margin-bottom: 12;
-                    margin-start: 12;
-                    margin-end: 12;
-                  };
-                }
+                child: $PixelRpgTilePalette palette {
+                  wrap: true;
+                  halign: fill;
+                  valign: start;
+                  hexpand: true;
+                  vexpand: false;
+                  tile-size: 32;
+                  margin-top: 16;
+                  margin-bottom: 16;
+                  margin-start: 16;
+                  margin-end: 16;
+                };
               };
-            }
+
+              // Phone bottom sheet. Non-modal — the palette above stays
+              // clickable, so picking another tile just updates it.
+              [overlay]
+              Gtk.Revealer tile_sheet {
+                valign: end;
+                halign: fill;
+                transition-type: slide_up;
+                reveal-child: false;
+
+                child: Gtk.Box {
+                  orientation: vertical;
+                  margin-top: 8;
+                  margin-bottom: 12;
+                  margin-start: 12;
+                  margin-end: 12;
+                  styles ["card", "tile-sheet"]
+
+                  Gtk.Box {
+                    orientation: horizontal;
+                    margin-top: 6;
+                    margin-start: 12;
+                    margin-end: 6;
+
+                    Gtk.Label {
+                      label: _("Tile");
+                      halign: start;
+                      hexpand: true;
+                      styles ["heading"]
+                    }
+
+                    Gtk.Button sheet_close {
+                      icon-name: "window-close-symbolic";
+                      tooltip-text: _("Close");
+                      valign: center;
+                      styles ["flat", "circular"]
+                    }
+                  }
+
+                  // Inspector parented here on phone (see tiles-view.ts).
+                  Gtk.ScrolledWindow {
+                    hscrollbar-policy: never;
+                    vscrollbar-policy: automatic;
+                    propagate-natural-height: true;
+                    max-content-height: 360;
+
+                    child: Gtk.Box sheet_slot {};
+                  }
+                };
+              }
+            };
           };
         };
       }

--- a/apps/maker-gjs/src/widgets/tiles-view.ts
+++ b/apps/maker-gjs/src/widgets/tiles-view.ts
@@ -60,10 +60,14 @@ export class TilesView extends Adw.Bin {
   declare _tilesets_gallery: CardGallery
   declare _nav: Adw.NavigationView
   declare _detail_page: Adw.NavigationPage
-  // Revealer acting as a bottom sheet — slides the selected tile's
-  // properties up over the palette (non-modal). Closed via `_sheet_close`.
+  // Responsive tile inspector. On desktop the inspector lives in the
+  // pinned right sidebar of `_tile_split` (`_side_slot`); on phone it's
+  // reparented into the `_tile_sheet` bottom-sheet revealer (`_sheet_slot`).
+  declare _tile_split: Adw.OverlaySplitView
   declare _tile_sheet: Gtk.Revealer
   declare _sheet_close: Gtk.Button
+  declare _sheet_slot: Gtk.Box
+  declare _side_slot: Gtk.Box
   // Desktop gallery quick-view (read-only glance for the selected tileset).
   declare _quick_stack: Gtk.Stack
   declare _quick_thumb: Gtk.Picture
@@ -103,8 +107,11 @@ export class TilesView extends Adw.Bin {
           'tilesets_gallery',
           'nav',
           'detail_page',
+          'tile_split',
           'tile_sheet',
           'sheet_close',
+          'sheet_slot',
+          'side_slot',
           'quick_stack',
           'quick_thumb',
           'quick_name',
@@ -173,6 +180,31 @@ export class TilesView extends Adw.Bin {
 
   constructor() {
     super()
+    // Place the inspector in the slot matching the initial (desktop)
+    // layout. Later breakpoint changes re-place it via the setter.
+    this._placeInspector()
+  }
+
+  /**
+   * Move the single tile inspector into the slot that matches the
+   * current responsive layout: the pinned right `side_panel` on desktop,
+   * or the `tile_sheet` bottom-sheet revealer on phone. Toggles the
+   * sidebar's visibility to match.
+   */
+  private _placeInspector(): void {
+    const collapsed = this._inspectorCollapsed
+    const target = collapsed ? this._sheet_slot : this._side_slot
+    const current = this._inspector.get_parent()
+    if (current !== target) {
+      if (current) (current as Gtk.Box).remove(this._inspector)
+      target.append(this._inspector)
+    }
+    // Desktop: show the split's pinned sidebar. Phone: hide it (the
+    // inspector lives in the bottom sheet instead).
+    this._tile_split.set_show_sidebar(!collapsed)
+    // The phone bottom sheet only reveals on tile-select; on desktop the
+    // sidebar is always shown, so keep the sheet closed.
+    if (!collapsed) this._tile_sheet.set_reveal_child(false)
   }
 
   /**
@@ -200,11 +232,12 @@ export class TilesView extends Adw.Bin {
     })
     this.signals.connect(this._quick_edit, 'clicked', () => this._openDetail())
     this.signals.connect(this._palette, 'tile-selected', (_p: TilePalette, tileId: number) => {
-      // Picking a tile refreshes the inspector + slides the bottom sheet
-      // up (non-modal — clicking another tile just updates it).
+      // Picking a tile refreshes the inspector. On phone that means
+      // sliding the bottom sheet up; on desktop the sidebar is already
+      // visible, so it just updates in place.
       this._selectedSpriteId = tileId
       this._refreshInspector()
-      this._tile_sheet.set_reveal_child(true)
+      if (this._inspectorCollapsed) this._tile_sheet.set_reveal_child(true)
     })
     // The sheet's close button slides it back down + clears the selection.
     this.signals.connect(this._sheet_close, 'clicked', () => {
@@ -286,6 +319,9 @@ export class TilesView extends Adw.Bin {
     // Collapsed = narrow/phone → hide the gallery quick-view (a tap
     // drills straight into the detail page). Expanded = desktop → show.
     this.showQuickview = !value
+    // Re-home the tile inspector: right sidebar (desktop) ↔ bottom sheet
+    // (phone).
+    this._placeInspector()
   }
 
   /**

--- a/packages/gjs/src/widgets/editor/tile-palette.ts
+++ b/packages/gjs/src/widgets/editor/tile-palette.ts
@@ -9,6 +9,13 @@ import type { GdkSpriteSheet } from '../../sprite'
 import Template from './tile-palette.blp'
 
 /**
+ * Max swatches per line in `wrap` mode — high enough that the available
+ * width (not this cap) decides how many fixed-size tiles fit per row, so
+ * tiles never stretch to fill a wide window.
+ */
+const WRAP_MAX_CHILDREN = 64
+
+/**
  * Descriptor for a single tile shown in {@link TilePalette}.
  *
  * `color` is rendered as the fallback swatch background; `paintable`,
@@ -164,12 +171,15 @@ export class TilePalette extends Adw.Bin {
   }
 
   set columns(value: number) {
-    // `wrap` decides whether `columns` pins the grid to exactly N
-    // per line or just caps the maximum:
-    //  - off → both min + max = value (rectangular grid).
-    //  - on  → min stays at 1, max = value (wraps freely).
+    // `wrap` decides the line policy:
+    //  - off → both min + max = value (rectangular grid that stretches
+    //    to fill, scrolls horizontally if the sheet is wider).
+    //  - on  → min 1, max = a high cap (NOT `value`), so the available
+    //    width — not the sheet's column count — decides how many
+    //    fixed-size tiles fit per row. Pinning max to the column count
+    //    made a wide window stretch each cell to `width / columns`.
     this._flow.set_min_children_per_line(this._wrap ? 1 : value)
-    this._flow.set_max_children_per_line(value)
+    this._flow.set_max_children_per_line(this._wrap ? WRAP_MAX_CHILDREN : value)
     this.notify('columns')
   }
 
@@ -181,8 +191,13 @@ export class TilePalette extends Adw.Bin {
     if (this._wrap === value) return
     this._wrap = value
     this.notify('wrap')
+    // Homogeneous makes the FlowBox stretch every cell to fill its line
+    // — fine for a fixed-column grid (wrap off), but in wrap mode it
+    // stretches fixed-size tiles across a wide window. Turn it off so
+    // wrapped tiles keep their `tile-size` and just pack left.
+    this._flow.set_homogeneous(!value)
     // Reapply the current column setting under the new policy so
-    // `set columns` picks the right `min-children-per-line`.
+    // `set columns` picks the right min/max-children-per-line.
     this.columns = this.columns
   }
 
@@ -199,7 +214,11 @@ export class TilePalette extends Adw.Bin {
    * needs to be denser (e.g., inside a narrow popover).
    */
   setFromSpriteSheet(sheet: GdkSpriteSheet, names?: Record<number, string>): void {
-    this.columns = sheet.columns
+    // Only pin the column count in fixed-grid (wrap off) mode. In wrap
+    // mode the width decides the columns (high cap), so the sheet's
+    // native column count must NOT cap the line — that's what stretched
+    // a wide window's tiles.
+    if (!this._wrap) this.columns = sheet.columns
     // Capture the per-cell aspect from the first sprite so swatch
     // sizing can match (aspect-mode `contain` only — `fill` ignores
     // this and stays square). Character sprite-sheets are uniform so


### PR DESCRIPTION
Two tiles-detail fixes from feedback.

## Tiles no longer stretch at wide widths
In `wrap` mode the `TilePalette` FlowBox stayed `homogeneous` and capped `max-children-per-line` at the sheet's column count, so a wide window stretched each cell to `width / columns`. Wrap mode now turns homogeneity off (cells keep their `tile-size`) and uses a high column cap, so the available width — not the sheet's column count — decides how many fixed-size tiles fit per row. Tiles stay square.

## Responsive tile inspector — sidebar on desktop, bottom sheet on phone
Editing a tile adapts to the layout:
- **Desktop**: a pinned right sidebar (`Adw.OverlaySplitView`, whose `min/max-sidebar-width` caps it to a phone-ish ~360px — so the inspector's smartphone-tuned layout reads the same on desktop, and the palette takes the rest).
- **Phone**: the slide-up bottom sheet (a `Gtk.Revealer`).

The single `TileInspector` is reparented between the split's sidebar slot and the bottom-sheet revealer based on the responsive `inspector-collapsed` state.

## Validation
- `gjsify foreach build` / `check` / `check:barrels` green; engine tests pass.
- Verified live via MCP: at desktop-large the palette shows **square** tiles full-width + a ~360px right inspector sidebar; at phone the palette is full-width with no sidebar (inspector reparented into the bottom sheet, which reveals on tile-select). (A palette tile-click to open the sheet isn't pointer-driveable via the bridge.)