### PR TITLE
feat(engine): render object placements tile-like (framed cell graphics)

### DIFF
--- a/packages/engine/src/entity/index.ts
+++ b/packages/engine/src/entity/index.ts
@@ -3,6 +3,7 @@
 export * from './component-spec'
 export * from './convert'
 export * from './data-access'
+export * from './placement-graphic'
 export * from './registry'
 export * from './spawn-placement'
 export * from './validate'

--- a/packages/engine/src/entity/placement-graphic.spec.ts
+++ b/packages/engine/src/entity/placement-graphic.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from '@gjsify/unit'
+import { GraphicsGroup, Polygon, Rectangle } from 'excalibur'
+import type { MapResource } from '../resource/MapResource.ts'
+import type { EntityDefinition } from '../types/data/index.ts'
+import { buildPlacementGraphic, fitContainScale, frameInset, markerColorFor } from './placement-graphic.ts'
+
+const fakeMapResource = {
+  mapData: { tileWidth: 16, tileHeight: 16, layers: [] },
+  getSpriteSetResource: () => undefined,
+} as unknown as MapResource
+
+/** Unwrap a GraphicsGrouping | Graphic member to its Graphic. */
+const memberGraphic = (group: GraphicsGroup, index: number) => {
+  const member = group.members[index]
+  return member && 'graphic' in member ? member.graphic : member
+}
+
+export default async () => {
+  await describe('fitContainScale', async () => {
+    await it('scales down to fit, preserving aspect', async () => {
+      // 32×48 NPC cell into a 14×14 box → bound by height.
+      expect(fitContainScale(32, 48, 14, 14)).toBe(14 / 48)
+    })
+
+    await it('scales up small content to cell size', async () => {
+      expect(fitContainScale(4, 4, 14, 14)).toBe(3.5)
+    })
+
+    await it('returns 1 for degenerate inputs', async () => {
+      expect(fitContainScale(0, 16, 14, 14)).toBe(1)
+      expect(fitContainScale(16, 16, 0, 14)).toBe(1)
+    })
+  })
+
+  await describe('frameInset', async () => {
+    await it('is 1px on 16px tiles and grows with tile size', async () => {
+      expect(frameInset(16, 16)).toBe(1)
+      expect(frameInset(32, 32)).toBe(2)
+      expect(frameInset(8, 8)).toBe(1)
+    })
+  })
+
+  await describe('markerColorFor', async () => {
+    await it('falls back for components without a marker colour', async () => {
+      expect(markerColorFor([{ type: 'collision' }])).toBe('#ff9966')
+      expect(markerColorFor([])).toBe('#ff9966')
+    })
+
+    await it('resolves by priority — teleport wins over trigger', async () => {
+      const both = markerColorFor([
+        { type: 'trigger', on: 'walk-onto' },
+        { type: 'teleport', targetMapId: 'm', targetTileX: 0, targetTileY: 0 },
+      ])
+      expect(both).toBe(markerColorFor([{ type: 'teleport', targetMapId: 'm', targetTileX: 0, targetTileY: 0 }]))
+    })
+  })
+
+  await describe('buildPlacementGraphic', async () => {
+    // Raster graphics (Rectangle / Polygon) need a DOM canvas — present
+    // under GJS / the browser, absent on a bare Node run (same gate as
+    // spawn-placement.spec.ts).
+    const domAvailable = typeof document !== 'undefined'
+
+    await it('builds a tile-sized framed group with a type marker for a sprite-less def', async () => {
+      if (!domAvailable) return
+      const def: EntityDefinition = { id: 'w', name: 'Wall', components: [{ type: 'collision' }] }
+      const group = buildPlacementGraphic(def, fakeMapResource, 16, 16)
+      expect(group instanceof GraphicsGroup).toBe(true)
+      expect(group.members.length).toBe(2)
+      expect(memberGraphic(group, 0) instanceof Rectangle).toBe(true)
+      expect(memberGraphic(group, 1) instanceof Polygon).toBe(true)
+      expect(group.width).toBe(16)
+      expect(group.height).toBe(16)
+    })
+
+    await it('falls back to the marker when the visual sprite set is missing', async () => {
+      if (!domAvailable) return
+      const def: EntityDefinition = {
+        id: 'npc',
+        name: 'Npc',
+        components: [{ type: 'visual', spriteSetId: 'ghost-set', spriteId: 0 }],
+      }
+      const group = buildPlacementGraphic(def, fakeMapResource, 16, 16)
+      expect(group.members.length).toBe(2)
+      expect(memberGraphic(group, 1) instanceof Polygon).toBe(true)
+    })
+  })
+}

