### PR TITLE
feat(gjs): generated component-inspector widgets

### DIFF
--- a/packages/gjs/src/stories.ts
+++ b/packages/gjs/src/stories.ts
@@ -10,6 +10,8 @@ import { CastInspector } from './widgets/cast/cast-inspector'
 import { CharacterPreview } from './widgets/cast/character-preview'
 import { AtlasCanvas } from './widgets/editor/atlas-canvas'
 import { AtlasCanvasStories } from './widgets/editor/atlas-canvas.story'
+import { EntityComponentsEditor } from './widgets/editor/entity-components-editor'
+import { EntityComponentsEditorStories } from './widgets/editor/entity-components-editor.story'
 import { FloatingTopBar } from './widgets/editor/floating-top-bar'
 import { FloatingTopBarStories } from './widgets/editor/floating-top-bar.story'
 import { FloatingZoom } from './widgets/editor/floating-zoom'
@@ -61,6 +63,7 @@ GObject.type_ensure(CharacterPreview.$gtype)
 GObject.type_ensure(AnimationList.$gtype)
 GObject.type_ensure(CastInspector.$gtype)
 GObject.type_ensure(TileInspector.$gtype)
+GObject.type_ensure(EntityComponentsEditor.$gtype)
 
 /** All story modules available in the UI-GJS package. */
 export const UIStories: StoryModule[] = [
@@ -75,6 +78,7 @@ export const UIStories: StoryModule[] = [
   AtlasCanvasStories,
   SceneInspectorStories,
   SceneEditorStories,
+  EntityComponentsEditorStories,
 ]
 
 export { SpriteWidgetStories } from './widgets/sprite/sprite.widget.story'

--- a/packages/gjs/src/widgets/editor/component-inspector.ts
+++ b/packages/gjs/src/widgets/editor/component-inspector.ts
@@ -1,0 +1,233 @@
+import Adw from '@girs/adw-1'
+import GObject from '@girs/gobject-2.0'
+import Gtk from '@girs/gtk-4.0'
+import type { ComponentData, ComponentSpec, FieldDescriptor } from '@pixelrpg/engine'
+import { gettext as _ } from 'gettext'
+
+/** Project-scoped options injected by the host for the `*-ref` field pickers. */
+export interface ComponentRefOptions {
+  maps?: ReadonlyArray<{ value: string; label: string }>
+  appearances?: ReadonlyArray<{ value: string; label: string }>
+  spriteSets?: ReadonlyArray<{ value: string; label: string }>
+}
+
+const FACING_OPTIONS = [
+  { value: 'up', label: 'Up' },
+  { value: 'down', label: 'Down' },
+  { value: 'left', label: 'Left' },
+  { value: 'right', label: 'Right' },
+]
+
+/** One generated row: its descriptor + read/write accessors over the live widget. */
+interface FieldRow {
+  field: FieldDescriptor
+  get: () => unknown
+  set: (value: unknown) => void
+}
+
+/**
+ * Inspector for ONE component — an `Adw.PreferencesGroup` whose rows are
+ * **generated from the component spec's {@link FieldDescriptor}s** (no
+ * hand-built template). Each `input` maps to an Adwaita row; edits emit
+ * `data-changed` with the whole {@link ComponentData} as a JSON string
+ * (GObject param-friendly + wholesale-replace semantics). A header remove
+ * button emits `remove-requested`.
+ *
+ * The host (`EntityComponentsEditor` / the objects + cast controllers)
+ * supplies `setSpec` + `setData` + `setRefOptions` and applies the
+ * resulting `data-changed`.
+ */
+export class ComponentInspector extends Adw.PreferencesGroup {
+  private _spec: ComponentSpec | null = null
+  private _refOptions: ComponentRefOptions = {}
+  private _rows: FieldRow[] = []
+  private _trackedRows: Adw.PreferencesRow[] = []
+  /** Suppresses `data-changed` while the host populates rows. */
+  private _silent = false
+  private _removeButton: Gtk.Button | null = null
+
+  static {
+    GObject.registerClass(
+      {
+        GTypeName: 'PixelRpgComponentInspector',
+        Signals: {
+          // The whole component data, JSON-stringified, on any edit.
+          'data-changed': { param_types: [GObject.TYPE_STRING] },
+          // The header remove (✕) was clicked.
+          'remove-requested': {},
+          // Whether this component can be removed (false for required ones).
+        },
+      },
+      ComponentInspector,
+    )
+  }
+
+  /** Show / hide the header remove (✕) button. */
+  setRemovable(removable: boolean): void {
+    if (removable && !this._removeButton) {
+      const btn = new Gtk.Button({
+        iconName: 'user-trash-symbolic',
+        tooltipText: _('Remove component'),
+        cssClasses: ['flat'],
+        valign: Gtk.Align.CENTER,
+      })
+      btn.connect('clicked', () => this.emit('remove-requested'))
+      this._removeButton = btn
+      this.set_header_suffix(btn)
+    } else if (!removable && this._removeButton) {
+      this.set_header_suffix(null)
+      this._removeButton = null
+    }
+  }
+
+  /** Project-scoped options for the `*-ref` pickers; rebuilds if a spec is set. */
+  setRefOptions(options: ComponentRefOptions): void {
+    this._refOptions = options
+    if (this._spec) this._rebuild()
+  }
+
+  /** Set the component spec (title + which rows to render). */
+  setSpec(spec: ComponentSpec): void {
+    this._spec = spec
+    this.set_title(_(spec.editor.label))
+    this._rebuild()
+  }
+
+  /** Populate the rows from component data without echoing `data-changed`. */
+  setData(data: ComponentData): void {
+    this._silent = true
+    try {
+      for (const row of this._rows) row.set(data[row.field.key])
+    } finally {
+      this._silent = false
+    }
+  }
+
+  private _rebuild(): void {
+    this._clearRows()
+    this._rows = []
+    if (!this._spec) return
+    for (const field of this._spec.fields) {
+      this._rows.push(this._buildRow(field))
+    }
+  }
+
+  private _clearRows(): void {
+    for (const r of this._trackedRows) this.remove(r)
+    this._trackedRows = []
+  }
+
+  private _buildRow(field: FieldDescriptor): FieldRow {
+    const label = _(field.label)
+    const onEdit = () => {
+      if (!this._silent) this._emitChange()
+    }
+    switch (field.input) {
+      case 'int':
+      case 'float': {
+        const adjustment = new Gtk.Adjustment({
+          lower: field.min ?? 0,
+          upper: field.max ?? 100000,
+          stepIncrement: field.step ?? (field.input === 'int' ? 1 : 0.5),
+          value: typeof field.default === 'number' ? field.default : (field.min ?? 0),
+        })
+        const row = new Adw.SpinRow({ title: label, adjustment, digits: field.input === 'float' ? 2 : 0 })
+        row.connect('notify::value', onEdit)
+        this._appendRow(row)
+        return {
+          field,
+          get: () => (field.input === 'int' ? Math.round(row.get_value()) : row.get_value()),
+          set: (v) => row.set_value(typeof v === 'number' ? v : (field.min ?? 0)),
+        }
+      }
+      case 'bool': {
+        const row = new Adw.SwitchRow({ title: label, active: field.default === true })
+        row.connect('notify::active', onEdit)
+        this._appendRow(row)
+        return { field, get: () => row.get_active(), set: (v) => row.set_active(v === true) }
+      }
+      case 'select':
+      case 'facing':
+      case 'map-ref':
+      case 'appearance-ref':
+      case 'sprite-ref': {
+        const options = this._optionsFor(field)
+        const values = options.map((o) => o.value)
+        const model = Gtk.StringList.new(options.map((o) => o.label))
+        const row = new Adw.ComboRow({ title: label, model })
+        row.connect('notify::selected', onEdit)
+        this._appendRow(row)
+        return {
+          field,
+          get: () => {
+            const i = row.get_selected()
+            return i >= 0 && i < values.length ? values[i] : undefined
+          },
+          set: (v) => {
+            const i = typeof v === 'string' ? values.indexOf(v) : -1
+            if (i >= 0) row.set_selected(i)
+          },
+        }
+      }
+      default: {
+        // text / map-ref fallback / json → an EntryRow. `json` parses on read.
+        const row = new Adw.EntryRow({ title: label })
+        row.connect('changed', onEdit)
+        this._appendRow(row)
+        if (field.input === 'json') {
+          return {
+            field,
+            get: () => {
+              const text = row.get_text().trim()
+              if (!text) return undefined
+              try {
+                return JSON.parse(text)
+              } catch {
+                return undefined // invalid JSON → omit (host validation flags it)
+              }
+            },
+            set: (v) => row.set_text(v === undefined ? '' : JSON.stringify(v)),
+          }
+        }
+        return {
+          field,
+          get: () => row.get_text() || undefined,
+          set: (v) => row.set_text(typeof v === 'string' ? v : ''),
+        }
+      }
+    }
+  }
+
+  private _appendRow(row: Adw.PreferencesRow): void {
+    this.add(row)
+    this._trackedRows.push(row)
+  }
+
+  /** Options for a select/ref field — from the descriptor or the injected refs. */
+  private _optionsFor(field: FieldDescriptor): ReadonlyArray<{ value: string; label: string }> {
+    switch (field.input) {
+      case 'facing':
+        return FACING_OPTIONS
+      case 'map-ref':
+        return this._refOptions.maps ?? []
+      case 'appearance-ref':
+      case 'sprite-ref':
+        return this._refOptions.appearances ?? this._refOptions.spriteSets ?? []
+      default:
+        return field.options ?? []
+    }
+  }
+
+  /** Re-assemble the component data from the rows + emit it. */
+  private _emitChange(): void {
+    if (!this._spec) return
+    const data: ComponentData = { type: this._spec.type }
+    for (const row of this._rows) {
+      const value = row.get()
+      if (value !== undefined) data[row.field.key] = value
+    }
+    this.emit('data-changed', JSON.stringify(data))
+  }
+}
+
+GObject.type_ensure(ComponentInspector.$gtype)

--- a/packages/gjs/src/widgets/editor/entity-components-editor.story.ts
+++ b/packages/gjs/src/widgets/editor/entity-components-editor.story.ts
@@ -1,0 +1,105 @@
+import GObject from '@girs/gobject-2.0'
+import type { EntityDefinition } from '@pixelrpg/engine'
+import { ControlType, type StoryArgs, type StoryMeta, type StoryModule, StoryWidget } from '@pixelrpg/story-gjs'
+import { EntityComponentsEditor } from './entity-components-editor'
+
+const SAMPLE_ENTITIES: Record<string, EntityDefinition> = {
+  npc: {
+    id: 'guard',
+    name: 'Town Guard',
+    components: [
+      { type: 'visual', spriteSetId: 'people', spriteId: 0, animationId: 'idle-down' },
+      { type: 'movement', tilesPerSec: 3 },
+      { type: 'dialogue', dialogueId: 'guard-intro' },
+      { type: 'trigger', on: 'action-button' },
+    ],
+    editorData: { template: 'npc' },
+  },
+  teleport: {
+    id: 'cave-door',
+    name: 'Cave Entrance',
+    components: [
+      { type: 'trigger', on: 'walk-onto' },
+      { type: 'teleport', targetMapId: 'cave', targetTileX: 4, targetTileY: 9, facing: 'down', label: 'Cave' },
+    ],
+    editorData: { template: 'teleport' },
+  },
+  item: {
+    id: 'apple',
+    name: 'Apple',
+    components: [
+      { type: 'visual', spriteSetId: 'overworld', spriteId: 4 },
+      { type: 'item', itemId: 'apple', qty: 1 },
+      { type: 'trigger', on: 'walk-onto' },
+    ],
+    editorData: { template: 'item' },
+  },
+}
+
+/** Showcase for the generated all-components editor. */
+export class EntityComponentsEditorStory extends StoryWidget {
+  private _editor: EntityComponentsEditor | null = null
+
+  static {
+    GObject.registerClass({ GTypeName: 'EntityComponentsEditorStory' }, EntityComponentsEditorStory)
+  }
+
+  constructor() {
+    super({
+      story: 'Default',
+      args: { sample: 'npc' },
+      meta: EntityComponentsEditorStory.getMetadata(),
+    })
+  }
+
+  static getMetadata(): StoryMeta {
+    return {
+      title: 'Editor/Entity Components Editor',
+      description:
+        'Advanced "all components" editor: one generated ComponentInspector per component (rows derived from the field DSL) + an "Add component" menu. Emits the whole EntityDefinition as JSON on every edit.',
+      component: EntityComponentsEditor.$gtype,
+      controls: [
+        {
+          name: 'sample',
+          label: 'Sample entity',
+          type: ControlType.SELECT,
+          options: [
+            { value: 'npc', label: 'NPC (visual + movement + dialogue + trigger)' },
+            { value: 'teleport', label: 'Teleport (trigger + teleport)' },
+            { value: 'item', label: 'Item (visual + item + trigger)' },
+          ],
+        },
+      ],
+    }
+  }
+
+  initialize(): void {
+    this._editor = new EntityComponentsEditor()
+    this._editor.setRefOptions({
+      maps: [
+        { value: 'cave', label: 'Cave' },
+        { value: 'overworld', label: 'Overworld' },
+      ],
+      appearances: [
+        { value: 'people', label: 'People' },
+        { value: 'overworld', label: 'Overworld' },
+      ],
+    })
+    this._applySample()
+    this.addContent(this._editor)
+  }
+
+  updateArgs(_args: StoryArgs): void {
+    this._applySample()
+  }
+
+  private _applySample(): void {
+    if (!this._editor) return
+    const key = typeof this.args.sample === 'string' ? this.args.sample : 'npc'
+    this._editor.setEntity(SAMPLE_ENTITIES[key] ?? SAMPLE_ENTITIES.npc)
+  }
+}
+
+GObject.type_ensure(EntityComponentsEditorStory.$gtype)
+
+export const EntityComponentsEditorStories: StoryModule = { stories: [EntityComponentsEditorStory] }

--- a/packages/gjs/src/widgets/editor/entity-components-editor.ts
+++ b/packages/gjs/src/widgets/editor/entity-components-editor.ts
@@ -1,0 +1,173 @@
+import Adw from '@girs/adw-1'
+import Gio from '@girs/gio-2.0'
+import GObject from '@girs/gobject-2.0'
+import Gtk from '@girs/gtk-4.0'
+import {
+  BUILT_IN_COMPONENT_SPECS,
+  type ComponentData,
+  type ComponentSpec,
+  type EntityDefinition,
+} from '@pixelrpg/engine'
+import { gettext as _ } from 'gettext'
+import { ComponentInspector, type ComponentRefOptions } from './component-inspector.ts'
+
+/**
+ * The advanced "all components" editor for one {@link EntityDefinition}: a
+ * vertical stack of {@link ComponentInspector}s (one per component,
+ * generated from the registry) + an "Add component" menu of the
+ * not-yet-present types. Any edit / add / remove emits `entity-changed`
+ * with the whole definition as a JSON string. The host (objects / cast
+ * controller) persists + broadcasts it.
+ *
+ * This is the progressive-disclosure power surface; the friendly Cast /
+ * template inspectors edit the same definition through a simpler view.
+ */
+export class EntityComponentsEditor extends Adw.Bin {
+  private _box: Gtk.Box
+  private _addButton: Gtk.MenuButton
+  private _id = ''
+  private _name = ''
+  private _editorData: EntityDefinition['editorData']
+  private _states: EntityDefinition['states']
+  private _components: ComponentData[] = []
+  private _refOptions: ComponentRefOptions = {}
+  /** Suppresses `entity-changed` while the host populates. */
+  private _silent = false
+
+  static {
+    GObject.registerClass(
+      {
+        GTypeName: 'PixelRpgEntityComponentsEditor',
+        Signals: {
+          // The whole EntityDefinition, JSON-stringified, on any change.
+          'entity-changed': { param_types: [GObject.TYPE_STRING] },
+        },
+      },
+      EntityComponentsEditor,
+    )
+  }
+
+  constructor() {
+    super()
+    this._box = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, spacing: 18 })
+    this._addButton = new Gtk.MenuButton({
+      label: _('Add component'),
+      iconName: 'list-add-symbolic',
+      alwaysShowArrow: true,
+      cssClasses: ['flat'],
+      halign: Gtk.Align.START,
+    })
+    this._box.append(this._addButton)
+    this.set_child(this._box)
+  }
+
+  /** Project-scoped picker options for the `*-ref` fields. */
+  setRefOptions(options: ComponentRefOptions): void {
+    this._refOptions = options
+    for (const inspector of this._inspectors()) inspector.setRefOptions(options)
+  }
+
+  /** Populate from an entity definition (no `entity-changed` echo). */
+  setEntity(def: EntityDefinition): void {
+    this._id = def.id
+    this._name = def.name
+    this._editorData = def.editorData
+    this._states = def.states
+    this._components = def.components.map((c) => ({ ...c }))
+    this._rebuild()
+  }
+
+  private _inspectors(): ComponentInspector[] {
+    const out: ComponentInspector[] = []
+    let child = this._box.get_first_child()
+    while (child) {
+      if (child instanceof ComponentInspector) out.push(child)
+      child = child.get_next_sibling()
+    }
+    return out
+  }
+
+  private _rebuild(): void {
+    this._silent = true
+    for (const inspector of this._inspectors()) this._box.remove(inspector)
+    for (let i = 0; i < this._components.length; i++) {
+      const comp = this._components[i]
+      const spec = BUILT_IN_COMPONENT_SPECS[comp.type]
+      if (!spec) continue // unknown type — skip (validation flags it elsewhere)
+      const inspector = new ComponentInspector()
+      inspector.setSpec(spec)
+      inspector.setRefOptions(this._refOptions)
+      inspector.setRemovable(true)
+      inspector.setData(comp)
+      const index = i
+      inspector.connect('data-changed', (_w: ComponentInspector, json: string) => {
+        try {
+          this._components[index] = JSON.parse(json) as ComponentData
+        } catch {
+          return
+        }
+        this._emitChange()
+      })
+      inspector.connect('remove-requested', () => this._removeComponent(index))
+      // Insert before the add button (which is the last child).
+      this._box.insert_child_after(inspector, this._lastInspectorOrNull())
+    }
+    this._rebuildAddMenu()
+    this._silent = false
+  }
+
+  private _lastInspectorOrNull(): Gtk.Widget | null {
+    const inspectors = this._inspectors()
+    return inspectors.length > 0 ? inspectors[inspectors.length - 1] : null
+  }
+
+  private _removeComponent(index: number): void {
+    this._components.splice(index, 1)
+    this._rebuild()
+    this._emitChange()
+  }
+
+  /** Build the "Add component" menu of the not-yet-present registry types. */
+  private _rebuildAddMenu(): void {
+    const present = new Set(this._components.map((c) => c.type))
+    const menu = Gio.Menu.new()
+    const group = new Gio.SimpleActionGroup()
+    let any = false
+    for (const spec of Object.values(BUILT_IN_COMPONENT_SPECS) as ComponentSpec[]) {
+      if (present.has(spec.type)) continue
+      any = true
+      const actionName = `add-${spec.type}`
+      const action = new Gio.SimpleAction({ name: actionName })
+      action.connect('activate', () => this._addComponent(spec))
+      group.add_action(action)
+      menu.append(_(spec.editor.label), `add.${actionName}`)
+    }
+    this._addButton.set_menu_model(menu)
+    this._addButton.insert_action_group('add', group)
+    this._addButton.set_sensitive(any)
+  }
+
+  private _addComponent(spec: ComponentSpec): void {
+    const data: ComponentData = { type: spec.type }
+    for (const field of spec.fields) {
+      if (field.default !== undefined) data[field.key] = field.default
+    }
+    this._components.push(data)
+    this._rebuild()
+    this._emitChange()
+  }
+
+  private _emitChange(): void {
+    if (this._silent) return
+    const def: EntityDefinition = {
+      id: this._id,
+      name: this._name,
+      components: this._components,
+      ...(this._states ? { states: this._states } : {}),
+      ...(this._editorData ? { editorData: this._editorData } : {}),
+    }
+    this.emit('entity-changed', JSON.stringify(def))
+  }
+}
+
+GObject.type_ensure(EntityComponentsEditor.$gtype)

