### PR TITLE
fix(maker): add the library toggle to the Objects view header

### DIFF
--- a/apps/maker-gjs/src/widgets/objects-view.blp
+++ b/apps/maker-gjs/src/widgets/objects-view.blp
@@ -30,6 +30,18 @@ template $ObjectsView : $PixelRpgResponsiveEditorView {
           [top]
           Adw.HeaderBar {
             show-title: false;
+            show-start-title-buttons: false;
+            show-end-title-buttons: false;
+
+            // Reopen the mode rail when it's collapsed to an overlay
+            // (narrow widths) — without this the Objects view had no way
+            // back to the other modes once the rail was dismissed.
+            [start]
+            Gtk.ToggleButton library_toggle {
+              icon-name: "sidebar-show-symbolic";
+              tooltip-text: _("Toggle library");
+              active: bind template.show-library bidirectional;
+            }
 
             [end]
             Gtk.Button new_object_button {


### PR DESCRIPTION
## Bug

Reported live: *"somehow I can't get back from here"* — stuck in the Objects view with no way to the other modes.

The Objects gallery header was **missing the `library_toggle` button** that Cast and Tiles have. At narrow widths the mode rail collapses to an overlay; once dismissed (e.g. by switching into Objects via the rail, which auto-dismisses the overlay) there was **no affordance in the Objects view to reopen it** — the only header button was the window-close "X". Stranded.

## Fix

- Add the `[start]` sidebar-show `Gtk.ToggleButton library_toggle` (bound `active: bind template.show-library bidirectional`, exactly like Cast/Tiles) so the rail can always be reopened.
- Set `show-start/end-title-buttons: false` for consistency with the other views (removes the stray window-close "X" from the gallery header).

Blueprint-only; no TS change (the toggle is purely declarative).

## Validation

Live (MCP, phone width 400×880): the Objects header now shows the library-toggle top-left; activating `win.toggle-library` reopens the rail overlay. Matches Cast/Tiles behaviour. Build + lint green.