### PR TITLE
feat: Assets & project manager (Data view) + MCP set_view data

### DIFF
--- a/apps/maker-gjs/src/services/data-controller.ts
+++ b/apps/maker-gjs/src/services/data-controller.ts
@@ -1,0 +1,212 @@
+import GLib from '@girs/glib-2.0'
+import {
+  GameProjectFormat,
+  type SpriteSetData,
+  SpriteSetFormat,
+  type SpriteSetKind,
+  type SpriteSetResource,
+} from '@pixelrpg/engine'
+import { GdkSpriteSetResource } from '@pixelrpg/gjs'
+import { gettext as _ } from 'gettext'
+
+import type { DataAssetRow, DataView, DataViewModel } from '../widgets/data-view.ts'
+import { readBinaryFile, writeTextFile } from './file-io.ts'
+import type { LoadedProject } from './project-loader.ts'
+
+/** Thumbnail edge passed to the sheet downscaler (≥ the row size, for sharpness). */
+const THUMB_PX = 96
+
+/**
+ * Owns the Data view's "Assets and project" model: builds the asset
+ * list (sprite sheets + tilesets, each with a thumbnail, metadata and a
+ * "used by" count from the reference graph), persists project-metadata
+ * edits, and renames an asset's display name. Asset import/delete +
+ * "open" are routed by the host (application-window) to the shared
+ * `CastController` / actions so there's one owner of the files.
+ */
+export class DataController {
+  private _project: LoadedProject | null = null
+
+  constructor(
+    private readonly view: DataView,
+    private readonly onToast: (message: string) => void,
+  ) {}
+
+  setProject(project: LoadedProject | null): void {
+    this._project = project
+    if (!project) {
+      this.view.setData(null)
+      return
+    }
+    void this._rebuild()
+  }
+
+  /** Persist a single project-metadata field edit (no row re-render). */
+  setProjectField(field: 'name' | 'author' | 'version' | 'description' | 'tileSize', value: string): void {
+    const data = this._project?.resource?.data
+    if (!data) return
+    const props = (data.properties ??= {})
+    switch (field) {
+      case 'name':
+        data.name = value
+        props.gameTitle = value
+        break
+      case 'author':
+        props.author = value
+        break
+      case 'version':
+        props.version = value
+        break
+      case 'description':
+        props.description = value
+        break
+      case 'tileSize': {
+        const n = Number.parseInt(value, 10)
+        if (Number.isFinite(n) && n > 0) props.defaultTileSize = n
+        break
+      }
+    }
+    this._persistProject()
+  }
+
+  /** Rename an asset's display name (the `name` in its sprite-set JSON). */
+  renameSpriteSet(id: string, name: string): void {
+    const resource = this._project?.resource
+    const engineSet = resource?.spriteSets.get(id)
+    const trimmed = name.trim()
+    if (!resource || !engineSet?.data || !trimmed) return
+    engineSet.data.name = trimmed
+    const projectDir = GLib.path_get_dirname(resource.path)
+    const jsonPath = GLib.build_filenamev([projectDir, 'spritesets', `${id}.json`])
+    if (!writeTextFile(jsonPath, SpriteSetFormat.serialize(engineSet.data))) {
+      this.onToast(_('Could not rename the asset'))
+      return
+    }
+    void this._rebuild()
+  }
+
+  private _persistProject(): void {
+    const resource = this._project?.resource
+    if (!resource?.data) return
+    try {
+      if (!writeTextFile(resource.path, GameProjectFormat.serialize(resource.data))) {
+        this.onToast(_('Could not save project'))
+      }
+    } catch (err) {
+      console.warn('[DataController] Failed to persist project:', err)
+      this.onToast(_('Could not save project'))
+    }
+  }
+
+  /** Rebuild the whole view model: project metadata + asset rows + usage. */
+  private async _rebuild(): Promise<void> {
+    const resource = this._project?.resource
+    if (!resource?.data) {
+      this.view.setData(null)
+      return
+    }
+    const data = resource.data
+    const props = data.properties ?? {}
+
+    const charUsers = this._countCharacterUsers(resource)
+    const mapUsers = this._countMapUsers(resource)
+
+    const sheets: DataAssetRow[] = []
+    const tilesets: DataAssetRow[] = []
+    for (const [id, engineSet] of resource.spriteSets) {
+      const sd = engineSet.data
+      if (!sd) continue
+      const usedByChars = charUsers.get(id) ?? 0
+      const isCharacter = sd.kind === 'character' || usedByChars > 0
+      const row = await this._buildRow(
+        id,
+        engineSet,
+        sd,
+        isCharacter ? 'character' : 'tileset',
+        usedByChars,
+        mapUsers.get(id) ?? 0,
+      )
+      ;(isCharacter ? sheets : tilesets).push(row)
+    }
+    sheets.sort((a, b) => a.name.localeCompare(b.name))
+    tilesets.sort((a, b) => a.name.localeCompare(b.name))
+
+    const model: DataViewModel = {
+      name: data.name ?? '',
+      author: typeof props.author === 'string' ? props.author : '',
+      version: typeof props.version === 'string' ? props.version : '',
+      description: typeof props.description === 'string' ? props.description : '',
+      tileSize: typeof props.defaultTileSize === 'number' ? props.defaultTileSize : 16,
+      path: resource.path,
+      sheets,
+      tilesets,
+    }
+    this.view.setData(model)
+  }
+
+  private async _buildRow(
+    id: string,
+    engineSet: SpriteSetResource,
+    sd: SpriteSetData,
+    kind: SpriteSetKind,
+    usedByChars: number,
+    usedByMaps: number,
+  ): Promise<DataAssetRow> {
+    const width = sd.columns * sd.spriteWidth
+    const height = sd.rows * sd.spriteHeight
+    const count = sd.sprites?.length ?? 0
+    const unit =
+      kind === 'character' ? (count === 1 ? _('sprite') : _('sprites')) : count === 1 ? _('tile') : _('tiles')
+    let paintable = null
+    try {
+      const gdk = await GdkSpriteSetResource.fromEngineResource(engineSet)
+      paintable =
+        kind === 'character'
+          ? (gdk.getSprite(0)?.createPaintable({ keepAspectRatio: true }) ?? null)
+          : gdk.createSheetThumbnail(THUMB_PX)
+    } catch (err) {
+      console.warn('[DataController] Failed to build asset thumbnail:', err)
+    }
+    return {
+      id,
+      name: sd.name || id,
+      kind,
+      paintable,
+      meta: `${width}×${height} · ${count} ${unit}`,
+      usedBy: usedByChars + usedByMaps,
+    }
+  }
+
+  /** spriteSetId → number of characters referencing it. */
+  private _countCharacterUsers(resource: LoadedProject['resource']): Map<string, number> {
+    const out = new Map<string, number>()
+    for (const c of resource.data?.characters ?? []) {
+      out.set(c.spriteSetId, (out.get(c.spriteSetId) ?? 0) + 1)
+    }
+    return out
+  }
+
+  /**
+   * spriteSetId → number of maps referencing it. Reads each map JSON's
+   * `spriteSets[]` directly (maps aren't preloaded). Best-effort: an
+   * unreadable/garbled map is skipped, not fatal.
+   */
+  private _countMapUsers(resource: LoadedProject['resource']): Map<string, number> {
+    const out = new Map<string, number>()
+    const projectDir = GLib.path_get_dirname(resource.path)
+    for (const mapRef of resource.data?.maps ?? []) {
+      try {
+        const mapPath = GLib.build_filenamev([projectDir, mapRef.path.replace(/^\.\//, '')])
+        const bytes = readBinaryFile(mapPath)
+        if (!bytes) continue
+        const mapData = JSON.parse(new TextDecoder().decode(bytes)) as { spriteSets?: { id: string }[] }
+        for (const s of mapData.spriteSets ?? []) {
+          out.set(s.id, (out.get(s.id) ?? 0) + 1)
+        }
+      } catch {
+        // skip unreadable/garbled map
+      }
+    }
+    return out
+  }
+}

--- a/apps/maker-gjs/src/widgets/application-window.blp
+++ b/apps/maker-gjs/src/widgets/application-window.blp
@@ -24,6 +24,7 @@ template $ApplicationWindow : Adw.ApplicationWindow {
       tiles_view.inspector-collapsed: true;
       scene_editor_view.library-collapsed: true;
       scene_editor_view.inspector-collapsed: true;
+      data_view.library-collapsed: true;
       welcome_view.inspector-collapsed: true;
     }
   }
@@ -47,6 +48,7 @@ template $ApplicationWindow : Adw.ApplicationWindow {
       cast_view.library-collapsed: true;
       tiles_view.library-collapsed: true;
       scene_editor_view.library-collapsed: true;
+      data_view.library-collapsed: true;
     }
   }
 
@@ -98,6 +100,12 @@ template $ApplicationWindow : Adw.ApplicationWindow {
         name: "scene-editor";
         title: _("Scene Editor");
         child: $SceneEditorView scene_editor_view {};
+      }
+
+      Adw.ViewStackPage {
+        name: "data";
+        title: _("Data");
+        child: $PixelRpgDataView data_view {};
       }
     };
   };

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -3,16 +3,24 @@ import Gio from '@girs/gio-2.0'
 import GLib from '@girs/glib-2.0'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
