### PR TITLE
feat: domain-aware import dialog (tileset vs sprite sheet)

### DIFF
--- a/apps/maker-gjs/src/services/cast-controller.ts
+++ b/apps/maker-gjs/src/services/cast-controller.ts
@@ -16,7 +16,6 @@ import {
   REQUIRED_ROLES,
   type SpriteSetAddPayload,
   SpriteSetFormat,
-  type SpriteSetKind,
   SpriteSetResource,
   SPRITESET_REMOVE_KIND,
 } from '@pixelrpg/engine'
@@ -373,10 +372,7 @@ export class CastController {
    * the new set as a {@link SpriteSetChoice} for the character dialog to
    * select, or `null` if the copy/write failed.
    */
-  private async _importSpriteSet(
-    { data, sourcePath }: SpriteSetImportResult,
-    kind: SpriteSetKind = 'tileset',
-  ): Promise<SpriteSetChoice | null> {
+  private async _importSpriteSet({ data, sourcePath }: SpriteSetImportResult): Promise<SpriteSetChoice | null> {
     const resource = this._project?.resource
     if (!resource?.data) return null
     const id = this._uniqueId(data.id, new Set(resource.spriteSets.keys()))
@@ -384,9 +380,9 @@ export class CastController {
     const finalData = {
       ...data,
       id,
-      // Tag the imported set so it surfaces in the right gallery: a Cast
-      // import is a character sheet, a Tiles import is a world tileset.
-      kind,
+      // The dialog tags the set by kind ('character' sheet vs 'tileset')
+      // so it surfaces in the right gallery; default to tileset if absent.
+      kind: data.kind ?? ('tileset' as const),
       image: { ...(data.image ?? { id: 'main', type: 'image' as const }), path: imageFile },
     }
 
@@ -439,8 +435,8 @@ export class CastController {
    * and route its result here so the copy + register + collab-broadcast
    * path lives in one place.
    */
-  importSpriteSet(result: SpriteSetImportResult, kind: SpriteSetKind = 'tileset'): Promise<SpriteSetChoice | null> {
-    return this._importSpriteSet(result, kind)
+  importSpriteSet(result: SpriteSetImportResult): Promise<SpriteSetChoice | null> {
+    return this._importSpriteSet(result)
   }
 
   /**

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -367,8 +367,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     // and delete both flow through the one path so the copy/register +
     // collab broadcast live in a single place.
     this.signals.connect(this._tiles_view, 'spriteset-imported', (_v: TilesView, result: SpriteSetImportResult) => {
-      // Tiles imports are world tilesets.
-      void this._castCtl?.importSpriteSet(result, 'tileset')
+      void this._castCtl?.importSpriteSet(result)
     })
     this.signals.connect(this._tiles_view, 'spriteset-delete-requested', (_v: TilesView, id: string) => {
       this._castCtl?.deleteSpriteSet(id)
@@ -668,9 +667,9 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
   /** Present the unified import dialog for a Data-view asset of `kind`. */
   private _presentAssetImport(kind: SpriteSetKind): void {
     const dialog = new SpriteSetImportDialog()
-    dialog.set_title(kind === 'character' ? _('Import sprite sheet') : _('Import tileset'))
+    dialog.kind = kind
     dialog.connect('spriteset-imported', (_d: SpriteSetImportDialog, result: SpriteSetImportResult) => {
-      void this._castCtl?.importSpriteSet(result, kind)
+      void this._castCtl?.importSpriteSet(result)
     })
     dialog.present(this)
   }

--- a/apps/maker-gjs/src/widgets/cast-view.ts
+++ b/apps/maker-gjs/src/widgets/cast-view.ts
@@ -1,7 +1,7 @@
 import Adw from '@girs/adw-1'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
-import type { CharacterAnimation, CharacterDefinition, SpriteSetKind } from '@pixelrpg/engine'
+import type { CharacterAnimation, CharacterDefinition } from '@pixelrpg/engine'
 import {
   AddAnimationDialog,
   AnimationList,
@@ -118,9 +118,7 @@ export class CastView extends Adw.Bin {
   private _onDeleteCharacterRequested: ((charId: string) => void) | null = null
   private _onListSpriteSets: (() => SpriteSetChoice[]) | null = null
   private _onCreateCharacter: ((draft: NewCharacterDraft) => void) | null = null
-  private _onImportSpriteSet:
-    | ((result: SpriteSetImportResult, kind: SpriteSetKind) => Promise<SpriteSetChoice | null>)
-    | null = null
+  private _onImportSpriteSet: ((result: SpriteSetImportResult) => Promise<SpriteSetChoice | null>) | null = null
   private _onLoadSpriteSetPreview: ((id: string) => Promise<GdkSpriteSetResource | null>) | null = null
 
   static {
@@ -386,10 +384,9 @@ export class CastView extends Adw.Bin {
    */
   private _presentSpriteSetImportDialog(onImported?: (choice: SpriteSetChoice) => void): void {
     const dialog = new SpriteSetImportDialog()
-    dialog.set_title(_('Import sprite sheet'))
+    dialog.kind = 'character'
     dialog.connect('spriteset-imported', (_d: SpriteSetImportDialog, result: SpriteSetImportResult) => {
-      // Cast imports are character sprite sheets.
-      void this._onImportSpriteSet?.(result, 'character').then((choice) => {
+      void this._onImportSpriteSet?.(result).then((choice) => {
         if (choice) onImported?.(choice)
       })
     })
@@ -499,7 +496,7 @@ export class CastView extends Adw.Bin {
     deleteCharacter: (charId: string) => void
     listSpriteSets: () => SpriteSetChoice[]
     createCharacter: (draft: NewCharacterDraft) => void
-    importSpriteSet: (result: SpriteSetImportResult, kind: SpriteSetKind) => Promise<SpriteSetChoice | null>
+    importSpriteSet: (result: SpriteSetImportResult) => Promise<SpriteSetChoice | null>
     loadSpriteSetPreview: (id: string) => Promise<GdkSpriteSetResource | null>
   }): void {
     this._onRenameRequested = callbacks.rename

--- a/apps/maker-gjs/src/widgets/tiles-view.ts
+++ b/apps/maker-gjs/src/widgets/tiles-view.ts
@@ -419,7 +419,7 @@ export class TilesView extends Adw.Bin {
    */
   presentTilesetImportDialog(): void {
     const dialog = new SpriteSetImportDialog()
-    dialog.set_title(_('Import tileset'))
+    dialog.kind = 'tileset'
     dialog.connect('spriteset-imported', (_d: SpriteSetImportDialog, result: SpriteSetImportResult) => {
       this.emit('spriteset-imported', result)
     })

--- a/packages/gjs/src/widgets/cast/sprite-set-import-dialog.blp
+++ b/packages/gjs/src/widgets/cast/sprite-set-import-dialog.blp
@@ -158,7 +158,7 @@ template $PixelRpgSpriteSetImportDialog : Adw.Dialog {
               }
             }
 
-            Adw.PreferencesGroup {
+            Adw.PreferencesGroup collision_group {
               title: _("Collision");
               description: _("Mark which part of each sprite blocks movement. The same box applies to every sprite.");
 

--- a/packages/gjs/src/widgets/cast/sprite-set-import-dialog.ts
+++ b/packages/gjs/src/widgets/cast/sprite-set-import-dialog.ts
@@ -4,7 +4,7 @@ import Gio from '@girs/gio-2.0'
 import GLib from '@girs/glib-2.0'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
-import { iterateSpriteGrid, type SpriteDataSet, type SpriteSetData } from '@pixelrpg/engine'
+import { iterateSpriteGrid, type SpriteDataSet, type SpriteSetData, type SpriteSetKind } from '@pixelrpg/engine'
 import { gettext as _ } from 'gettext'
 
 import { GdkImageTexture, GdkSpriteSheet } from '../../sprite/index.ts'
@@ -73,6 +73,8 @@ export class SpriteSetImportDialog extends Adw.Dialog {
   declare _collider_y_row: Adw.SpinRow
   declare _collider_w_row: Adw.SpinRow
   declare _collider_h_row: Adw.SpinRow
+  declare _size_group: Adw.PreferencesGroup
+  declare _collision_group: Adw.PreferencesGroup
   declare _collision_preview: CollisionPreview
   declare _palette: TilePalette
   // Responsive preview placement: `preview_block` is reparented between
@@ -90,6 +92,11 @@ export class SpriteSetImportDialog extends Adw.Dialog {
   private _gridSummary = '—'
   /** Guard so programmatic spin updates don't re-trigger their own handlers. */
   private _syncing = false
+  // What's being imported. Drives the title, wording, and whether the
+  // shared-collision section is shown: a character sprite sheet shares
+  // ONE collision box across its frames; a tileset's collision is
+  // per-tile (set later in the Tiles inspector), so it has no box here.
+  private _kind: SpriteSetKind = 'character'
 
   static {
     GObject.registerClass(
@@ -110,6 +117,8 @@ export class SpriteSetImportDialog extends Adw.Dialog {
           'collider_y_row',
           'collider_w_row',
           'collider_h_row',
+          'size_group',
+          'collision_group',
           'collision_preview',
           'palette',
           'desktop_breakpoint',
@@ -152,6 +161,37 @@ export class SpriteSetImportDialog extends Adw.Dialog {
     // transition, so the initial phone layout needs no action.
     this._desktop_breakpoint.connect('apply', () => this._movePreview(this._desktop_preview_slot))
     this._desktop_breakpoint.connect('unapply', () => this._movePreview(this._phone_preview_slot))
+    this._applyKind()
+  }
+
+  /** What's being imported. Callers set this to tailor the dialog to its domain. */
+  get kind(): SpriteSetKind {
+    return this._kind
+  }
+
+  set kind(value: SpriteSetKind) {
+    if (this._kind === value) return
+    this._kind = value
+    this._applyKind()
+  }
+
+  /**
+   * Tailor the (shared) dialog to its kind: title + "sprite"/"tile"
+   * wording, and hide the shared-collision section for tilesets (their
+   * collision is per-tile, set in the Tiles inspector after import).
+   */
+  private _applyKind(): void {
+    const isCharacter = this._kind === 'character'
+    this.set_title(isCharacter ? _('Import sprite sheet') : _('Import tileset'))
+    this._size_group.set_title(isCharacter ? _('Sprite size') : _('Tile size'))
+    this._size_group.set_description(
+      isCharacter
+        ? _('Every sprite in the image is the same size. The image is sliced into a grid using this size.')
+        : _('Every tile in the image is the same size. The image is sliced into a grid using this size.'),
+    )
+    this._collision_group.set_visible(isCharacter)
+    this._refreshGrid()
+    this._refreshPreview()
   }
 
   /** Reparent the preview block into `target` (no-op if already there). */
@@ -223,7 +263,8 @@ export class SpriteSetImportDialog extends Adw.Dialog {
 
   /** Open a native file picker filtered to images; load the pick into a texture. */
   private _chooseImage(): void {
-    const dialog = new Gtk.FileDialog({ title: _('Choose sprite sheet image'), modal: true })
+    const title = this._kind === 'character' ? _('Choose sprite sheet image') : _('Choose tileset image')
+    const dialog = new Gtk.FileDialog({ title, modal: true })
     const filter = new Gtk.FileFilter()
     filter.set_name(_('Images'))
     filter.add_mime_type('image/png')
@@ -300,7 +341,8 @@ export class SpriteSetImportDialog extends Adw.Dialog {
       this._palette.setTiles([])
       return
     }
-    this.gridSummary = _(`${columns} × ${rows} — ${columns * rows} sprites`)
+    const unit = this._kind === 'character' ? _('sprites') : _('tiles')
+    this.gridSummary = `${columns} × ${rows} — ${columns * rows} ${unit}`
     const data = this._buildSpriteSetData(columns, rows, false)
     const sheet = new GdkSpriteSheet(data, GdkImageTexture.fromTexture(this._texture))
     this._palette.setFromSpriteSheet(sheet)
@@ -329,7 +371,8 @@ export class SpriteSetImportDialog extends Adw.Dialog {
       Math.round(this._collider_y_row.get_value()),
       Math.round(this._collider_w_row.get_value()),
       Math.round(this._collider_h_row.get_value()),
-      this._collision_row.get_active(),
+      // Tilesets have no shared collider, so never draw one in the preview.
+      this._collision_row.get_active() && this._kind === 'character',
     )
   }
 
@@ -389,6 +432,7 @@ export class SpriteSetImportDialog extends Adw.Dialog {
       version: '1.0.0',
       id,
       name: this._name_row.get_text().trim() || id,
+      kind: this._kind,
       image: { id: 'main', path: `${id}.png`, type: 'image' },
       spriteWidth: this._spriteWidth,
       spriteHeight: this._spriteHeight,
@@ -417,7 +461,11 @@ export class SpriteSetImportDialog extends Adw.Dialog {
     const columns = this._columns()
     const rows = this._rows()
     if (columns < 1 || rows < 1) return null
-    return { data: this._buildSpriteSetData(columns, rows, true), sourcePath: this._sourcePath }
+    // Tilesets carry no shared collider — collision is per-tile.
+    return {
+      data: this._buildSpriteSetData(columns, rows, this._kind === 'character'),
+      sourcePath: this._sourcePath,
+    }
   }
 }
 


### PR DESCRIPTION
The shared import dialog is unified (good), but sprite sheets and tilesets have different needs — a character sprite sheet shares **one** collision box across its frames, while a tileset's collision is **per-tile** (set in the Tiles inspector). The dialog was showing the shared-collision section for tilesets too.

## Change
A single `kind` knob now tailors the dialog:
- **Sprite sheet** (`kind: 'character'`): "Sprite size" wording + the Collision section (shared box).
- **Tileset** (`kind: 'tileset'`): "Tile size" wording, **no** Collision section, "tile" everywhere (grid summary, file-picker title).

Callers just set `dialog.kind` (replacing the external `set_title`). The dialog tags the emitted `SpriteSetData.kind`, which let the `kind` argument be **dropped** from `CastController.importSpriteSet` and its threading through cast-view / tiles-view / application-window — a small de-duplication.

## Validation
- `gjsify foreach build` / `check` / `check:barrels` green; engine tests pass.
- Verified live via MCP: `win.new-tileset` → "Import tileset", "Tile size", no Collision section; `win.new-spriteset` → "Import sprite sheet", "Sprite size", Collision section present.