### PR TITLE
feat: separate character sprite sheets from world tilesets

### DIFF
--- a/apps/maker-gjs/src/services/cast-controller.ts
+++ b/apps/maker-gjs/src/services/cast-controller.ts
@@ -16,6 +16,7 @@ import {
   REQUIRED_ROLES,
   type SpriteSetAddPayload,
   SpriteSetFormat,
+  type SpriteSetKind,
   SpriteSetResource,
   SPRITESET_REMOVE_KIND,
 } from '@pixelrpg/engine'
@@ -302,7 +303,12 @@ export class CastController {
     const resource = this._project?.resource
     if (!resource) return []
     const usedByCharacter = new Set((resource.data?.characters ?? []).map((c) => c.spriteSetId))
+    // Only sprite SHEETS are assignable to a character — world tilesets
+    // are excluded (a character sheet is `kind: 'character'` or already
+    // referenced by a character; untagged-but-referenced sheets still
+    // qualify so legacy projects keep working).
     return [...resource.spriteSets.entries()]
+      .filter(([id, set]) => set.data?.kind === 'character' || usedByCharacter.has(id))
       .map(([id, set]) => ({ id, name: set.data?.name ?? id }))
       .sort((a, b) => Number(usedByCharacter.has(b.id)) - Number(usedByCharacter.has(a.id)))
   }