-import { ASSISTANT_PEER_ID, type AwarenessPeerState, type EditorTool, MapFormat } from '@pixelrpg/engine'
+import {
+  ASSISTANT_PEER_ID,
+  type AwarenessPeerState,
+  type EditorTool,
+  MapFormat,
+  type SpriteSetKind,
+} from '@pixelrpg/engine'
 import {
   type CollaboratorEntry,
   type EditorMode,
   type SampleScene,
   SignalScope,
+  SpriteSetImportDialog,
   type SpriteSetImportResult,
 } from '@pixelrpg/gjs'
 import { gettext as _ } from 'gettext'
 import { CastController } from '../services/cast-controller.ts'
+import { DataController } from '../services/data-controller.ts'
 import { EngineController } from '../services/engine-controller.ts'
 import { writeTextFile } from '../services/file-io.ts'
 import type { DiscoveredService } from '../services/lan-discovery-parse.ts'
@@ -27,17 +35,19 @@ import { TilesController } from '../services/tiles-controller.ts'
 import Template from './application-window.blp'
 import type { AtlasView } from './atlas-view.ts'
 import { CastView } from './cast-view.ts'
+import { DataView } from './data-view.ts'
 import type { SceneEditorView } from './scene-editor-view.ts'
 import { ShareDialog } from './share-dialog.ts'
 import { TilesView } from './tiles-view.ts'
 import type { WelcomeView } from './welcome-view.ts'
 
