### PR TITLE
refactor: dedup sprite-set classification + widget reparenting

### DIFF
--- a/apps/maker-gjs/src/services/cast-controller.ts
+++ b/apps/maker-gjs/src/services/cast-controller.ts
@@ -30,6 +30,7 @@ import type { CastView } from '../widgets/cast-view.ts'
 import type { CollabSession } from './collab-session.ts'
 import { copyFile, deleteFile, readBinaryFile, writeBinaryFile, writeTextFile } from './file-io.ts'
 import type { LoadedProject } from './project-loader.ts'
+import { characterSpriteSetIds, isCharacterSpriteSet } from './sprite-set-classification.ts'
 
 /** Default per-frame duration (ms) seeded into a new character's animations. */
 const DEFAULT_ANIMATION_MS = 200
@@ -301,13 +302,11 @@ export class CastController {
   private _listSpriteSets(): SpriteSetChoice[] {
     const resource = this._project?.resource
     if (!resource) return []
-    const usedByCharacter = new Set((resource.data?.characters ?? []).map((c) => c.spriteSetId))
     // Only sprite SHEETS are assignable to a character — world tilesets
-    // are excluded (a character sheet is `kind: 'character'` or already
-    // referenced by a character; untagged-but-referenced sheets still
-    // qualify so legacy projects keep working).
+    // are excluded (see `isCharacterSpriteSet`).
+    const usedByCharacter = characterSpriteSetIds(resource.data?.characters)
     return [...resource.spriteSets.entries()]
-      .filter(([id, set]) => set.data?.kind === 'character' || usedByCharacter.has(id))
+      .filter(([id, set]) => isCharacterSpriteSet(set.data?.kind, usedByCharacter.has(id)))
       .map(([id, set]) => ({ id, name: set.data?.name ?? id }))
       .sort((a, b) => Number(usedByCharacter.has(b.id)) - Number(usedByCharacter.has(a.id)))
   }

--- a/apps/maker-gjs/src/services/data-controller.ts
+++ b/apps/maker-gjs/src/services/data-controller.ts
@@ -12,6 +12,7 @@ import { gettext as _ } from 'gettext'
 import type { DataAssetRow, DataView, DataViewModel } from '../widgets/data-view.ts'
 import { readBinaryFile, writeTextFile } from './file-io.ts'
 import type { LoadedProject } from './project-loader.ts'
+import { isCharacterSpriteSet } from './sprite-set-classification.ts'
 
 /** Thumbnail edge passed to the sheet downscaler (≥ the row size, for sharpness). */
 const THUMB_PX = 96
@@ -117,7 +118,7 @@ export class DataController {
       const sd = engineSet.data
       if (!sd) continue
       const usedByChars = charUsers.get(id) ?? 0
-      const isCharacter = sd.kind === 'character' || usedByChars > 0
+      const isCharacter = isCharacterSpriteSet(sd.kind, usedByChars > 0)
       const row = await this._buildRow(
         id,
         engineSet,

--- a/apps/maker-gjs/src/services/sprite-set-classification.ts
+++ b/apps/maker-gjs/src/services/sprite-set-classification.ts
@@ -1,0 +1,22 @@
+import type { CharacterDefinition, SpriteSetKind } from '@pixelrpg/engine'
+
+/**
+ * Sprite-set classification — the single source of truth for "is this a
+ * character animation sheet or a world tileset". Used by the Cast picker,
+ * the Tiles gallery, and the Data view so the rule stays consistent.
+ */
+
+/** Ids of every sprite-set referenced by a character (i.e. used as its sheet). */
+export function characterSpriteSetIds(characters: readonly CharacterDefinition[] | undefined): Set<string> {
+  return new Set((characters ?? []).map((c) => c.spriteSetId))
+}
+
+/**
+ * Whether a sprite-set is a CHARACTER animation sheet (vs a world
+ * tileset): explicitly tagged `kind: 'character'`, OR referenced by a
+ * character (the belt-and-suspenders fallback that covers legacy /
+ * untagged sheets). Tiles shows the complement; Cast shows these.
+ */
+export function isCharacterSpriteSet(kind: SpriteSetKind | undefined, referencedByCharacter: boolean): boolean {
+  return kind === 'character' || referencedByCharacter
+}

--- a/apps/maker-gjs/src/widgets/cast-view.ts
+++ b/apps/maker-gjs/src/widgets/cast-view.ts
@@ -546,8 +546,8 @@ export class CastView extends Adw.Bin {
 
   /**
    * Rebuild the character cards. Each card's preview is a live
-   * {@link CharacterCardPreview} — the character walks in its default
-   * direction, and hovering reveals direction arrows to spin it.
+   * {@link CharacterPreview} that auto-cycles walking direction while the
+   * card is the active or hovered one (static otherwise).
    */
   private _rebuildGallery(): void {
     this._characters_gallery.setItems(

--- a/apps/maker-gjs/src/widgets/tiles-view.ts
+++ b/apps/maker-gjs/src/widgets/tiles-view.ts
@@ -8,6 +8,7 @@ import {
   type GalleryCardItem,
   GdkSpriteSetResource,
   type ModeRail,
+  reparentWidget,
   SignalScope,
   SpriteSetImportDialog,
   type SpriteSetImportResult,
@@ -16,6 +17,7 @@ import {
 } from '@pixelrpg/gjs'
 import { gettext as _ } from 'gettext'
 
+import { characterSpriteSetIds, isCharacterSpriteSet } from '../services/sprite-set-classification.ts'
 import Template from './tiles-view.blp'
 
 // Force registration so blueprint `$PixelRpg…` refs resolve at parse time.
@@ -193,12 +195,7 @@ export class TilesView extends Adw.Bin {
    */
   private _placeInspector(): void {
     const collapsed = this._inspectorCollapsed
-    const target = collapsed ? this._sheet_slot : this._side_slot
-    const current = this._inspector.get_parent()
-    if (current !== target) {
-      if (current) (current as Gtk.Box).remove(this._inspector)
-      target.append(this._inspector)
-    }
+    reparentWidget(this._inspector, collapsed ? this._sheet_slot : this._side_slot)
     // Desktop: show the split's pinned sidebar. Phone: hide it (the
     // inspector lives in the bottom sheet instead).
     this._tile_split.set_show_sidebar(!collapsed)
@@ -359,10 +356,8 @@ export class TilesView extends Adw.Bin {
     }
 
     // Tiles shows ONLY world tilesets — character animation sheets
-    // belong to the Cast view. Exclude any set tagged `kind: 'character'`
-    // AND any set a character references (belt-and-suspenders: catches
-    // legacy/untagged sheets like a project that predates the split).
-    const usedByCharacter = new Set((project.data?.characters ?? []).map((c) => c.spriteSetId))
+    // belong to the Cast view (see `isCharacterSpriteSet`).
+    const usedByCharacter = characterSpriteSetIds(project.data?.characters)
 
     // Snapshot sprite-sets in project order, wrapping each as a GTK
     // resource up-front so its card can show a sheet thumbnail. Tilesets
@@ -370,7 +365,7 @@ export class TilesView extends Adw.Bin {
     // keeps the gallery from popping in thumbnails one by one.
     const items: TilesetEntry[] = []
     for (const [id, resource] of project.spriteSets) {
-      if (resource.data?.kind === 'character' || usedByCharacter.has(id)) continue
+      if (isCharacterSpriteSet(resource.data?.kind, usedByCharacter.has(id))) continue
       let gdk: GdkSpriteSetResource | null = null
       try {
         gdk = await GdkSpriteSetResource.fromEngineResource(resource)

--- a/packages/gjs/src/utils/index.ts
+++ b/packages/gjs/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './reparent.ts'
 export * from './signal-scope.ts'

--- a/packages/gjs/src/utils/reparent.ts
+++ b/packages/gjs/src/utils/reparent.ts
@@ -1,0 +1,16 @@
+import type Gtk from '@girs/gtk-4.0'
+
+/**
+ * Move `widget` so its parent becomes `target`, a no-op if it's already
+ * there. Used for responsive layouts that relocate one widget between
+ * two slots on a breakpoint change (e.g. an inspector that's a desktop
+ * sidebar vs. a phone bottom-sheet, or a preview shown beside vs. above
+ * its controls). `target` must be a `Gtk.Box` (uses `append`); the old
+ * parent is detached via its own `remove`.
+ */
+export function reparentWidget(widget: Gtk.Widget, target: Gtk.Box): void {
+  const current = widget.get_parent()
+  if (current === target) return
+  if (current) (current as Gtk.Box).remove(widget)
+  target.append(widget)
+}

--- a/packages/gjs/src/widgets/cast/sprite-set-import-dialog.ts
+++ b/packages/gjs/src/widgets/cast/sprite-set-import-dialog.ts
@@ -8,6 +8,7 @@ import { iterateSpriteGrid, type SpriteDataSet, type SpriteSetData, type SpriteS
 import { gettext as _ } from 'gettext'
 
 import { GdkImageTexture, GdkSpriteSheet } from '../../sprite/index.ts'
+import { reparentWidget } from '../../utils/index.ts'
 import { TilePalette } from '../editor/tile-palette.ts'
 import { CollisionPreview } from './collision-preview.ts'
 
@@ -196,10 +197,7 @@ export class SpriteSetImportDialog extends Adw.Dialog {
 
   /** Reparent the preview block into `target` (no-op if already there). */
   private _movePreview(target: Gtk.Box): void {
-    const current = this._preview_block.get_parent()
-    if (current === target) return
-    if (current) (current as Gtk.Box).remove(this._preview_block)
-    target.append(this._preview_block)
+    reparentWidget(this._preview_block, target)
   }
 
   get imageName(): string {


### PR DESCRIPTION
Behaviour-preserving cleanup of duplication that accumulated over the recent UI iterations (first of the simplification pass).

- **`sprite-set-classification.ts`** — one source of truth for "character sheet vs tileset" (`characterSpriteSetIds` + `isCharacterSpriteSet`), replacing the inline `kind === 'character' || referenced` rule that was copy-pasted in `cast-controller` (`_listSpriteSets`), `tiles-view` (`setProject` filter) and `data-controller` (`_rebuild`).
- **`reparentWidget()`** (`@pixelrpg/gjs` util) — the "move a widget between two slots" logic shared by the tiles inspector (desktop sidebar ↔ phone sheet) and the import dialog's responsive preview, replacing two hand-rolled copies.
- Fixed a stale doc comment (`CharacterCardPreview` → `CharacterPreview`, and dropped the removed hover-arrows description).

## Validation
- `gjsify foreach build` / `check` / `check:barrels` green; engine tests pass.
- Verified live via MCP: Tiles gallery still shows only tilesets (Scientist excluded); the tile-detail inspector still reparents into the desktop sidebar.

## Deferred (deliberately)
The biggest remaining duplication is the responsive view shell — `show-library`/`library-collapsed` (+ inspector/quickview) props, their camelCase get/set, and `syncActiveMode`, copy-pasted across all five views (~180 lines). DRYing that into a base class is high-value but higher-risk (GObject inheritance + it touches the just-stabilized responsive behaviour), so I've left it out of this PR to keep it safe; happy to do it as a focused follow-up.