--- a/packages/engine/src/entity/placement-graphic.ts
+++ b/packages/engine/src/entity/placement-graphic.ts
@@ -1,0 +1,113 @@
+import { Color, GraphicsGroup, type GraphicsGrouping, Polygon, Rectangle, vec } from 'excalibur'
+import type { MapResource } from '../resource/MapResource.ts'
+import type { ComponentData, EntityDefinition } from '../types/data/index.ts'
+import { EDITOR_CONSTANTS } from '../utils/constants.ts'
+import type { ComponentSpecRegistry } from './component-spec.ts'
+import { BUILT_IN_COMPONENT_SPECS } from './registry.ts'
+import { buildVisualGraphic } from './visual-graphic.ts'
+
+/**
+ * Tile-like placement visuals — the single source for how an object
+ * placement looks on the map: a tile-sized frame (the object accent
+ * colour, same hue as the object hover border) holding either the
+ * definition's appearance sprite scaled to fit the cell, or — for a
+ * sprite-less definition — a diamond marker in the dominant marker
+ * component's colour ("a sign for the object type").
+ *
+ * Used by both the spawn pipeline (`spawn-placement.ts`) and the
+ * object-tool hover ghost (`services/object-preview.ts`), so the
+ * preview is pixel-identical to the placed result.
+ */
+
+/** Outline colour for a sprite-less placement carrying no marker component. */
+const FALLBACK_MARKER_COLOR = '#ff9966'
+
+/**
+ * Priority order for a sprite-less placement that carries several
+ * marker components — the first match's `editor.markerColor` wins.
+ * Preserves the pre-refactor per-kind colours (teleport/item/spawn-point
+ * /npc/event), now derived from the components instead of a `kind`.
+ */
+const MARKER_PRIORITY = ['teleport', 'item', 'spawn-point', 'npc-route', 'dialogue', 'trigger'] as const
+
+/** Resolve the marker colour for a component set (see {@link MARKER_PRIORITY}). */
+export function markerColorFor(
+  components: readonly ComponentData[],
+  registry: ComponentSpecRegistry = BUILT_IN_COMPONENT_SPECS,
+): string {
+  const types = new Set(components.map((c) => c.type))
+  for (const t of MARKER_PRIORITY) {
+    const color = types.has(t) ? registry[t]?.editor.markerColor : undefined
+    if (color) return color
+  }
+  return FALLBACK_MARKER_COLOR
+}
+
+/**
+ * Contain-fit scale factor: the largest factor that fits `width × height`
+ * inside `maxWidth × maxHeight` preserving aspect. May scale up (a tiny
+ * item icon grows to cell size) as well as down (an NPC sheet cell
+ * shrinks into the tile grid). Returns 1 for degenerate inputs.
+ */
+export function fitContainScale(width: number, height: number, maxWidth: number, maxHeight: number): number {
+  if (width <= 0 || height <= 0 || maxWidth <= 0 || maxHeight <= 0) return 1
+  return Math.min(maxWidth / width, maxHeight / height)
+}
+
+/**
+ * Inset between the cell frame and the sprite, so the sprite reads as
+ * "slightly smaller than a tile, inside a frame". 1px on 16px tiles,
+ * scales with the tile size.
+ */
+export function frameInset(tileWidth: number, tileHeight: number): number {
+  return Math.max(1, Math.round(Math.min(tileWidth, tileHeight) * 0.07))
+}
+
+/**
+ * Build the tile-like graphic for one resolved placement definition:
+ * a `GraphicsGroup` of [cell frame, content]. Content is the `visual`
+ * component's sprite/animation contain-fitted into the framed cell, or
+ * the type-coloured diamond marker when no sprite resolves.
+ *
+ * The group's local bounds are exactly `tileWidth × tileHeight`, so an
+ * anchor of (0.5, 0.5) centres it on a tile-centre actor and (0, 0)
+ * pins it to a tile origin (the hover ghost).
+ */
+export function buildPlacementGraphic(
+  def: EntityDefinition,
+  mapResource: MapResource,
+  tileWidth: number,
+  tileHeight: number,
+  registry: ComponentSpecRegistry = BUILT_IN_COMPONENT_SPECS,
+): GraphicsGroup {
+  const frame = new Rectangle({
+    width: tileWidth,
+    height: tileHeight,
+    color: Color.Transparent,
+    strokeColor: Color.fromHex(EDITOR_CONSTANTS.HOVER_OBJECT_BORDER_COLOR),
+    lineWidth: 1,
+  })
+  const members: GraphicsGrouping[] = [{ offset: vec(0, 0), graphic: frame }]
+
+  const visualData = def.components.find((c) => c.type === 'visual')
+  const sprite = visualData ? buildVisualGraphic(visualData, mapResource) : null
+  if (sprite) {
+    const inset = frameInset(tileWidth, tileHeight)
+    const scale = fitContainScale(sprite.width, sprite.height, tileWidth - 2 * inset, tileHeight - 2 * inset)
+    sprite.scale = vec(scale, scale)
+    // sprite.width / .height include the scale from here on.
+    members.push({
+      offset: vec((tileWidth - sprite.width) / 2, (tileHeight - sprite.height) / 2),
+      graphic: sprite,
+    })
+  } else {
+    const r = Math.max(2, Math.round(Math.min(tileWidth, tileHeight) * 0.25))
+    const diamond = new Polygon({
+      points: [vec(r, 0), vec(2 * r, r), vec(r, 2 * r), vec(0, r)],
+      color: Color.fromHex(markerColorFor(def.components, registry)),
+    })
+    members.push({ offset: vec(tileWidth / 2 - r, tileHeight / 2 - r), graphic: diamond })
+  }
+
+  return new GraphicsGroup({ members })
+}