-// Force registration so the `$CastView` / `$TilesView` references in
-// the blueprint resolve at template-parse time.
+// Force registration so the `$CastView` / `$TilesView` / `$PixelRpgDataView`
+// references in the blueprint resolve at template-parse time.
 GObject.type_ensure(CastView.$gtype)
 GObject.type_ensure(TilesView.$gtype)
+GObject.type_ensure(DataView.$gtype)
 
-type ViewName = 'welcome' | 'atlas' | 'cast' | 'tiles' | 'scene-editor'
+type ViewName = 'welcome' | 'atlas' | 'cast' | 'tiles' | 'scene-editor' | 'data'
 
 /**
  * Read-only snapshot of the editor's live state, surfaced to external
@@ -124,6 +134,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
   declare _cast_view: CastView
   declare _tiles_view: TilesView
   declare _scene_editor_view: SceneEditorView
+  declare _data_view: DataView
   declare _stack: Adw.ViewStack
   declare _toast_overlay: Adw.ToastOverlay
 
@@ -194,6 +205,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
    */
   private _castCtl: CastController | null = null
   private _tilesCtl: TilesController | null = null
+  private _dataCtl: DataController | null = null
   /**
    * Pair-Editing orchestration. Constructed once in `vfunc_map` with
    * a lazy engine provider — Welcome-view discovery flows work
@@ -224,6 +236,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
           'cast_view',
           'tiles_view',
           'scene_editor_view',
+          'data_view',
           'stack',
           'toast_overlay',
         ],
@@ -327,7 +340,10 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       // cast controller owns all sprite-set CRUD + collab broadcast, so
       // when its set list changes (import / delete / inbound peer op)
       // re-hydrate the Tiles view too.
-      this._castCtl.onSpriteSetsChanged = () => void this._tilesCtl?.setProject(this._loadedProject)
+      this._castCtl.onSpriteSetsChanged = () => {
+        void this._tilesCtl?.setProject(this._loadedProject)
+        this._dataCtl?.setProject(this._loadedProject)
+      }
     }
     if (!this._tilesCtl) {
       this._tilesCtl = new TilesController(
@@ -336,6 +352,17 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
         (msg) => this._showToast(msg),
       )
     }
+    if (!this._dataCtl) {
+      this._dataCtl = new DataController(this._data_view, (msg) => this._showToast(msg))
+      this._data_view.bindCallbacks({
+        importAsset: (kind) => this._presentAssetImport(kind),
+        openAsset: (id, kind) => this._openAsset(id, kind),
+        renameAsset: (id, currentName) => this._presentRenameAsset(id, currentName),
+        deleteAsset: (id, name, usedBy) => this._presentDeleteAsset(id, name, usedBy),
+        setProjectField: (field, value) => this._dataCtl?.setProjectField(field, value),
+      })
+    }
+    this.signals.connect(this._data_view, 'mode-changed', (_v: DataView, mode: string) => setMode(mode))
     // Tiles view → shared sprite-set CRUD on the cast controller. Import
     // and delete both flow through the one path so the copy/register +
     // collab broadcast live in a single place.
@@ -622,17 +649,77 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       case 'tiles':
         if (this._loadedProject) this._setView('tiles')
         break
-      case 'audio':
-      case 'data': {
+      case 'data':
+        if (this._loadedProject) this._setView('data')
+        break
+      case 'audio': {
         this._showToast(_('Coming soon — this mode is not yet implemented'))
         // Reset back to whichever view we were on; the action state
         // already advanced to the new mode but no view exists.
         const current = this._stack.get_visible_child_name()
-        const fallback = current === 'cast' ? 'cast' : current === 'tiles' ? 'tiles' : 'world'
+        const fallback =
+          current === 'cast' ? 'cast' : current === 'tiles' ? 'tiles' : current === 'data' ? 'data' : 'world'
         this._modeAction?.set_state(GLib.Variant.new_string(fallback))
         break
       }
     }
+  }
+
+  /** Present the unified import dialog for a Data-view asset of `kind`. */
+  private _presentAssetImport(kind: SpriteSetKind): void {
+    const dialog = new SpriteSetImportDialog()
+    dialog.set_title(kind === 'character' ? _('Import sprite sheet') : _('Import tileset'))
+    dialog.connect('spriteset-imported', (_d: SpriteSetImportDialog, result: SpriteSetImportResult) => {
+      void this._castCtl?.importSpriteSet(result, kind)
+    })
+    dialog.present(this)
+  }
+
+  /** Jump from a Data-view asset row to its editor (Cast for sheets, Tiles for tilesets). */
+  private _openAsset(id: string, kind: SpriteSetKind): void {
+    if (!this._loadedProject) return
+    if (kind === 'tileset') {
+      this._setView('tiles')
+      this._tiles_view.focusTileset(id)
+      return
+    }
+    // Sprite sheet → open the first character that uses it, else the Cast view.
+    const character = this._loadedProject.resource.data?.characters?.find((c) => c.spriteSetId === id)
+    this._setView('cast')
+    if (character) this._cast_view.focusCharacter(character.id)
+  }
+
+  /** Rename an asset's display name via a small dialog (Data view). */
+  private _presentRenameAsset(id: string, currentName: string): void {
+    const entry = new Gtk.Entry({ text: currentName, activatesDefault: true })
+    const dialog = new Adw.AlertDialog({ heading: _('Rename asset'), extraChild: entry })
+    dialog.add_response('cancel', _('Cancel'))
+    dialog.add_response('rename', _('Rename'))
+    dialog.set_response_appearance('rename', Adw.ResponseAppearance.SUGGESTED)
+    dialog.set_default_response('rename')
+    dialog.set_close_response('cancel')
+    dialog.connect('response', (_d: Adw.AlertDialog, response: string) => {
+      if (response === 'rename') this._dataCtl?.renameSpriteSet(id, entry.get_text())
+    })
+    dialog.present(this)
+  }
+
+  /** Confirm + delete an asset (sprite set) through the shared cast controller. */
+  private _presentDeleteAsset(id: string, name: string, usedBy: number): void {
+    const body =
+      usedBy > 0
+        ? _(`“${name}” is still used in ${usedBy} place(s). Deleting it may break them. Continue?`)
+        : _(`“${name}” will be removed from the project, including its files. This cannot be undone.`)
+    const dialog = new Adw.AlertDialog({ heading: _('Delete asset?'), body })
+    dialog.add_response('cancel', _('Cancel'))
+    dialog.add_response('delete', _('Delete'))
+    dialog.set_response_appearance('delete', Adw.ResponseAppearance.DESTRUCTIVE)
+    dialog.set_default_response('cancel')
+    dialog.set_close_response('cancel')
+    dialog.connect('response', (_d: Adw.AlertDialog, response: string) => {
+      if (response === 'delete') this._castCtl?.deleteSpriteSet(id)
+    })
+    dialog.present(this)
   }
 
   /**
@@ -697,6 +784,8 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this.bind_property('show-inspector', view, 'show-inspector', flags)
     }
     this.bind_property('show-inspector', this._welcome_view, 'show-inspector', flags)
+    // The Data view has a mode rail but no inspector — bind only the library.
+    this.bind_property('show-library', this._data_view, 'show-library', flags)
   }
 
   private _installActions(): void {
@@ -1078,6 +1167,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       cast: 'cast',
       tiles: 'tiles',
       'scene-editor': 'world',
+      data: 'data',
     }
     const targetMode = modeForView[name]
     if (targetMode && this._modeAction?.get_state()?.get_string()[0] !== targetMode) {
@@ -1105,6 +1195,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     this._cast_view.syncActiveMode(mode)
     this._tiles_view.syncActiveMode(mode)
     this._scene_editor_view.syncActiveMode(mode)
+    this._data_view.syncActiveMode(mode)
   }
 
   private _showAtlas(): void {
@@ -1245,6 +1336,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       // about the new project so their views can hydrate.
       this._castCtl?.setProject(project)
       this._tilesCtl?.setProject(project)
+      this._dataCtl?.setProject(project)
       // A fresh project starts on the card overview, not a stale detail
       // page left over from the previous project.
       this._cast_view.resetToOverview()

--- a/apps/maker-gjs/src/widgets/data-view.blp
+++ b/apps/maker-gjs/src/widgets/data-view.blp
@@ -1,0 +1,114 @@
+using Gtk 4.0;
+using Adw 1;
+
+// Data view — the project's lower-level "Assets and project" surface.
+// ModeRail (left) holds the whole view; the content is an
+// `Adw.PreferencesPage` (clamped + scrollable → responsive for free):
+//   • Project   — editable project metadata (name, author, …).
+//   • Sprite sheets / Tilesets — every imported asset as a management
+//     row (thumbnail · metadata · "used by") with a ⋯ menu; rows are
+//     built in data-view.ts. Import buttons reuse the unified dialog.
+template $PixelRpgDataView : Adw.Bin {
+  Adw.OverlaySplitView outer_split {
+    sidebar-position: start;
+    min-sidebar-width: 220;
+    max-sidebar-width: 260;
+    sidebar-width-fraction: 0.7;
+    pin-sidebar: true;
+    collapsed: bind template.library-collapsed;
+    show-sidebar: bind template.show-library bidirectional;
+
+    sidebar: $PixelRpgModeRail mode_rail {
+      project-name: _("New Project");
+      project-tagline: _("Data view");
+    };
+
+    content: Adw.ToolbarView {
+      top-bar-style: flat;
+
+      [top]
+      Adw.HeaderBar {
+        show-title: false;
+        show-start-title-buttons: false;
+        show-end-title-buttons: false;
+
+        [start]
+        Gtk.ToggleButton library_toggle {
+          icon-name: "sidebar-show-symbolic";
+          tooltip-text: _("Toggle library");
+          active: bind template.show-library bidirectional;
+        }
+      }
+
+      content: Adw.PreferencesPage {
+        title: _("Data");
+
+        Adw.PreferencesGroup {
+          title: _("Project");
+          description: _("Project-wide settings saved into game-project.json.");
+
+          Adw.EntryRow name_row {
+            show-apply-button: true;
+            title: _("Name");
+          }
+
+          Adw.EntryRow author_row {
+            show-apply-button: true;
+            title: _("Author");
+          }
+
+          Adw.EntryRow version_row {
+            show-apply-button: true;
+            title: _("Version");
+          }
+
+          Adw.EntryRow description_row {
+            show-apply-button: true;
+            title: _("Description");
+          }
+
+          Adw.SpinRow tilesize_row {
+            title: _("Default tile size");
+            subtitle: _("Pixel grid step for new maps.");
+            adjustment: Gtk.Adjustment {
+              lower: 4;
+              upper: 256;
+              step-increment: 1;
+              page-increment: 8;
+            };
+          }
+
+          Adw.ActionRow path_row {
+            title: _("Project file");
+            subtitle-selectable: true;
+            styles ["property"]
+          }
+        }
+
+        Adw.PreferencesGroup sheets_group {
+          title: _("Sprite sheets");
+          description: _("Character animation sheets used by the Cast.");
+
+          header-suffix: Gtk.Button import_sheet_button {
+            valign: center;
+            icon-name: "list-add-symbolic";
+            tooltip-text: _("Import a sprite sheet from an image");
+            styles ["flat", "circular"]
+          };
+        }
+
+        Adw.PreferencesGroup tilesets_group {
+          title: _("Tilesets");
+          description: _("World-building tile images used by the map editor.");
+
+          header-suffix: Gtk.Button import_tileset_button {
+            valign: center;
+            icon-name: "list-add-symbolic";
+            tooltip-text: _("Import a tileset from an image");
+            styles ["flat", "circular"]
+          };
+        }
+      };
+    };
+  }
+}

--- a/apps/maker-gjs/src/widgets/data-view.ts
+++ b/apps/maker-gjs/src/widgets/data-view.ts
@@ -1,0 +1,279 @@
+import Adw from '@girs/adw-1'
+import type Gdk from '@girs/gdk-4.0'
+import Gio from '@girs/gio-2.0'
+import GObject from '@girs/gobject-2.0'
+import Gtk from '@girs/gtk-4.0'
+import type { SpriteSetKind } from '@pixelrpg/engine'
+import type { EditorMode, ModeRail } from '@pixelrpg/gjs'
+import { gettext as _ } from 'gettext'
+
+import Template from './data-view.blp'
+
+/** One asset (sprite sheet or tileset) as a management row. */
+export interface DataAssetRow {
+  id: string
+  name: string
+  kind: SpriteSetKind
+  /** Bounded thumbnail (first sprite for sheets, downscaled sheet for tilesets). */
+  paintable: Gdk.Paintable | null
+  /** e.g. "320×32 · 20 sprites". */
+  meta: string
+  /** How many characters/maps reference it — 0 ⇒ orphan. */
+  usedBy: number
+}
+
+/** The whole Data-view model the controller pushes in one shot. */
+export interface DataViewModel {
+  name: string
+  author: string
+  version: string
+  description: string
+  tileSize: number
+  path: string
+  sheets: DataAssetRow[]
+  tilesets: DataAssetRow[]
+}
+
+export interface DataViewCallbacks {
+  importAsset: (kind: SpriteSetKind) => void
+  openAsset: (id: string, kind: SpriteSetKind) => void
+  renameAsset: (id: string, currentName: string) => void
+  deleteAsset: (id: string, name: string, usedBy: number) => void
+  setProjectField: (field: 'name' | 'author' | 'version' | 'description' | 'tileSize', value: string) => void
+}
+
+const THUMB_SIZE = 44
+
+/**
+ * Data view — the project's "Assets and project" surface. A management
+ * list (Adwaita rows grouped by type) of every imported sprite sheet +
+ * tileset, each with a thumbnail, metadata, a "used by" count (orphans
+ * flagged) and a ⋯ menu (open / rename / delete), plus editable
+ * project metadata. Complements the visual Cast/Tiles galleries — same
+ * assets, file/management angle. See `data-controller.ts` for the data.
+ */
+export class DataView extends Adw.Bin {
+  declare _outer_split: Adw.OverlaySplitView
+  declare _mode_rail: ModeRail
+  declare _library_toggle: Gtk.ToggleButton
+  declare _name_row: Adw.EntryRow
+  declare _author_row: Adw.EntryRow
+  declare _version_row: Adw.EntryRow
+  declare _description_row: Adw.EntryRow
+  declare _tilesize_row: Adw.SpinRow
+  declare _path_row: Adw.ActionRow
+  declare _sheets_group: Adw.PreferencesGroup
+  declare _tilesets_group: Adw.PreferencesGroup
+  declare _import_sheet_button: Gtk.Button
+  declare _import_tileset_button: Gtk.Button
+
+  private _callbacks: DataViewCallbacks | null = null
+  // True while `setData` writes the row texts, so the `notify`/`apply`
+  // handlers don't fire the edit callbacks back during a refresh.
+  private _loading = false
+  private _sheetRows: Adw.ActionRow[] = []
+  private _tilesetRows: Adw.ActionRow[] = []
+  // Backing fields for the GObject properties (GJS uses the camelCase
+  // get/set below as the `show-library` / `library-collapsed` accessors).
+  private _showLibrary = false
+  private _libraryCollapsed = false
+
+  static {
+    GObject.registerClass(
+      {
+        GTypeName: 'PixelRpgDataView',
+        Template,
+        InternalChildren: [
+          'outer_split',
+          'mode_rail',
+          'library_toggle',
+          'name_row',
+          'author_row',
+          'version_row',
+          'description_row',
+          'tilesize_row',
+          'path_row',
+          'sheets_group',
+          'tilesets_group',
+          'import_sheet_button',
+          'import_tileset_button',
+        ],
+        Properties: {
+          'show-library': GObject.ParamSpec.boolean(
+            'show-library',
+            'Show Library',
+            'Whether the left mode-rail sidebar is visible (shared across views)',
+            GObject.ParamFlags.READWRITE,
+            true,
+          ),
+          'library-collapsed': GObject.ParamSpec.boolean(
+            'library-collapsed',
+            'Library Collapsed',
+            'Whether the mode rail should auto-overlay (responsive breakpoint)',
+            GObject.ParamFlags.READWRITE,
+            false,
+          ),
+        },
+        Signals: {
+          'mode-changed': { param_types: [GObject.TYPE_STRING] },
+        },
+      },
+      DataView,
+    )
+  }
+
+  constructor() {
+    super()
+    this._mode_rail.connect('mode-changed', (_r: ModeRail, mode: string) => this.emit('mode-changed', mode))
+    this._import_sheet_button.connect('clicked', () => this._callbacks?.importAsset('character'))
+    this._import_tileset_button.connect('clicked', () => this._callbacks?.importAsset('tileset'))
+
+    this._name_row.connect('apply', () => this._emitField('name', this._name_row.get_text()))
+    this._author_row.connect('apply', () => this._emitField('author', this._author_row.get_text()))
+    this._version_row.connect('apply', () => this._emitField('version', this._version_row.get_text()))
+    this._description_row.connect('apply', () => this._emitField('description', this._description_row.get_text()))
+    this._tilesize_row.connect('notify::value', () => {
+      if (this._loading) return
+      this._callbacks?.setProjectField('tileSize', String(Math.round(this._tilesize_row.get_value())))
+    })
+  }
+
+  private _emitField(field: 'name' | 'author' | 'version' | 'description', value: string): void {
+    if (this._loading) return
+    this._callbacks?.setProjectField(field, value.trim())
+  }
+
+  bindCallbacks(callbacks: DataViewCallbacks): void {
+    this._callbacks = callbacks
+  }
+
+  get showLibrary(): boolean {
+    return this._showLibrary
+  }
+
+  set showLibrary(value: boolean) {
+    if (this._showLibrary === value) return
+    this._showLibrary = value
+    this.notify('show-library')
+  }
+
+  get libraryCollapsed(): boolean {
+    return this._libraryCollapsed
+  }
+
+  set libraryCollapsed(value: boolean) {
+    if (this._libraryCollapsed === value) return
+    this._libraryCollapsed = value
+    this.notify('library-collapsed')
+  }
+
+  /** Sync the ModeRail's active mode (called when the host changes view). */
+  syncActiveMode(mode: EditorMode): void {
+    this._mode_rail.activeMode = mode
+  }
+
+  /** Replace the whole view from a freshly built model. */
+  setData(model: DataViewModel | null): void {
+    this._loading = true
+    this._name_row.set_text(model?.name ?? '')
+    this._author_row.set_text(model?.author ?? '')
+    this._version_row.set_text(model?.version ?? '')
+    this._description_row.set_text(model?.description ?? '')
+    this._tilesize_row.set_value(model?.tileSize ?? 16)
+    this._path_row.set_subtitle(model?.path ?? '—')
+    this._mode_rail.projectName = model?.name || _('New Project')
+    this._loading = false
+
+    const sensitive = model !== null
+    for (const row of [
+      this._name_row,
+      this._author_row,
+      this._version_row,
+      this._description_row,
+      this._tilesize_row,
+    ]) {
+      row.set_sensitive(sensitive)
+    }
+    this._import_sheet_button.set_sensitive(sensitive)
+    this._import_tileset_button.set_sensitive(sensitive)
+
+    this._rebuild(this._sheets_group, this._sheetRows, model?.sheets ?? [], _('No sprite sheets yet.'))
+    this._rebuild(this._tilesets_group, this._tilesetRows, model?.tilesets ?? [], _('No tilesets yet.'))
+  }
+
+  private _rebuild(
+    group: Adw.PreferencesGroup,
+    tracked: Adw.ActionRow[],
+    rows: DataAssetRow[],
+    emptyText: string,
+  ): void {
+    for (const row of tracked) group.remove(row)
+    tracked.length = 0
+    if (rows.length === 0) {
+      const empty = new Adw.ActionRow({ title: emptyText, sensitive: false })
+      group.add(empty)
+      tracked.push(empty)
+      return
+    }
+    for (const model of rows) {
+      const row = this._buildAssetRow(model)
+      group.add(row)
+      tracked.push(row)
+    }
+  }
+
+  private _buildAssetRow(model: DataAssetRow): Adw.ActionRow {
+    const usedLabel = model.usedBy === 0 ? _('unused') : `${_('used by')} ${model.usedBy}`
+    const row = new Adw.ActionRow({
+      title: model.name,
+      subtitle: `${model.meta} · ${usedLabel}`,
+    })
+    if (model.usedBy === 0) row.add_css_class('dim-label')
+
+    // Bounded thumbnail prefix (paintable is already small/downscaled).
+    if (model.paintable) {
+      const picture = new Gtk.Picture({
+        contentFit: Gtk.ContentFit.CONTAIN,
+        canShrink: true,
+        widthRequest: THUMB_SIZE,
+        heightRequest: THUMB_SIZE,
+        valign: Gtk.Align.CENTER,
+      })
+      picture.set_paintable(model.paintable)
+      row.add_prefix(picture)
+    } else {
+      row.add_prefix(new Gtk.Image({ iconName: 'image-x-generic-symbolic', pixelSize: 24 }))
+    }
+
+    // Per-row ⋯ menu: Open / Rename / Delete.
+    const actions = new Gio.SimpleActionGroup()
+    const open = new Gio.SimpleAction({ name: 'open' })
+    open.connect('activate', () => this._callbacks?.openAsset(model.id, model.kind))
+    actions.add_action(open)
+    const rename = new Gio.SimpleAction({ name: 'rename' })
+    rename.connect('activate', () => this._callbacks?.renameAsset(model.id, model.name))
+    actions.add_action(rename)
+    const del = new Gio.SimpleAction({ name: 'delete' })
+    del.connect('activate', () => this._callbacks?.deleteAsset(model.id, model.name, model.usedBy))
+    actions.add_action(del)
+    row.insert_action_group('asset', actions)
+
+    const menu = new Gio.Menu()
+    menu.append(_('Open'), 'asset.open')
+    menu.append(_('Rename…'), 'asset.rename')
+    menu.append(_('Delete…'), 'asset.delete')
+    const menuButton = new Gtk.MenuButton({
+      iconName: 'view-more-symbolic',
+      tooltipText: _('Asset actions'),
+      valign: Gtk.Align.CENTER,
+      menuModel: menu,
+      cssClasses: ['flat'],
+    })
+    row.add_suffix(menuButton)
+    row.set_activatable_widget(menuButton)
+
+    return row
+  }
+}
+
+GObject.type_ensure(DataView.$gtype)