@@ -367,7 +373,10 @@ export class CastController {
    * the new set as a {@link SpriteSetChoice} for the character dialog to
    * select, or `null` if the copy/write failed.
    */
-  private async _importSpriteSet({ data, sourcePath }: SpriteSetImportResult): Promise<SpriteSetChoice | null> {
+  private async _importSpriteSet(
+    { data, sourcePath }: SpriteSetImportResult,
+    kind: SpriteSetKind = 'tileset',
+  ): Promise<SpriteSetChoice | null> {
     const resource = this._project?.resource
     if (!resource?.data) return null
     const id = this._uniqueId(data.id, new Set(resource.spriteSets.keys()))
@@ -375,6 +384,9 @@ export class CastController {
     const finalData = {
       ...data,
       id,
+      // Tag the imported set so it surfaces in the right gallery: a Cast
+      // import is a character sheet, a Tiles import is a world tileset.
+      kind,
       image: { ...(data.image ?? { id: 'main', type: 'image' as const }), path: imageFile },
     }
 
@@ -427,8 +439,8 @@ export class CastController {
    * and route its result here so the copy + register + collab-broadcast
    * path lives in one place.
    */
-  importSpriteSet(result: SpriteSetImportResult): Promise<SpriteSetChoice | null> {
-    return this._importSpriteSet(result)
+  importSpriteSet(result: SpriteSetImportResult, kind: SpriteSetKind = 'tileset'): Promise<SpriteSetChoice | null> {
+    return this._importSpriteSet(result, kind)
   }
 
   /**

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -340,7 +340,8 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     // and delete both flow through the one path so the copy/register +
     // collab broadcast live in a single place.
     this.signals.connect(this._tiles_view, 'spriteset-imported', (_v: TilesView, result: SpriteSetImportResult) => {
-      void this._castCtl?.importSpriteSet(result)
+      // Tiles imports are world tilesets.
+      void this._castCtl?.importSpriteSet(result, 'tileset')
     })
     this.signals.connect(this._tiles_view, 'spriteset-delete-requested', (_v: TilesView, id: string) => {
       this._castCtl?.deleteSpriteSet(id)

--- a/apps/maker-gjs/src/widgets/cast-view.ts
+++ b/apps/maker-gjs/src/widgets/cast-view.ts
@@ -1,7 +1,7 @@
 import Adw from '@girs/adw-1'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
-import type { CharacterAnimation, CharacterDefinition } from '@pixelrpg/engine'
+import type { CharacterAnimation, CharacterDefinition, SpriteSetKind } from '@pixelrpg/engine'
 import {
   AddAnimationDialog,
   AnimationList,
@@ -118,7 +118,9 @@ export class CastView extends Adw.Bin {
   private _onDeleteCharacterRequested: ((charId: string) => void) | null = null
   private _onListSpriteSets: (() => SpriteSetChoice[]) | null = null
   private _onCreateCharacter: ((draft: NewCharacterDraft) => void) | null = null
-  private _onImportSpriteSet: ((result: SpriteSetImportResult) => Promise<SpriteSetChoice | null>) | null = null
+  private _onImportSpriteSet:
+    | ((result: SpriteSetImportResult, kind: SpriteSetKind) => Promise<SpriteSetChoice | null>)
+    | null = null
   private _onLoadSpriteSetPreview: ((id: string) => Promise<GdkSpriteSetResource | null>) | null = null
 
   static {
@@ -384,8 +386,10 @@ export class CastView extends Adw.Bin {
    */
   private _presentSpriteSetImportDialog(onImported?: (choice: SpriteSetChoice) => void): void {
     const dialog = new SpriteSetImportDialog()
+    dialog.set_title(_('Import sprite sheet'))
     dialog.connect('spriteset-imported', (_d: SpriteSetImportDialog, result: SpriteSetImportResult) => {
-      void this._onImportSpriteSet?.(result).then((choice) => {
+      // Cast imports are character sprite sheets.
+      void this._onImportSpriteSet?.(result, 'character').then((choice) => {
         if (choice) onImported?.(choice)
       })
     })
@@ -495,7 +499,7 @@ export class CastView extends Adw.Bin {
     deleteCharacter: (charId: string) => void
     listSpriteSets: () => SpriteSetChoice[]
     createCharacter: (draft: NewCharacterDraft) => void
-    importSpriteSet: (result: SpriteSetImportResult) => Promise<SpriteSetChoice | null>
+    importSpriteSet: (result: SpriteSetImportResult, kind: SpriteSetKind) => Promise<SpriteSetChoice | null>
     loadSpriteSetPreview: (id: string) => Promise<GdkSpriteSetResource | null>
   }): void {
     this._onRenameRequested = callbacks.rename

--- a/apps/maker-gjs/src/widgets/tiles-view.ts
+++ b/apps/maker-gjs/src/widgets/tiles-view.ts
@@ -358,12 +358,19 @@ export class TilesView extends Adw.Bin {
       return
     }
 
+    // Tiles shows ONLY world tilesets — character animation sheets
+    // belong to the Cast view. Exclude any set tagged `kind: 'character'`
+    // AND any set a character references (belt-and-suspenders: catches
+    // legacy/untagged sheets like a project that predates the split).
+    const usedByCharacter = new Set((project.data?.characters ?? []).map((c) => c.spriteSetId))
+
     // Snapshot sprite-sets in project order, wrapping each as a GTK
     // resource up-front so its card can show a sheet thumbnail. Tilesets
     // are few (a handful per project) so eager wrapping is cheap and
     // keeps the gallery from popping in thumbnails one by one.
     const items: TilesetEntry[] = []
     for (const [id, resource] of project.spriteSets) {
+      if (resource.data?.kind === 'character' || usedByCharacter.has(id)) continue
       let gdk: GdkSpriteSetResource | null = null
       try {
         gdk = await GdkSpriteSetResource.fromEngineResource(resource)
@@ -412,6 +419,7 @@ export class TilesView extends Adw.Bin {
    */
   presentTilesetImportDialog(): void {
     const dialog = new SpriteSetImportDialog()
+    dialog.set_title(_('Import tileset'))
     dialog.connect('spriteset-imported', (_d: SpriteSetImportDialog, result: SpriteSetImportResult) => {
       this.emit('spriteset-imported', result)
     })

--- a/packages/engine/src/__demo__/scientist/index.ts
+++ b/packages/engine/src/__demo__/scientist/index.ts
@@ -23,6 +23,7 @@ export const BUILT_IN_SCIENTIST_SPRITESET: SpriteSetData = {
   version: '1.0.0',
   id: BUILT_IN_SCIENTIST_SPRITESET_ID,
   name: 'Scientist (built-in)',
+  kind: 'character',
   image: {
     id: 'main',
     path: SCIENTIST_PNG_DATA_URL,

--- a/packages/engine/src/types/data/SpriteSetData.ts
+++ b/packages/engine/src/types/data/SpriteSetData.ts
@@ -1,5 +1,16 @@
 import type { ImageReference } from '../reference/index'
 import type { AnimationData, EditorMetadata, Properties, SpriteDataSet } from './index'
+
+/**
+ * What a sprite set is FOR — drives which gallery surfaces it:
+ *  - `tileset`   → world-building tiles (Tiles view).
+ *  - `character` → a character animation sheet (Cast view).
+ *
+ * Absent on a {@link SpriteSetData} is treated as `tileset` (back-compat
+ * with projects written before the character/tileset split).
+ */
+export type SpriteSetKind = 'tileset' | 'character'
+
 /**
  * Represents a sprite set that can be used in a map
  * Compatible with Excalibur.js graphics system
@@ -19,6 +30,13 @@ export interface SpriteSetData {
    * Display name of the sprite set
    */
   name: string
+
+  /**
+   * Whether this set holds world tiles (`tileset`) or a character
+   * animation sheet (`character`). Absent ⇒ `tileset`. Keeps character
+   * sheets out of the Tiles gallery and vice-versa.
+   */
+  kind?: SpriteSetKind
 
   /**
    * Multiple image sources for the sprite set

--- a/packages/gjs/src/widgets/cast/new-character-dialog.blp
+++ b/packages/gjs/src/widgets/cast/new-character-dialog.blp
@@ -85,17 +85,17 @@ template $PixelRpgNewCharacterDialog : Adw.Dialog {
 
           Adw.PreferencesGroup {
             title: _("Appearance");
-            description: _("Pick an existing sprite set, or import a new image.");
+            description: _("Pick an existing sprite sheet, or import a new image.");
 
             header-suffix: Gtk.Button import_button {
               valign: center;
               icon-name: "list-add-symbolic";
-              tooltip-text: _("Import a new sprite set");
+              tooltip-text: _("Import a new sprite sheet");
               styles ["flat", "circular"]
             };
 
             Adw.ComboRow spriteset_row {
-              title: _("Sprite set");
+              title: _("Sprite sheet");
             }
           }
 

--- a/packages/gjs/src/widgets/cast/sprite-set-import-dialog.blp
+++ b/packages/gjs/src/widgets/cast/sprite-set-import-dialog.blp
@@ -67,7 +67,7 @@ template $PixelRpgSpriteSetImportDialog : Adw.Dialog {
             margin-end: 18;
 
             Adw.PreferencesGroup {
-              title: _("Sprite set");
+              title: _("Details");
 
               Adw.EntryRow name_row {
                 title: _("Name");


### PR DESCRIPTION
First of two PRs splitting character animation sheets from world tilesets (the Scientist was showing up under Tiles).

## What changed
- **`SpriteSetData.kind`** — `'tileset' | 'character'` (optional; absent ⇒ `tileset`, so existing projects are unaffected).
- **Tiles** gallery shows only tilesets — excludes `kind: 'character'` **and** any sheet a character references (belt-and-suspenders for legacy/untagged data). The built-in Scientist no longer appears under Tiles.
- **Imports tagged by entry point**: a Cast import is a `character` sprite sheet, a Tiles import is a `tileset` — a freshly imported character sheet never lands in Tiles.
- **New-Character picker** only offers sprite sheets (not tilesets).
- **Terminology**: user-facing label is now **"Sprite sheet"** (world tiles stay **"Tileset"**); the shared import dialog titles itself per caller ("Import sprite sheet" / "Import tileset").

## Validation
- `gjsify foreach build` / `check` / `check:barrels` green; engine tests pass.
- Verified live via MCP (zelda-like): Tiles shows only *Lokiri Forest* + *OoT2D Water* (Scientist gone); Cast still shows the *Scientist* character.

## Follow-up (PR B)
De-built-in the Scientist — bake it as real project files in the starter templates and drop the in-memory `_registerBuiltIns` injection so it's a normal, deletable/editable project member.