### PR TITLE
perf: bake map previews to one texture + welcome shrinks to phone

### DIFF
--- a/apps/maker-gjs/src/widgets/welcome-view.blp
+++ b/apps/maker-gjs/src/widgets/welcome-view.blp
@@ -208,6 +208,11 @@ template $WelcomeView : Adw.Bin {
           Gtk.Label welcome_title {
             label: _("Welcome to Pixel RPG Editor");
             halign: center;
+            // Wrap so the large title doesn't force a wide minimum window
+            // width — a non-wrapping title-1's min width is the full text.
+            wrap: true;
+            wrap-mode: word_char;
+            justify: center;
             margin-top: 24;
             margin-bottom: 6;
             styles ["title-1"]

--- a/packages/gjs/src/widgets/editor/map-preview.ts
+++ b/packages/gjs/src/widgets/editor/map-preview.ts
@@ -1,4 +1,5 @@
 import Gdk from '@girs/gdk-4.0'
+import GLib from '@girs/glib-2.0'
 import GObject from '@girs/gobject-2.0'
 import Graphene from '@girs/graphene-1.0'
 import Gsk from '@girs/gsk-4.0'
@@ -40,12 +41,21 @@ interface SheetRange {
  * batches one `append_scaled_texture` call per tile. GTK caches the
  * resulting GSK tree, so the per-tile cost is paid exactly once.
  */
+/** Cap the baked preview texture's longest edge — these are small thumbnails. */
+const BAKE_MAX_EDGE = 512
+
 export class MapPreview extends Gtk.Widget {
   private _ops: DrawOp[] = []
   private _mapWidth = 0
   private _mapHeight = 0
   private _accentColor: Gdk.RGBA
   private _loaded = false
+  // The composited tiles, rasterised to ONE texture so repaints (atlas
+  // pan, card hover) are O(1) instead of re-rendering N clipped tile nodes
+  // every frame. Invalidated whenever the tile ops change; rebuilt lazily
+  // off the first paint (when the widget has a renderer).
+  private _baked: Gdk.Texture | null = null
+  private _bakeScheduled = false
 
   static {
     GObject.registerClass(
@@ -152,6 +162,7 @@ export class MapPreview extends Gtk.Widget {
     }
     this._ops = ops
     this._loaded = true
+    this._baked = null // tiles changed → re-bake on next paint
     this.queue_draw()
   }
 
@@ -167,18 +178,60 @@ export class MapPreview extends Gtk.Widget {
     if (!this._loaded || !this._ops.length || !this._mapWidth || !this._mapHeight) return
 
     const scale = Math.min(width / this._mapWidth, height / this._mapHeight)
-    const offsetX = (width - this._mapWidth * scale) / 2
-    const offsetY = (height - this._mapHeight * scale) / 2
+    const dw = this._mapWidth * scale
+    const dh = this._mapHeight * scale
+    const dest = new Graphene.Rect()
+    dest.init((width - dw) / 2, (height - dh) / 2, dw, dh)
 
-    const translatePoint = new Graphene.Point({ x: offsetX, y: offsetY })
-    snapshot.save()
-    snapshot.translate(translatePoint)
-
-    for (const op of this._ops) {
-      this._paintTile(snapshot, op, scale)
+    // Fast path: paint the pre-rasterised composite (one texture).
+    if (this._baked) {
+      snapshot.append_scaled_texture(this._baked, Gsk.ScalingFilter.NEAREST, dest)
+      return
     }
 
+    // First paint (or just after the tiles changed): draw the tiles
+    // directly this once, and bake them to a texture for every paint
+    // after. The bake runs off an idle so it isn't a re-entrant
+    // `render_texture` inside this snapshot.
+    snapshot.save()
+    snapshot.translate(new Graphene.Point({ x: dest.get_x(), y: dest.get_y() }))
+    for (const op of this._ops) this._paintTile(snapshot, op, scale)
     snapshot.restore()
+    this._scheduleBake()
+  }
+
+  /** Rasterise the tile composite to one texture (off-snapshot), then repaint. */
+  private _scheduleBake(): void {
+    if (this._bakeScheduled) return
+    this._bakeScheduled = true
+    GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+      this._bakeScheduled = false
+      if (!this._baked && this._ops.length) {
+        this._baked = this._bakeTexture()
+        if (this._baked) this.queue_draw()
+      }
+      return GLib.SOURCE_REMOVE
+    })
+  }
+
+  private _bakeTexture(): Gdk.Texture | null {
+    const renderer = this.get_native()?.get_renderer()
+    if (!renderer || !this._mapWidth || !this._mapHeight) return null
+    // Bake at native map resolution, capped so a large map stays a small
+    // thumbnail texture (it's only ever shown card-sized).
+    const bakeScale = Math.min(1, BAKE_MAX_EDGE / Math.max(this._mapWidth, this._mapHeight))
+    const sub = Gtk.Snapshot.new()
+    for (const op of this._ops) this._paintTile(sub, op, bakeScale)
+    const node = sub.to_node()
+    if (!node) return null
+    const region = new Graphene.Rect()
+    region.init(0, 0, this._mapWidth * bakeScale, this._mapHeight * bakeScale)
+    try {
+      return renderer.render_texture(node, region)
+    } catch (error) {
+      console.warn('[MapPreview] Failed to bake preview texture:', error)
+      return null
+    }
   }
 
   private _paintTile(snapshot: Gtk.Snapshot, op: DrawOp, scale: number): void {


### PR DESCRIPTION
Two responsiveness fixes — the app should always feel fluid.

## perf: MapPreview bakes to one cached texture
`MapPreview` painted **every** map tile on **every** snapshot, and for each tile pushed a clip + drew the **whole sprite-sheet atlas** (clipped to one tile). So a single preview was N clip-nodes + N full-atlas texture-nodes, re-rendered on every repaint. That made the **Atlas** (a `Gtk.Fixed` of scene-card previews) and the **Welcome** page (template/recent previews) sluggish to pan/hover, while **Cast/Tiles** (one cached `Gtk.Picture` per card) stayed smooth even with many tiles.

Now the composite is rasterised **once** to a single `Gdk.Texture` (off an idle so it's not a re-entrant `render_texture`, capped to 512px since these are thumbnails) and every paint just blits that one texture — O(1) repaints, matching the smooth views.

## fix: welcome page shrinks to phone width
The `welcome_title` (title-1) had no `wrap`, so its minimum width was the full text (~400px) — the real floor keeping the page from narrowing (the CTA buttons were already in a wrapping `FlowBox`). Wrapping the title lets the page reach phone width, where the buttons stack vertically.

## Validation
- `gjsify foreach build` / `check` / `check:barrels` green; engine tests pass.
- Perf: user confirmed Atlas + Welcome are now smooth ("deutlich besser"); previews render correctly (Welcome templates, Atlas scene cards) via the baked texture.
- Welcome at 400px: title wraps to 2 lines, buttons stack, no horizontal overflow.