--- a/packages/gjs/src/widgets/editor/index.ts
+++ b/packages/gjs/src/widgets/editor/index.ts
@@ -2,6 +2,9 @@
 
 export * from './atlas-canvas.story'
 export * from './atlas-canvas'
+export * from './component-inspector'
+export * from './entity-components-editor.story'
+export * from './entity-components-editor'
 export * from './floating-collaborators'
 export * from './floating-play'
 export * from './floating-top-bar.story'


### PR DESCRIPTION
## What — concept Phase C building block (additive)

Editor widgets that render an entity's `components[]` **from the component registry's field DSL** (#161) — the advanced "power" surface that complements the friendly Cast / template inspectors.

- **`ComponentInspector`** (`Adw.PreferencesGroup`): rows generated per `FieldDescriptor` (text→EntryRow, int/float→SpinRow, bool→SwitchRow, select/facing/`*-ref`→ComboRow, json→EntryRow+parse guard). `setSpec` / `setData` (silent) / `setRefOptions` / `setRemovable`; emits **`data-changed`** (whole ComponentData as JSON) + a `remove-requested` header button.
- **`EntityComponentsEditor`** (`Adw.Bin`): a stack of inspectors (one per component) + an **"Add component"** menu of the not-yet-present registry types; emits **`entity-changed`** (whole EntityDefinition as JSON). Host injects the `*-ref` picker options.
- `entity-components-editor.story.ts` registered in `stories.ts` (NPC / teleport / item samples).

JSON-string signal payloads keep it within GObject param limits + match the wholesale-replace persistence semantics the controllers already use.

## Scope
**Additive** — not consumed yet. Wired into the objects-library view (PR-6) + the Cast "all components" disclosure (PR-8).

## Validation
- ✅ `gjsify foreach check` / `build` / `check:barrels` + engine tests (gjs + node)
- Rendering is exercised once consumed (PR-6/8) + via the storybook story added here.