### PR TITLE
fix: import dialog single-scroll + responsive preview

### DIFF
--- a/packages/gjs/src/widgets/cast/sprite-set-import-dialog.blp
+++ b/packages/gjs/src/widgets/cast/sprite-set-import-dialog.blp
@@ -37,29 +37,33 @@ template $PixelRpgSpriteSetImportDialog : Adw.Dialog {
 
       // ≥ 720sp = desktop: settings on the left, cell grid on the
       // right. Below it the columns stack (phone bottom-sheet scroll).
-      Adw.Breakpoint {
+      Adw.Breakpoint desktop_breakpoint {
         condition ("min-width: 720sp")
 
         setters {
           split_box.orientation: horizontal;
-          settings_scroller.width-request: 340;
-          settings_scroller.hexpand: false;
+          settings_column.width-request: 340;
+          settings_column.hexpand: false;
         }
       }
 
-      child: Gtk.Box split_box {
-        orientation: vertical;
-        spacing: 0;
+      // One outer scroll for the whole dialog — neither column scrolls on
+      // its own (the settings/"Details" column doing so on the phone
+      // bottom-sheet read as a confusing nested scroll). The BreakpointBin
+      // wraps the scroller (not vice-versa) so it can still switch the
+      // columns horizontal↔vertical.
+      child: Gtk.ScrolledWindow {
+        hscrollbar-policy: never;
+        vscrollbar-policy: automatic;
+        vexpand: true;
 
-        Gtk.ScrolledWindow settings_scroller {
-          hscrollbar-policy: never;
-          vscrollbar-policy: automatic;
-          hexpand: true;
-          vexpand: true;
-          propagate-natural-width: true;
+        child: Gtk.Box split_box {
+          orientation: vertical;
+          spacing: 0;
 
-          child: Gtk.Box {
+          Gtk.Box settings_column {
             orientation: vertical;
+            hexpand: true;
             spacing: 18;
             margin-top: 18;
             margin-bottom: 18;
@@ -83,6 +87,37 @@ template $PixelRpgSpriteSetImportDialog : Adw.Dialog {
                   valign: center;
                   label: _("Choose…");
                   styles ["flat"]
+                }
+              }
+            }
+
+            // Phone: the preview lives here, right under the file picker,
+            // so it's immediately visible. On desktop the breakpoint moves
+            // `preview_block` into `desktop_preview_slot` (right column).
+            // See `_movePreviewForBreakpoint` in the .ts.
+            Gtk.Box phone_preview_slot {
+              orientation: vertical;
+
+              Gtk.Box preview_block {
+                orientation: vertical;
+                spacing: 12;
+
+                Gtk.Label {
+                  label: _("Preview");
+                  halign: start;
+                  styles ["caption-heading"]
+                }
+
+                $PixelRpgCollisionPreview collision_preview {
+                  halign: center;
+                  valign: start;
+                  height-request: 168;
+                }
+
+                Gtk.Label {
+                  label: _("Tap a cell below to inspect it");
+                  halign: center;
+                  styles ["dim-label", "caption"]
                 }
               }
             }
@@ -180,12 +215,12 @@ template $PixelRpgSpriteSetImportDialog : Adw.Dialog {
                 };
               }
             }
-          };
-        }
+          }
 
-        // Right column: a big crisp preview of the picked cell with
-        // the collision box, plus the full sliced grid so the user can
-        // verify the size + tap any cell to inspect it.
+        // Right column on desktop / lower section on phone: the sliced
+        // grid. `desktop_preview_slot` receives `preview_block` on desktop
+        // (so the preview sits beside the settings); on phone the preview
+        // stays up in `phone_preview_slot` and this slot is empty.
         Gtk.Box picker_column {
           orientation: vertical;
           spacing: 12;
@@ -196,27 +231,8 @@ template $PixelRpgSpriteSetImportDialog : Adw.Dialog {
           margin-start: 18;
           margin-end: 18;
 
-          Gtk.Label {
-            label: _("Preview");
-            halign: start;
-            styles ["caption-heading"]
-          }
-
-          $PixelRpgCollisionPreview collision_preview {
-            halign: center;
-            valign: start;
-            height-request: 168;
-          }
-
-          Gtk.Label {
-            label: _("Tap a cell below to inspect it");
-            halign: center;
-            styles ["dim-label", "caption"]
-          }
-
-          Gtk.Separator {
-            margin-top: 4;
-            margin-bottom: 4;
+          Gtk.Box desktop_preview_slot {
+            orientation: vertical;
           }
 
           Gtk.Label {
@@ -225,23 +241,17 @@ template $PixelRpgSpriteSetImportDialog : Adw.Dialog {
             styles ["caption-heading"]
           }
 
-          Gtk.ScrolledWindow {
+          $PixelRpgTilePalette palette {
+            aspect-mode: "contain";
+            wrap: true;
+            tile-size: 40;
+            halign: start;
+            valign: start;
             hexpand: true;
-            vexpand: true;
-            hscrollbar-policy: automatic;
-            vscrollbar-policy: automatic;
-
-            child: $PixelRpgTilePalette palette {
-              aspect-mode: "contain";
-              wrap: true;
-              tile-size: 40;
-              halign: start;
-              valign: start;
-              hexpand: true;
-              vexpand: false;
-            };
+            vexpand: false;
           }
         }
+        };
       };
     };
   };

--- a/packages/gjs/src/widgets/cast/sprite-set-import-dialog.ts
+++ b/packages/gjs/src/widgets/cast/sprite-set-import-dialog.ts
@@ -75,6 +75,13 @@ export class SpriteSetImportDialog extends Adw.Dialog {
   declare _collider_h_row: Adw.SpinRow
   declare _collision_preview: CollisionPreview
   declare _palette: TilePalette
+  // Responsive preview placement: `preview_block` is reparented between
+  // `phone_preview_slot` (under the file picker) and `desktop_preview_slot`
+  // (right column) by the `desktop_breakpoint` apply/unapply signals.
+  declare _desktop_breakpoint: Adw.Breakpoint
+  declare _preview_block: Gtk.Box
+  declare _phone_preview_slot: Gtk.Box
+  declare _desktop_preview_slot: Gtk.Box
 
   private _texture: Gdk.Texture | null = null
   private _sourcePath: string | null = null
@@ -105,6 +112,10 @@ export class SpriteSetImportDialog extends Adw.Dialog {
           'collider_h_row',
           'collision_preview',
           'palette',
+          'desktop_breakpoint',
+          'preview_block',
+          'phone_preview_slot',
+          'desktop_preview_slot',
         ],
         Properties: {
           'image-name': GObject.ParamSpec.string(
@@ -136,6 +147,19 @@ export class SpriteSetImportDialog extends Adw.Dialog {
     this._wireInputs()
     this._refreshGrid()
     this._refreshValidity()
+    // Desktop (≥720sp): preview beside the settings. Phone: preview under
+    // the file picker (its blp home). apply/unapply only fire on a
+    // transition, so the initial phone layout needs no action.
+    this._desktop_breakpoint.connect('apply', () => this._movePreview(this._desktop_preview_slot))
+    this._desktop_breakpoint.connect('unapply', () => this._movePreview(this._phone_preview_slot))
+  }
+
+  /** Reparent the preview block into `target` (no-op if already there). */
+  private _movePreview(target: Gtk.Box): void {
+    const current = this._preview_block.get_parent()
+    if (current === target) return
+    if (current) (current as Gtk.Box).remove(this._preview_block)
+    target.append(this._preview_block)
   }
 
   get imageName(): string {
@@ -351,7 +375,12 @@ export class SpriteSetImportDialog extends Adw.Dialog {
     const id = slugifySpriteSetName(this._name_row.get_text())
     const collider = withCollision && this._collision_row.get_active() ? this._buildCollider() : null
     const sprites: SpriteDataSet[] = []
-    for (const cell of iterateSpriteGrid({ columns, rows, spriteWidth: this._spriteWidth, spriteHeight: this._spriteHeight } as SpriteSetData)) {
+    for (const cell of iterateSpriteGrid({
+      columns,
+      rows,
+      spriteWidth: this._spriteWidth,
+      spriteHeight: this._spriteHeight,
+    } as SpriteSetData)) {
       const sprite: SpriteDataSet = { id: cell.index, col: cell.col, row: cell.row }
       if (collider) sprite.colliders = [collider]
       sprites.push(sprite)


### PR DESCRIPTION
Refinements to the shared import dialog (`SpriteSetImportDialog` — used for both **Import sprite sheet** and **Import tileset**, titled per caller).

## One page scroll
The settings/**Details** column had its own `ScrolledWindow`, so on the phone bottom-sheet it scrolled independently (a confusing nested scroll). Restructured to a single outer scroll: `Adw.BreakpointBin > one ScrolledWindow > split_box` — the whole dialog scrolls as one page.

## Responsive preview placement
The **Preview** is now reparented by the breakpoint's `apply`/`unapply`:
- **Phone**: right under the file picker (`Details → Preview → Sprite size → …`) so it's immediately visible.
- **Desktop**: in the right column, beside the settings (unchanged).

## Validation
- `gjsify foreach build` / `check` / `check:barrels` green; engine tests pass.
- Verified live via MCP (`win.new-tileset`): phone shows Details → **Preview** → Sprite size in one scroll; desktop shows settings left | Preview + Sliced cells right. (Used the new `win.new-tileset`/`win.new-spriteset` actions to open the dialog — a nice case where the existing actions made an otherwise widget-only dialog MCP-validatable.)