--- a/packages/engine/src/entity/spawn-placement.spec.ts
+++ b/packages/engine/src/entity/spawn-placement.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@gjsify/unit'
-import type { Actor } from 'excalibur'
+import { type Actor, GraphicsGroup } from 'excalibur'
 import {
   CollisionComponent,
   PlacementIdComponent,
@@ -109,6 +109,19 @@ export default async () => {
       ) as Actor
       expect(entity.has(SpriteRefComponent)).toBe(false)
       expect(entity.has(CollisionComponent)).toBe(true)
+    })
+
+    await it('attaches the tile-like framed group graphic', async () => {
+      if (!domAvailable) return
+      const def: EntityDefinition = { id: 'wall', name: 'Wall', components: [{ type: 'collision' }] }
+      const entity = buildPlacementEntity(
+        { id: 'wall-2', layerId: 'l1', tileX: 1, tileY: 1, inline: def },
+        def,
+        fakeMapResource,
+        layersById,
+      ) as Actor
+      expect(entity.graphics.current instanceof GraphicsGroup).toBe(true)
+      expect((entity.graphics.current as GraphicsGroup).width).toBe(16)
     })
   })
 }

--- a/packages/engine/src/entity/spawn-placement.ts
+++ b/packages/engine/src/entity/spawn-placement.ts
@@ -1,25 +1,14 @@
-import { Actor, Color, type Entity, Rectangle, vec } from 'excalibur'
+import { Actor, type Entity, vec } from 'excalibur'
 import { PlacementIdComponent, TileTransformComponent } from '../components/index.ts'
 import { TIER_Z } from '../components/tilemap-tier.component.ts'
 import type { MapResource } from '../resource/MapResource.ts'
 import { isLayerVisible } from '../services/layer-visibility.ts'
-import type { ComponentData, EntityDefinition, ObjectPlacement } from '../types/data/index.ts'
+import type { EntityDefinition, ObjectPlacement } from '../types/data/index.ts'
 import { DEFAULT_LAYER_TIER, type LayerData } from '../types/data/LayerData.ts'
 import type { ComponentSpecRegistry } from './component-spec.ts'
 import { mergePlacementComponents } from './data-access.ts'
+import { buildPlacementGraphic } from './placement-graphic.ts'
 import { BUILT_IN_COMPONENT_SPECS } from './registry.ts'
