### PR TITLE
refactor: sprite sheets own their character animations (phase 1)

### DIFF
--- a/apps/maker-gjs/src/services/cast-controller.ts
+++ b/apps/maker-gjs/src/services/cast-controller.ts
@@ -229,58 +229,48 @@ export class CastController {
         c.speedTilesPerSec = tilesPerSec
       })
     },
+    // Animations live on the SHEET now (shared by every character using
+    // it), so these mutate the character's sprite-sheet, not the character.
     setDuration: (id: string, animId: string, durationMs: number) => {
-      this._mutate(id, (c) => {
-        const anim = c.animations.find((a) => a.id === animId)
+      this._mutateSheetAnimations(id, (anims) => {
+        const anim = anims.find((a) => a.id === animId)
         if (anim) anim.durationMs = durationMs
       })
-      void this.refresh()
     },
     addAnimation: (id: string, animation: CharacterAnimation) => {
-      this._mutate(id, (c) => {
-        // Dialog-side validation already rejected duplicate ids +
-        // empty frames; this is a defensive double-check so a
-        // dialog/controller mismatch can't corrupt the project.
+      this._mutateSheetAnimations(id, (anims) => {
+        // Dialog-side validation already rejected duplicate ids + empty
+        // frames; defensive double-check so a mismatch can't corrupt it.
         if (animation.frames.length === 0) return
-        if (c.animations.some((a) => a.id === animation.id)) return
-        c.animations.push(animation)
+        if (anims.some((a) => a.id === animation.id)) return
+        anims.push(animation)
       })
-      void this.refresh()
     },
     editAnimation: (id: string, originalId: string, animation: CharacterAnimation) => {
-      this._mutate(id, (c) => {
+      this._mutateSheetAnimations(id, (anims) => {
         if (animation.frames.length === 0) return
-        const idx = c.animations.findIndex((a) => a.id === originalId)
+        const idx = anims.findIndex((a) => a.id === originalId)
         if (idx === -1) {
-          // The original isn't there anymore (deleted in another
-          // session, race with file reload, …). Treat the edit as
-          // an add — the user's frames don't get lost.
-          if (!c.animations.some((a) => a.id === animation.id)) {
-            c.animations.push(animation)
-          }
+          // The original is gone (edited in another session, …) — treat
+          // as an add so the user's frames aren't lost.
+          if (!anims.some((a) => a.id === animation.id)) anims.push(animation)
           return
         }
-        // Renaming a custom animation has to clear any existing
-        // entry that already holds the new name (collisions are
-        // dialog-side rejected, but a stale list could still slip
-        // one through). Replace in place when the id is unchanged.
+        // A rename must not collide with an existing entry.
         if (animation.id !== originalId) {
-          const collision = c.animations.findIndex((a) => a.id === animation.id)
+          const collision = anims.findIndex((a) => a.id === animation.id)
           if (collision !== -1 && collision !== idx) return
         }
-        c.animations[idx] = animation
+        anims[idx] = animation
       })
-      void this.refresh()
     },
     deleteAnimation: (id: string, animId: string) => {
-      // Guard the required roles even though the UI only offers delete
-      // on custom rows — a stale view or a future caller mustn't be
-      // able to strip a character of a contract animation.
+      // Required roles can't be removed (part of the character contract).
       if ((REQUIRED_ROLES as readonly string[]).includes(animId)) return
-      this._mutate(id, (c) => {
-        c.animations = c.animations.filter((a) => a.id !== animId)
+      this._mutateSheetAnimations(id, (anims) => {
+        const idx = anims.findIndex((a) => a.id === animId)
+        if (idx !== -1) anims.splice(idx, 1)
       })
-      void this.refresh()
     },
     deleteCharacter: (id: string) => this._deleteCharacter(id),
     listSpriteSets: () => this._listSpriteSets(),
@@ -323,16 +313,13 @@ export class CastController {
     if (!resource?.data) return
     const characters = (resource.data.characters ??= [])
     const id = this._uniqueId(draft.name, new Set(characters.map((c) => c.id)))
+    // No animations here — the character inherits them from its chosen
+    // sheet (seeded on sheet import; see `_seedCharacterAnimations`).
     const character: CharacterDefinition = {
       id,
       name: draft.name,
       kind: draft.kind,
       spriteSetId: draft.spriteSetId,
-      animations: REQUIRED_ROLES.map((role) => ({
-        id: role,
-        frames: [DEFAULT_FRAME],
-        durationMs: DEFAULT_ANIMATION_MS,
-      })),
       defaultAnimation: 'idle-down',
       speedTilesPerSec: draft.speedTilesPerSec,
     }
@@ -376,12 +363,21 @@ export class CastController {
     if (!resource?.data) return null
     const id = this._uniqueId(data.id, new Set(resource.spriteSets.keys()))
     const imageFile = `${id}.png`
+    const kind = data.kind ?? ('tileset' as const)
     const finalData = {
       ...data,
       id,
       // The dialog tags the set by kind ('character' sheet vs 'tileset')
       // so it surfaces in the right gallery; default to tileset if absent.
-      kind: data.kind ?? ('tileset' as const),
+      kind,
+      // A character sheet OWNS its animations — seed the 8 required roles
+      // (single placeholder frame) so a character using it can animate
+      // immediately; the user refines frames in the sheet's editor.
+      characterAnimations:
+        kind === 'character'
+          ? (data.characterAnimations ??
+            REQUIRED_ROLES.map((role) => ({ id: role, frames: [DEFAULT_FRAME], durationMs: DEFAULT_ANIMATION_MS })))
+          : undefined,
       image: { ...(data.image ?? { id: 'main', type: 'image' as const }), path: imageFile },
     }
 
@@ -610,6 +606,35 @@ export class CastController {
     mutator(character)
     this._persist()
     this._broadcastCharacter(id)
+  }
+
+  /**
+   * Mutate the animations of the SHEET a character references (animations
+   * are sheet-owned now, shared by every character using it) + persist
+   * the sheet's JSON + refresh.
+   */
+  private _mutateSheetAnimations(charId: string, mutator: (anims: CharacterAnimation[]) => void): void {
+    const resource = this._project?.resource
+    const character = resource?.data?.characters?.find((c) => c.id === charId)
+    const engineSet = character ? resource?.spriteSets.get(character.spriteSetId) : undefined
+    if (!resource || !engineSet?.data) return
+    const anims = (engineSet.data.characterAnimations ??= [])
+    mutator(anims)
+    this._persistSheet(character?.spriteSetId ?? '')
+    this._spriteSetCache.delete(character?.spriteSetId ?? '')
+    void this.refresh()
+  }
+
+  /** Serialise a sprite sheet's `SpriteSetData` back to `spritesets/<id>.json`. */
+  private _persistSheet(spriteSetId: string): void {
+    const resource = this._project?.resource
+    const engineSet = resource?.spriteSets.get(spriteSetId)
+    if (!resource || !engineSet?.data || !isPlainFilename(spriteSetId)) return
+    const projectDir = GLib.path_get_dirname(resource.path)
+    const jsonPath = GLib.build_filenamev([projectDir, 'spritesets', `${spriteSetId}.json`])
+    if (!writeTextFile(jsonPath, SpriteSetFormat.serialize(engineSet.data))) {
+      this.onToast(_('Could not save the sprite sheet'))
+    }
   }
 
   /**

--- a/apps/maker-gjs/src/widgets/cast-view.ts
+++ b/apps/maker-gjs/src/widgets/cast-view.ts
@@ -294,7 +294,7 @@ export class CastView extends ResponsiveEditorView {
   private _presentEditAnimationDialog(animId: string): void {
     const character = this._currentCharacter()
     if (!character) return
-    const existing = character.animations.find((a) => a.id === animId)
+    const existing = this._animationsFor(character).find((a) => a.id === animId)
     if (!existing) return
     const dialog = new AddAnimationDialog()
     dialog.setContext(character, this._activeSpriteSet(), existing)
@@ -587,7 +587,12 @@ export class CastView extends ResponsiveEditorView {
   private _currentAnimation(): CharacterAnimation | null {
     const character = this._currentCharacter()
     if (!character || !this._activeAnimationId) return null
-    return character.animations.find((a) => a.id === this._activeAnimationId) ?? null
+    return this._animationsFor(character).find((a) => a.id === this._activeAnimationId) ?? null
+  }
+
+  /** Animations for a character — sheet-owned now, with the deprecated per-character fallback. */
+  private _animationsFor(character: CharacterDefinition): CharacterAnimation[] {
+    return this._spriteSetsById.get(character.spriteSetId)?.data?.characterAnimations ?? character.animations ?? []
   }
 
   /**

--- a/games/blank-starter/game-project.json
+++ b/games/blank-starter/game-project.json
@@ -49,49 +49,7 @@
       "isPlayer": true,
       "spriteSetId": "scientist",
       "speedTilesPerSec": 6,
-      "defaultAnimation": "idle-down",
-      "animations": [
-        {
-          "id": "idle-up",
-          "frames": [0],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-up",
-          "frames": [1, 2, 3, 4],
-          "durationMs": 200
-        },
-        {
-          "id": "idle-down",
-          "frames": [5],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-down",
-          "frames": [6, 7, 8, 9],
-          "durationMs": 200
-        },
-        {
-          "id": "idle-left",
-          "frames": [10],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-left",
-          "frames": [11, 12, 13, 14],
-          "durationMs": 200
-        },
-        {
-          "id": "idle-right",
-          "frames": [15],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-right",
-          "frames": [16, 17, 18, 19],
-          "durationMs": 200
-        }
-      ]
+      "defaultAnimation": "idle-down"
     }
   ]
 }

--- a/games/blank-starter/spritesets/scientist.json
+++ b/games/blank-starter/spritesets/scientist.json
@@ -115,5 +115,75 @@
       "col": 19,
       "row": 0
     }
+  ],
+  "characterAnimations": [
+    {
+      "id": "idle-up",
+      "frames": [
+        0
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-up",
+      "frames": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "idle-down",
+      "frames": [
+        5
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-down",
+      "frames": [
+        6,
+        7,
+        8,
+        9
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "idle-left",
+      "frames": [
+        10
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-left",
+      "frames": [
+        11,
+        12,
+        13,
+        14
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "idle-right",
+      "frames": [
+        15
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-right",
+      "frames": [
+        16,
+        17,
+        18,
+        19
+      ],
+      "durationMs": 200
+    }
   ]
 }

--- a/games/minimalist-starter/game-project.json
+++ b/games/minimalist-starter/game-project.json
@@ -77,49 +77,7 @@
       "isPlayer": true,
       "spriteSetId": "scientist",
       "speedTilesPerSec": 6,
-      "defaultAnimation": "idle-down",
-      "animations": [
-        {
-          "id": "idle-up",
-          "frames": [0],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-up",
-          "frames": [1, 2, 3, 4],
-          "durationMs": 200
-        },
-        {
-          "id": "idle-down",
-          "frames": [5],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-down",
-          "frames": [6, 7, 8, 9],
-          "durationMs": 200
-        },
-        {
-          "id": "idle-left",
-          "frames": [10],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-left",
-          "frames": [11, 12, 13, 14],
-          "durationMs": 200
-        },
-        {
-          "id": "idle-right",
-          "frames": [15],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-right",
-          "frames": [16, 17, 18, 19],
-          "durationMs": 200
-        }
-      ]
+      "defaultAnimation": "idle-down"
     }
   ]
 }

--- a/games/minimalist-starter/spritesets/scientist.json
+++ b/games/minimalist-starter/spritesets/scientist.json
@@ -115,5 +115,75 @@
       "col": 19,
       "row": 0
     }
+  ],
+  "characterAnimations": [
+    {
+      "id": "idle-up",
+      "frames": [
+        0
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-up",
+      "frames": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "idle-down",
+      "frames": [
+        5
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-down",
+      "frames": [
+        6,
+        7,
+        8,
+        9
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "idle-left",
+      "frames": [
+        10
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-left",
+      "frames": [
+        11,
+        12,
+        13,
+        14
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "idle-right",
+      "frames": [
+        15
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-right",
+      "frames": [
+        16,
+        17,
+        18,
+        19
+      ],
+      "durationMs": 200
+    }
   ]
 }

--- a/games/zelda-like/game-project.json
+++ b/games/zelda-like/game-project.json
@@ -70,49 +70,7 @@
       "isPlayer": true,
       "spriteSetId": "scientist",
       "speedTilesPerSec": 6,
-      "defaultAnimation": "idle-down",
-      "animations": [
-        {
-          "id": "idle-up",
-          "frames": [0],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-up",
-          "frames": [1, 2, 3, 4],
-          "durationMs": 200
-        },
-        {
-          "id": "idle-down",
-          "frames": [5],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-down",
-          "frames": [6, 7, 8, 9],
-          "durationMs": 200
-        },
-        {
-          "id": "idle-left",
-          "frames": [10],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-left",
-          "frames": [11, 12, 13, 14],
-          "durationMs": 200
-        },
-        {
-          "id": "idle-right",
-          "frames": [15],
-          "durationMs": 200
-        },
-        {
-          "id": "walk-right",
-          "frames": [16, 17, 18, 19],
-          "durationMs": 200
-        }
-      ]
+      "defaultAnimation": "idle-down"
     }
   ]
 }

--- a/games/zelda-like/spritesets/scientist.json
+++ b/games/zelda-like/spritesets/scientist.json
@@ -115,5 +115,75 @@
       "col": 19,
       "row": 0
     }
+  ],
+  "characterAnimations": [
+    {
+      "id": "idle-up",
+      "frames": [
+        0
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-up",
+      "frames": [
+        1,
+        2,
+        3,
+        4
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "idle-down",
+      "frames": [
+        5
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-down",
+      "frames": [
+        6,
+        7,
+        8,
+        9
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "idle-left",
+      "frames": [
+        10
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-left",
+      "frames": [
+        11,
+        12,
+        13,
+        14
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "idle-right",
+      "frames": [
+        15
+      ],
+      "durationMs": 200
+    },
+    {
+      "id": "walk-right",
+      "frames": [
+        16,
+        17,
+        18,
+        19
+      ],
+      "durationMs": 200
+    }
   ]
 }

--- a/packages/engine/src/types/data/CharacterDefinition.ts
+++ b/packages/engine/src/types/data/CharacterDefinition.ts
@@ -44,8 +44,13 @@ export interface CharacterDefinition {
   isPlayer?: boolean
   /** Source sprite-set the frames are indexed into. */
   spriteSetId: string
-  /** Per-character animation timeline (8 required + any custom). */
-  animations: CharacterAnimation[]
+  /**
+   * @deprecated Animations now live on the sprite sheet
+   * ({@link SpriteSetData.characterAnimations}) so characters sharing a
+   * sheet share them. Optional only for back-compat: the engine falls
+   * back to this when the referenced sheet carries no animations.
+   */
+  animations?: CharacterAnimation[]
   /** Default animation when the character is first instantiated. Falls back to `idle-down`. */
   defaultAnimation?: string
   /** Movement speed (tiles per second) when controlled by PlayerSystem. Default 4. */

--- a/packages/engine/src/types/data/SpriteSetData.ts
+++ b/packages/engine/src/types/data/SpriteSetData.ts
@@ -1,4 +1,5 @@
 import type { ImageReference } from '../reference/index'
+import type { CharacterAnimation } from './CharacterDefinition'
 import type { AnimationData, EditorMetadata, Properties, SpriteDataSet } from './index'
 
 /**
@@ -80,9 +81,19 @@ export interface SpriteSetData {
   rows: number
 
   /**
-   * Array of animation definitions
+   * Array of animation definitions (engine-level, for animated TILES /
+   * object graphics — referenced by `animationId`).
    */
   animations?: AnimationData[]
+
+  /**
+   * Character animations OWNED by this sheet (kind: 'character'): the
+   * directional roles (idle/walk-*) + any custom animations, as frame
+   * indices into this set's sprites. A {@link CharacterDefinition} that
+   * references this sheet inherits these — so several characters sharing
+   * a sheet share its animations (edit once). Absent for tilesets.
+   */
+  characterAnimations?: CharacterAnimation[]
 
   /**
    * Editor-specific metadata

--- a/packages/engine/src/utils/character.ts
+++ b/packages/engine/src/utils/character.ts
@@ -29,7 +29,10 @@ export function buildCharacterAnimations(
 } | null {
   if (!spriteSet) return null
   const animations: Partial<Record<CharacterAnimationRole, Animation>> = {}
-  for (const anim of character.animations) {
+  // Animations are owned by the sheet now; fall back to the (deprecated)
+  // per-character list for projects written before the move.
+  const sourceAnimations = spriteSet.data?.characterAnimations ?? character.animations ?? []
+  for (const anim of sourceAnimations) {
     if (!REQUIRED_ROLES.includes(anim.id as CharacterAnimationRole)) continue
     const built = buildAnimation(anim, spriteSet.sprites)
     if (built) animations[anim.id as CharacterAnimationRole] = built

--- a/packages/gjs/src/widgets/cast/animation-list.ts
+++ b/packages/gjs/src/widgets/cast/animation-list.ts
@@ -110,14 +110,18 @@ export class AnimationList extends Adw.Bin {
 
     if (!this._character) return
 
+    // Animations are owned by the SHEET now (shared across characters
+    // using it); fall back to the deprecated per-character list.
+    const anims = this._spriteSet?.data?.characterAnimations ?? this._character.animations ?? []
+
     // Required roles first (sorted by canonical order), then custom anims
     // alphabetically.
-    const present = new Map(this._character.animations.map((a) => [a.id, a]))
+    const present = new Map(anims.map((a) => [a.id, a]))
     const requiredOrdered = REQUIRED_ROLES.map((role) => ({
       role,
       anim: present.get(role) ?? null,
     }))
-    const customAnims = this._character.animations
+    const customAnims = anims
       .filter((a) => !REQUIRED_ROLES.includes(a.id as (typeof REQUIRED_ROLES)[number]))
       .sort((a, b) => a.id.localeCompare(b.id))
 

--- a/packages/gjs/src/widgets/cast/character-preview.ts
+++ b/packages/gjs/src/widgets/cast/character-preview.ts
@@ -491,18 +491,17 @@ export class CharacterPreview extends Adw.Bin {
    */
   private _activeAnimation(): CharacterAnimation | null {
     if (!this._character) return null
+    // Animations are owned by the sheet now (shared across characters);
+    // fall back to the deprecated per-character list.
+    const anims = this._spriteSet?.data?.characterAnimations ?? this._character.animations ?? []
     if (this._customAnimationId !== null) {
-      return this._character.animations.find((a) => a.id === this._customAnimationId) ?? null
+      return anims.find((a) => a.id === this._customAnimationId) ?? null
     }
     const primaryKind: AnimationKind = this._paused ? 'idle' : 'walk'
     const fallbackKind: AnimationKind = primaryKind === 'idle' ? 'walk' : 'idle'
     const primary = `${primaryKind}-${this._activeDirection}` as CharacterAnimationRole
     const fallback = `${fallbackKind}-${this._activeDirection}` as CharacterAnimationRole
-    return (
-      this._character.animations.find((a) => a.id === primary) ??
-      this._character.animations.find((a) => a.id === fallback) ??
-      null
-    )
+    return anims.find((a) => a.id === primary) ?? anims.find((a) => a.id === fallback) ?? null
   }
 
   private _applyFrame(): void {


### PR DESCRIPTION
**Phase 1** of aligning sprite sheets with tilesets as first-class assets (your idea: "a spritesheet contains the available animations and a character only selects the spritesheet").

## What moved
A character's animations now live on its **sheet** (`SpriteSetData.characterAnimations`) instead of on the character. So several characters sharing a sheet share its animations (edit once) — mirroring how a tileset owns its per-tile collision.

- `CharacterDefinition.animations` → **deprecated** (optional; the engine falls back to it for projects written before the move).
- The engine (`buildCharacterAnimations`), the animated `CharacterPreview`, and the `AnimationList` all read from the **resolved sheet**.
- The cast controller's animation edits mutate + persist the **sheet's** JSON; importing a character sheet **seeds** the 8 default roles; creating a character no longer seeds animations (it inherits the sheet's).
- Demo data migrated: the Scientist's animations moved from the character onto `scientist.json`.

The app stays fully working — animation editing is still reachable from the character detail (now sheet-owned, shared).

## Validation
- Full dependency-order `gjsify foreach build` / `check` / `check:barrels` green (rebuilt engine `.d.ts`); engine tests pass.
- Verified live via MCP: the Scientist detail animates (walk-down) and its Animations list shows all 8 roles — sourced from `scientist.json`'s `characterAnimations`, with the character carrying none.

## Next (Phase 2)
Split the Cast view into a **Sprite sheets** section (gallery + the animation editor per sheet) and a **Characters** section (each picks a sheet), per the agreed UX.