### PR TITLE
fix(engine,gjs): let in-progress object definitions save

### DIFF
--- a/packages/engine/src/entity/validate.spec.ts
+++ b/packages/engine/src/entity/validate.spec.ts
@@ -25,8 +25,11 @@ export default async () => {
     await it('accepts valid data', async () => {
       expect(validateComponentData(speedSpec, { type: 'movement', tilesPerSec: 4 })).toStrictEqual([])
     })
-    await it('flags a missing required field', async () => {
-      expect(validateComponentData(speedSpec, { type: 'movement' }).length).toBe(1)
+    await it('only flags a missing required field when requireComplete', async () => {
+      // Lenient (save / draft) — an empty required field is allowed.
+      expect(validateComponentData(speedSpec, { type: 'movement' })).toStrictEqual([])
+      // Strict (spawn / publish) — required is enforced.
+      expect(validateComponentData(speedSpec, { type: 'movement' }, true).length).toBe(1)
     })
     await it('enforces numeric range', async () => {
       expect(validateComponentData(speedSpec, { type: 'movement', tilesPerSec: 99 }).length).toBe(1)
@@ -51,9 +54,18 @@ export default async () => {
       const errors = validateEntityDefinition(def, registry)
       expect(errors.some((e) => e.includes('unregistered component type "teleport"'))).toBe(true)
     })
-    await it('validates component data through the registry', async () => {
-      const def: EntityDefinition = { id: 'x', name: 'X', components: [{ type: 'movement' }] }
-      expect(validateEntityDefinition(def, registry).length).toBe(1)
+    await it('flags wrong field types always, but required only when requireComplete', async () => {
+      // Wrong TYPE is always rejected (even on the lenient save path).
+      const wrongType: EntityDefinition = {
+        id: 'x',
+        name: 'X',
+        components: [{ type: 'movement', tilesPerSec: 'fast' }],
+      }
+      expect(validateEntityDefinition(wrongType, registry).length).toBe(1)
+      // Empty required field: a draft saves clean, the strict gate flags it.
+      const draft: EntityDefinition = { id: 'x', name: 'X', components: [{ type: 'movement' }] }
+      expect(validateEntityDefinition(draft, registry)).toStrictEqual([])
+      expect(validateEntityDefinition(draft, registry, true).length).toBe(1)
     })
     await it('validates state-overlay components too', async () => {
       const def: EntityDefinition = {

--- a/packages/engine/src/entity/validate.ts
+++ b/packages/engine/src/entity/validate.ts
@@ -4,10 +4,17 @@ import { BUILT_IN_COMPONENT_SPECS } from './registry.ts'
 
 const FACINGS = new Set(['up', 'down', 'left', 'right'])
 
-/** Validate one field's value against its descriptor. Returns an error string or null. */
-function validateField(field: FieldDescriptor, value: unknown): string | null {
+/**
+ * Validate one field's value against its descriptor. Returns an error
+ * string or null. `requireComplete` gates the `required` check: a save /
+ * draft passes `false` (an in-progress definition may leave required
+ * fields empty — e.g. a freshly-templated NPC with no appearance chosen
+ * yet), while a spawn / publish check passes `true`. Type errors on
+ * *present* values are reported regardless.
+ */
+function validateField(field: FieldDescriptor, value: unknown, requireComplete: boolean): string | null {
   const present = value !== undefined && value !== null && !(typeof value === 'string' && value.length === 0)
-  if (!present) return field.required ? `"${field.key}" is required` : null
+  if (!present) return field.required && requireComplete ? `"${field.key}" is required` : null
 
   switch (field.input) {
     case 'text':
@@ -43,26 +50,30 @@ function validateField(field: FieldDescriptor, value: unknown): string | null {
 
 /**
  * Validate one component's data against its spec's field descriptors.
- * Returns a list of human-readable errors (empty = valid).
+ * Returns a list of human-readable errors (empty = valid). `requireComplete`
+ * (default false) gates the per-field `required` check — see {@link validateField}.
  */
-export function validateComponentData(spec: ComponentSpec, data: ComponentData): string[] {
+export function validateComponentData(spec: ComponentSpec, data: ComponentData, requireComplete = false): string[] {
   const errors: string[] = []
   for (const field of spec.fields) {
-    const err = validateField(field, data[field.key])
+    const err = validateField(field, data[field.key], requireComplete)
     if (err) errors.push(`${spec.type}: ${err}`)
   }
   return errors
 }
 
 /**
- * Registry-aware validation of an entity definition. **Fails loudly on
- * an unregistered component `type`** (the concept's no-silent-skip rule)
- * and validates every component's data against its spec. Returns a list
- * of errors (empty = valid). Used by the format validators + the editor.
+ * Registry-aware validation of an entity definition. **Always fails loudly
+ * on an unregistered component `type`** (the concept's no-silent-skip rule)
+ * and on wrong field *types*. The `requireComplete` flag (default false)
+ * additionally enforces per-field `required`: the save path leaves it
+ * false (a draft may have empty required fields), a spawn / publish gate
+ * passes true. Returns a list of errors (empty = valid).
  */
 export function validateEntityDefinition(
   def: EntityDefinition,
   registry: ComponentSpecRegistry = BUILT_IN_COMPONENT_SPECS,
+  requireComplete = false,
 ): string[] {
   const errors: string[] = []
   if (typeof def.id !== 'string' || def.id.length === 0) errors.push('Entity definition is missing an id')
@@ -78,7 +89,7 @@ export function validateEntityDefinition(
         errors.push(`Entity "${def.id}" ${where} references unregistered component type "${comp.type}"`)
         continue
       }
-      errors.push(...validateComponentData(spec, comp))
+      errors.push(...validateComponentData(spec, comp, requireComplete))
     }
   }
   validateList(def.components, 'components')

--- a/packages/gjs/src/widgets/editor/component-inspector.ts
+++ b/packages/gjs/src/widgets/editor/component-inspector.ts
@@ -203,16 +203,22 @@ export class ComponentInspector extends Adw.PreferencesGroup {
     this._trackedRows.push(row)
   }
 
-  /** Options for a select/ref field — from the descriptor or the injected refs. */
+  /**
+   * Options for a select/ref field. `*-ref` lists get a leading "(None)"
+   * sentinel (value `''`) so an unset reference shows honestly + maps back
+   * to empty — without it the ComboRow would silently display the first
+   * option for a value it doesn't contain.
+   */
   private _optionsFor(field: FieldDescriptor): ReadonlyArray<{ value: string; label: string }> {
+    const none = { value: '', label: _('(None)') }
     switch (field.input) {
       case 'facing':
         return FACING_OPTIONS
       case 'map-ref':
-        return this._refOptions.maps ?? []
+        return [none, ...(this._refOptions.maps ?? [])]
       case 'appearance-ref':
       case 'sprite-ref':
-        return this._refOptions.appearances ?? this._refOptions.spriteSets ?? []
+        return [none, ...(this._refOptions.appearances ?? this._refOptions.spriteSets ?? [])]
       default:
         return field.options ?? []
     }


### PR DESCRIPTION
Two bugs in the Objects library flow (#165), found by live-testing the create flow:

### 1. Silent save failure
A freshly-templated object (NPC / item) seeds **required-but-empty** fields (`visual.spriteSetId: ''`, `item.itemId: ''`), and `validateEntityDefinition` (run by `GameProjectFormat.serialize`) treated empty-required as a hard error → the project **never persisted** (caught → toast, no write). `required`-completeness is a **spawn / publish** concern, not a save one — a draft may legitimately have unfilled fields.

`validateEntityDefinition` / `validateComponentData` / `validateField` now take **`requireComplete`** (default `false`): the save path is lenient, but **unregistered component types + wrong field _types_ are still rejected always**. A future spawn / publish gate passes `true`.

### 2. Ref ComboRow showed the wrong value when unset
An empty `*-ref` value isn't in the options list, so `Adw.ComboRow` silently displayed the **first** option (an unset Appearance read as "Lokiri Forest"). Ref lists now lead with a **"(None)"** sentinel (value `''`) → unset shows honestly + round-trips to empty.

## Validation
- ✅ Live: creating an item from a template now **persists** (`entityLibrary` gains the entry); its Appearance reads **"(None)"** (screenshot-verified).
- ✅ `validate.spec.ts` updated for the lenient/strict split; gates green (check / build / barrels / engine tests gjs+node).