--- a/apps/maker-gjs/src/widgets/index.ts
+++ b/apps/maker-gjs/src/widgets/index.ts
@@ -3,6 +3,7 @@
 export * from './application-window'
 export * from './atlas-view'
 export * from './cast-view'
+export * from './data-view'
 export * from './preferences-dialog'
 export * from './scene-editor-view'
 export * from './share-dialog'

--- a/apps/mcp-bridge/src/index.ts
+++ b/apps/mcp-bridge/src/index.ts
@@ -321,7 +321,7 @@ server.registerTool(
   {
     description:
       'Host a collaboration session on the given instance (needs a loaded project; open a scene so the ' +
-      "engine is live before a joiner connects). Returns the room id for join_session.",
+      'engine is live before a joiner connects). Returns the room id for join_session.',
     inputSchema: z.object({ ...instanceArg }),
   },
   async ({ instance }) => {
@@ -356,7 +356,8 @@ server.registerTool(
 server.registerTool(
   'get_session_state',
   {
-    description: 'Get the collaboration session state (kind: idle/browsing/hosting/connecting/awaiting-engine/connected).',
+    description:
+      'Get the collaboration session state (kind: idle/browsing/hosting/connecting/awaiting-engine/connected).',
     inputSchema: z.object({ ...instanceArg }),
   },
   async ({ instance }) => {
@@ -503,7 +504,8 @@ server.registerTool(
 server.registerTool(
   'change_action_state',
   {
-    description: 'Set a stateful GTK action\'s state (e.g. win.set-tool, win.toggle-grid, win.play). scope "app"/"win" (default).',
+    description:
+      'Set a stateful GTK action\'s state (e.g. win.set-tool, win.toggle-grid, win.play). scope "app"/"win" (default).',
     inputSchema: z.object({
       scope: z.enum(['app', 'win']).optional(),
       name: z.string(),
@@ -580,9 +582,12 @@ server.registerTool(
   'set_view',
   {
     description:
-      'Switch the top-level view. "atlas"/"cast"/"tiles" need a loaded project; "welcome" closes it; ' +
-      'for "scene-editor" use open_scene.',
-    inputSchema: z.object({ view: z.enum(['welcome', 'atlas', 'cast', 'tiles', 'scene-editor']), ...instanceArg }),
+      'Switch the top-level view. "atlas"/"cast"/"tiles"/"data" need a loaded project; "welcome" closes it; ' +
+      'for "scene-editor" use open_scene. "data" is the Assets & project view.',
+    inputSchema: z.object({
+      view: z.enum(['welcome', 'atlas', 'cast', 'tiles', 'data', 'scene-editor']),
+      ...instanceArg,
+    }),
   },
   async ({ view, instance }) => {
     try {
@@ -598,6 +603,9 @@ server.registerTool(
           break
         case 'tiles':
           await activate(instance, 'win', 'mode', 'tiles')
+          break
+        case 'data':
+          await activate(instance, 'win', 'mode', 'data')
           break
         case 'scene-editor':
           return fail('Use open_scene { sceneId } to enter the scene editor.')
@@ -658,7 +666,7 @@ server.registerTool(
   'present_window',
   {
     description:
-      "Bring the editor window to the foreground (map + focus). Needed before hosting/painting on a " +
+      'Bring the editor window to the foreground (map + focus). Needed before hosting/painting on a ' +
       'background instance whose WebGL engine has not initialised yet (get_status.engineReady === false).',
     inputSchema: z.object({ ...instanceArg }),
   },
@@ -741,7 +749,9 @@ server.registerTool(
       const [applied] = reply.recursiveUnpack() as [boolean]
       return applied
         ? ok(`Assistant cursor at (${x}, ${y})`)
-        : fail('Assistant cursor not applied — no active scene, or the user paused the assistant (check get_status.assistantPaused).')
+        : fail(
+            'Assistant cursor not applied — no active scene, or the user paused the assistant (check get_status.assistantPaused).',
+          )
     } catch (error) {
       return dbusError(error, instance)
     }
@@ -767,7 +777,7 @@ server.registerTool(
 server.registerTool(
   'assistant_hide',
   {
-    description: "Remove the AI assistant collaborator cursor/presence from the editor.",
+    description: 'Remove the AI assistant collaborator cursor/presence from the editor.',
     inputSchema: z.object({ ...instanceArg }),
   },
   async ({ instance }) => {
@@ -786,7 +796,7 @@ server.registerTool(
     description:
       'Follow a session participant with the camera so the user (or you) can watch their activity. Pass a ' +
       'peerId from get_status.participants[].peerId; an empty string stops following. Mirrors clicking a chip ' +
-      'in the editor\'s collaborators bar.',
+      "in the editor's collaborators bar.",
     inputSchema: z.object({ peerId: z.string(), ...instanceArg }),
   },
   async ({ peerId, instance }) => {

--- a/packages/gjs/src/widgets/editor/mode-rail.blp
+++ b/packages/gjs/src/widgets/editor/mode-rail.blp
@@ -161,7 +161,7 @@ template $PixelRpgModeRail : Adw.Bin {
 
       Adw.ActionRow row_data {
         title: _("Data");
-        subtitle: _("Project and save format");
+        subtitle: _("Assets and project");
         activatable: true;
         action-name: "win.mode";
         action-target: "'data'";


### PR DESCRIPTION
Turns the **Data** view (was a "Coming soon" stub) into the project's lower-level **Assets & project** manager — complementing the visual Cast/Tiles galleries with a file/management angle.

## Data view
Built on `Adw.PreferencesPage` (clamped + scrollable → responsive; the mode rail collapses to an overlay on phone):
- **Project** group — editable metadata: name, author, version, description, default tile size, + the read-only project-file path. Edits persist to `game-project.json` (text rows commit on the apply button / Enter).
- **Sprite sheets** + **Tilesets** groups — every imported asset as a management row: thumbnail · `W×H · N sprites/tiles` · **"used by N"** (reverse lookup over characters + maps; `0` ⇒ *unused/orphan*, dimmed). Per-row ⋯ menu: **Open** (jump to its Cast/Tiles editor), **Rename** (display name), **Delete** (with a usage warning). An **Import** button per group reuses the unified import dialog.
- One `DataController` builds the model + persists; asset import/delete reuse the shared `CastController` so there's a single owner of the files + collab broadcast. `onSpriteSetsChanged` re-hydrates Data alongside Tiles.

The rail subtitle is retitled **"Assets and project"**.

## MCP
`set_view` now accepts `data` (it didn't know the new view) — per the standing "fix MCP gaps as you hit them" task.

## Validation
- `gjsify foreach build` / `check` / `check:barrels` green; engine tests pass (439); bridge type-checks.
- Verified live via MCP (zelda-like): desktop shows the full layout — Project metadata, *Scientist* (320×32 · 20 sprites · used by 1), *Lokiri Forest* (used by 1), *OoT2D Water* (used by 1); phone collapses the rail to an overlay with the clamped content behind. (Row ⋯ menus / import / apply buttons are widget signals not driveable via the bridge.)