-import { buildVisualGraphic } from './visual-graphic.ts'
-
-/** Outline colour for a sprite-less placement carrying no marker component. */
-const FALLBACK_MARKER_COLOR = '#ff9966'
-
-/**
- * Priority order for a sprite-less placement that carries several
- * marker components — the first match's `editor.markerColor` wins.
- * Preserves the pre-refactor per-kind colours (teleport/item/spawn-point
- * /npc/event), now derived from the components instead of a `kind`.
- */
-const MARKER_PRIORITY = ['teleport', 'item', 'spawn-point', 'npc-route', 'dialogue', 'trigger'] as const
 
 /**
  * Resolve a placement to its effective {@link EntityDefinition}: an inline
@@ -45,12 +34,12 @@ export function resolvePlacementDefinition(
 
 /**
  * Build one Excalibur entity from a placement + its resolved definition,
- * by walking the definition's `components[]` through the registry. Runtime
- * shape is identical to the pre-refactor kind-switch spawn: an `Actor` at
- * the tile centre, always-on `TileTransform` + `PlacementId`, each
- * component instantiated by its spec, the `visual` component's graphic
- * attached, a coloured outline marker for sprite-less placements, z from
- * the layer's tier, and the layer's visibility flag respected.
+ * by walking the definition's `components[]` through the registry: an
+ * `Actor` at the tile centre, always-on `TileTransform` + `PlacementId`,
+ * each component instantiated by its spec, the tile-like framed graphic
+ * from {@link buildPlacementGraphic} (sprite fitted into the cell, or a
+ * type-coloured marker for sprite-less placements), z from the layer's
+ * tier, and the layer's visibility flag respected.
  */
 export function buildPlacementEntity(
   placement: ObjectPlacement,
@@ -74,7 +63,6 @@ export function buildPlacementEntity(
   actor.addComponent(new PlacementIdComponent(placement.id))
 
   const ctx = { placementId: placement.id, tileX: placement.tileX, tileY: placement.tileY, tileWidth, tileHeight }
-  let graphicAttached = false
   for (const comp of def.components) {
     const spec = registry[comp.type]
     if (!spec) continue // load-time validation rejects unknowns; defensive here
@@ -82,47 +70,13 @@ export function buildPlacementEntity(
     if (built) {
       for (const c of Array.isArray(built) ? built : [built]) actor.addComponent(c)
     }
-    if (comp.type === 'visual') {
-      const graphic = buildVisualGraphic(comp, mapResource)
-      if (graphic) {
-        actor.graphics.use(graphic)
-        actor.graphics.anchor = vec(0.5, 0.5)
-        graphicAttached = true
-      }
-    }
   }
-  if (!graphicAttached) attachOutlineMarker(actor, def.components, tileWidth, tileHeight, registry)
+  actor.graphics.use(buildPlacementGraphic(def, mapResource, tileWidth, tileHeight, registry))
+  actor.graphics.anchor = vec(0.5, 0.5)
 
   const layer = layersById.get(placement.layerId)
   actor.z = TIER_Z[layer?.tier ?? DEFAULT_LAYER_TIER]
   if (!isLayerVisible(mapResource, placement.layerId)) actor.graphics.visible = false
 
   return actor
-}
-
-function markerColorFor(components: ComponentData[], registry: ComponentSpecRegistry): string {
-  const types = new Set(components.map((c) => c.type))
-  for (const t of MARKER_PRIORITY) {
-    const color = types.has(t) ? registry[t]?.editor.markerColor : undefined
-    if (color) return color
-  }
-  return FALLBACK_MARKER_COLOR
-}
-
-function attachOutlineMarker(
-  actor: Actor,
-  components: ComponentData[],
-  width: number,
-  height: number,
-  registry: ComponentSpecRegistry,
-): void {
-  const rect = new Rectangle({
-    width,
-    height,
-    color: Color.Transparent,
-    strokeColor: Color.fromHex(markerColorFor(components, registry)),
-    lineWidth: 1,
-  })
-  actor.graphics.use(rect)
-  actor.graphics.anchor = vec(0.5, 0.5)
 }

--- a/packages/engine/src/services/object-preview.ts
+++ b/packages/engine/src/services/object-preview.ts
@@ -1,16 +1,19 @@
-import { Actor, type Scene, type Sprite, type TileMap, Vector, vec } from 'excalibur'
+import { Actor, type GraphicsGroup, type Scene, type TileMap, Vector, vec } from 'excalibur'
 import { ActiveLayerComponent, ActiveObjectComponent, ActiveToolComponent, TIER_Z } from '../components/index.ts'
-import { getComponentData } from '../entity/data-access.ts'
+import { buildPlacementGraphic } from '../entity/placement-graphic.ts'
 import type { MapScene } from '../scenes/map.scene.ts'
+import type { EntityDefinition } from '../types/data/index.ts'
 import { EDITOR_CONSTANTS } from '../utils/constants.ts'
 import { SessionState } from '../utils/session-state.ts'
 
 /**
  * Object-tool hover preview — a half-transparent ghost of the armed
- * object brush's appearance that follows the pointer on the active map,
- * so placing a library object feels like painting a tile (its tile-twin
- * is `services/pencil-preview.ts`). Renders as a regular scene `Actor`
- * above every tilemap tier; spawn / despawn rebuilds don't disturb it.
+ * object brush that follows the pointer on the active map, so placing a
+ * library object feels like painting a tile (its tile-twin is
+ * `services/pencil-preview.ts`). The ghost is the exact graphic the
+ * placement will get (`entity/placement-graphic.ts`): framed cell +
+ * fitted sprite, or frame + type marker for a sprite-less definition —
+ * so every armed brush previews, appearance or not.
  *
  * Owner contract mirrors the pencil preview: the caller holds the actor +
  * the current hover state and hands both to {@link refreshObjectPreview};
@@ -23,6 +26,17 @@ export interface ObjectPreviewHover {
   tileMap: TileMap
   coords: { x: number; y: number }
 }
+
+/**
+ * Per-actor cache of the built ghost graphic. Rebuilding the framed
+ * `GraphicsGroup` rasterizes two canvas textures, so doing it on every
+ * pointer move would churn; the def's object identity invalidates the
+ * cache (the entity library is replaced wholesale on edits).
+ */
+const ghostCache = new WeakMap<
+  Actor,
+  { def: EntityDefinition; tileWidth: number; tileHeight: number; graphic: GraphicsGroup }
+>()
 
 /**
  * Construct the preview actor. Top-left anchored so `pos` maps directly
@@ -44,38 +58,42 @@ export function createObjectPreviewActor(): Actor {
  *
  * - Active tool isn't `'object'`
  * - No object brush armed (`ActiveObjectComponent.defId`)
- * - The armed def has no resolvable appearance sprite
+ * - The armed def no longer exists in the entity library
  * - The active layer is locked (a click would no-op)
  *
  * Idempotent — safe to call on every pointer move + on every
  * `ActiveTool` / `ActiveObject` / `ActiveLayer` mutation.
  */
 export function refreshObjectPreview(actor: Actor, scene: Scene, hover: ObjectPreviewHover | null): void {
-  const sprite = resolvePreviewSprite(scene, hover)
-  if (!sprite || !hover) {
+  const def = hover ? resolveArmedDefinition(scene) : null
+  if (!def || !hover) {
     actor.graphics.visible = false
     return
   }
-  // Clone — sharing one Sprite across draw targets corrupts per-frame
-  // transforms (same invariant the pencil preview relies on).
-  const cloned = sprite.clone()
-  cloned.opacity = EDITOR_CONSTANTS.PAINT_PREVIEW_OPACITY
-  actor.graphics.use(cloned)
+
+  const { tileWidth, tileHeight } = hover.tileMap
+  let cached = ghostCache.get(actor)
+  if (!cached || cached.def !== def || cached.tileWidth !== tileWidth || cached.tileHeight !== tileHeight) {
+    const graphic = buildPlacementGraphic(def, (scene as MapScene).mapResource, tileWidth, tileHeight)
+    graphic.opacity = EDITOR_CONSTANTS.PAINT_PREVIEW_OPACITY
+    cached = { def, tileWidth, tileHeight, graphic }
+    ghostCache.set(actor, cached)
+  }
+
+  actor.graphics.use(cached.graphic)
   actor.pos = new Vector(
-    hover.tileMap.pos.x + hover.coords.x * hover.tileMap.tileWidth,
-    hover.tileMap.pos.y + hover.coords.y * hover.tileMap.tileHeight,
+    hover.tileMap.pos.x + hover.coords.x * tileWidth,
+    hover.tileMap.pos.y + hover.coords.y * tileHeight,
   )
   actor.graphics.visible = true
 }
 
 /**
- * Resolve the sprite to ghost at the hover position, or `null` when any
+ * Resolve the armed brush to its library definition, or `null` when any
  * precondition is missing. Split out so {@link refreshObjectPreview} has
  * one "draw vs. hide" branch instead of nested guards.
  */
-function resolvePreviewSprite(scene: Scene, hover: ObjectPreviewHover | null): Sprite | null {
-  if (!hover) return null
-
+function resolveArmedDefinition(scene: Scene): EntityDefinition | null {
   const tool = SessionState.get(scene, ActiveToolComponent)?.tool
   if (tool !== 'object') return null
 
@@ -89,12 +107,5 @@ function resolvePreviewSprite(scene: Scene, hover: ObjectPreviewHover | null): S
   const layer = layerId ? mapResource.mapData?.layers.find((l) => l.id === layerId) : null
   if (layer?.locked) return null
 
-  const def = (scene as MapScene).entityLibrary?.find((e) => e.id === defId)
-  if (!def) return null
-  const visual = getComponentData(def, 'visual')
-  const spriteSetId = typeof visual?.spriteSetId === 'string' ? visual.spriteSetId : null
-  if (!spriteSetId) return null
-  const spriteId = typeof visual?.spriteId === 'number' ? visual.spriteId : 0
-
-  return mapResource.getSpriteSetResource(spriteSetId)?.sprites[spriteId] ?? null
+  return (scene as MapScene).entityLibrary?.find((e) => e.id === defId) ?? null
 }

--- a/packages/engine/src/test.mts
+++ b/packages/engine/src/test.mts
@@ -16,6 +16,7 @@ import { run } from '@gjsify/unit'
 // follow-up — a test that asserts every spec file is registered.)
 import registrySuite from './commands/registry.spec.js'
 import entityConvertSuite from './entity/convert.spec.js'
+import entityPlacementGraphicSuite from './entity/placement-graphic.spec.js'
 import entityRegistrySuite from './entity/registry.spec.js'
 import entitySpawnPlacementSuite from './entity/spawn-placement.spec.js'
 import entityValidateSuite from './entity/validate.spec.js'
@@ -42,6 +43,7 @@ run({
   entityRegistrySuite,
   entityValidateSuite,
   entityConvertSuite,
+  entityPlacementGraphicSuite,
   entitySpawnPlacementSuite,
   objectSystemValidationSuite,
   layerVisibilitySuite,


### PR DESCRIPTION
## What

Part 1 of the "objects look + behave like tiles" redesign: **placements on the map now render like tiles**.

- Every placement renders as a **tile-sized framed cell** (object accent colour — same hue as the object hover border), so placed objects are instantly distinguishable from painted tiles.
- The appearance sprite is **contain-fitted into the cell**: NPC sheet cells scale down into the tile grid, tile-sized graphics render slightly smaller inside the frame.
- A **sprite-less** placement shows the frame + a diamond marker in its dominant marker component's colour (a visible sign for the object type) — replacing the old near-invisible 1px outline for functional markers (triggers/teleports).
- The **object-tool hover ghost** (#178) now uses the *same* graphic builder: the preview is pixel-identical to the placed result, and every armed brush previews — appearance or not.

## Changes

- `entity/placement-graphic.ts` (new) — single source for placement visuals: `buildPlacementGraphic` (GraphicsGroup [frame, content]), `fitContainScale`, `frameInset`, `markerColorFor`.
- `spawn-placement.ts` — delegates graphic construction to the shared builder; outline-marker path removed.
- `services/object-preview.ts` — ghost = shared builder at preview opacity, cached per def (no re-rasterizing per pointer move).
- New `placement-graphic.spec.ts` + extended spawn spec; registered in `test.mts`.

## Validation

- **528** engine tests green (GJS + Node), `check`/`build` green across engine/gjs/maker.
- **Live-validated via MCP screenshots** on the zelda-like starter map: sprite placements (pots, bushes, sign) render framed + grid-fitted; sprite-less functional markers render framed diamonds; painted tiles stay frameless; selection ring + hover border coexist with the frames.

Next parts (separate PRs): object brushes inside the Tiles tab w/ shared swatch rendering, tool-dependent quick-select toolbar, Props-tab object settings, Objects visibility row in Layers.