### PR TITLE
fix(maker): surface AI presence on every Control mutation

### DIFF
--- a/apps/maker-gjs/src/services/control-dbus.service.ts
+++ b/apps/maker-gjs/src/services/control-dbus.service.ts
@@ -157,6 +157,7 @@ export class ControlDbusService {
    */
   ActivateAction(scope: string, name: string, valueJson: string): void {
     const win = this.requireWindow()
+    this._surfaceAssistantActivity()
     win.activateAction(toScope(scope), name, valueJson ? JSON.parse(valueJson) : undefined)
   }
 
@@ -167,11 +168,13 @@ export class ControlDbusService {
    */
   ChangeActionState(scope: string, name: string, valueJson: string): void {
     const win = this.requireWindow()
+    this._surfaceAssistantActivity()
     win.changeActionState(toScope(scope), name, JSON.parse(valueJson))
   }
 
   /** `OpenProject(path)` — load a project by its game-project.json path. */
   OpenProject(path: string): void {
+    this._surfaceAssistantActivity()
     this.requireWindow().openProject(path)
   }
 
@@ -206,6 +209,7 @@ export class ControlDbusService {
 
   /** `SetZoom(zoom)` — set the camera zoom to an absolute value (1 = 100%). */
   SetZoom(zoom: number): void {
+    this._surfaceAssistantActivity()
     this.requireWindow().setZoom(zoom)
   }
 
@@ -229,6 +233,7 @@ export class ControlDbusService {
    * `>0` = paint that global tile id.
    */
   PaintTile(layerId: string, tileX: number, tileY: number, spriteId: number): boolean {
+    this._surfaceAssistantActivity({ x: tileX, y: tileY })
     return this.requireWindow().paintTile(layerId || null, tileX, tileY, spriteId < 0 ? undefined : spriteId)
   }
 
@@ -238,6 +243,7 @@ export class ControlDbusService {
    * active layer. Goes through the engine command path (undo + collab).
    */
   PlaceObject(defId: string, layerId: string, tileX: number, tileY: number): boolean {
+    this._surfaceAssistantActivity({ x: tileX, y: tileY })
     return this.requireWindow().placeObject(defId, layerId || null, tileX, tileY)
   }
 
@@ -265,6 +271,24 @@ export class ControlDbusService {
     const win = this.window
     if (!win) throw new Error('No active window')
     return win
+  }
+
+  /**
+   * Surface the external driver as the AI participant. Called by every
+   * MUTATING control method (read-onlys like `GetStatus` / `Screenshot`
+   * stay silent), so the user always sees in the participants bar that an
+   * AI/automation is acting — and can follow it — even when the driver
+   * never announces itself explicitly. Tile-targeted mutations also move
+   * the assistant cursor onto the target tile, making the activity
+   * followable on the map. `HideAssistant` remains the explicit opt-out
+   * when a driver finishes.
+   */
+  private _surfaceAssistantActivity(tile?: { x: number; y: number }): void {
+    const win = this.window
+    if (!win) return
+    // The cursor path only applies with a live engine (scene editor);
+    // fall back to bare presence everywhere else.
+    if (!(tile && win.setAssistantCursor(tile.x, tile.y))) win.ensureAssistantPresence()
   }
 }
 

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -1553,7 +1553,10 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       canRedo: engine?.canRedo() ?? false,
       isPlaying: ex?.isRuntimeMode() ?? false,
       selectedPlacements: engine?.getSelectedPlacements() ?? [],
-      assistantPresent: ex?.isAssistantActive() ?? false,
+      // Window-level presence OR an engine-side active assistant — the
+      // participants bar and this status flag must tell the same story
+      // (presence can exist without a live engine, e.g. in the atlas).
+      assistantPresent: this._assistantPresent || (ex?.isAssistantActive() ?? false),
       assistantPaused: ex?.isAssistantPaused() ?? false,
       participants: this.getParticipants(),
       followedPeerId: this._followedPeerId,
@@ -1612,6 +1615,24 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this._refreshCollaborators()
     }
     return applied
+  }
+
+  /**
+   * Mark the AI assistant present without moving its cursor. The Control
+   * D-Bus surface calls this on every mutating method, so ANY external
+   * driver (MCP bridge, scripts) shows up in the participants bar the
+   * moment it starts acting — visibility must not depend on the driver
+   * remembering to announce itself via `SetAssistantInfo` /
+   * `SetAssistantCursor` first.
+   */
+  ensureAssistantPresence(): void {
+    if (this._assistantPresent) return
+    this._assistantPresent = true
+    // Mirror into the engine (when one is live) so `isAssistantActive`
+    // and the participants bar agree about the assistant being around.
+    this._engineCtl.engine?.excalibur?.setAssistantInfo(this._assistantName, this._assistantColor)
+    this._announceAssistantOnce()
+    this._refreshCollaborators()
   }
 
   /** Set the AI-assistant cursor's display name + colour. */


### PR DESCRIPTION
## Problem

The editor has an AI-collaborator presence system (participants bar, follow, pause), but it only engaged when the external driver **explicitly announced itself** via `SetAssistantInfo` / `SetAssistantCursor`. An AI steering the editor through the MCP bridge with `PlaceObject` / `PaintTile` / `ActivateAction` / `OpenProject` was completely invisible — no participants entry, no toast, nothing to follow.

## Fix

Visibility no longer depends on the driver's goodwill:

- Every **mutating** Control method (`ActivateAction`, `ChangeActionState`, `OpenProject`, `SetZoom`, `PaintTile`, `PlaceObject`) surfaces the AI participant. Read-onlys (`GetStatus`, `Screenshot`, `List*`) stay silent.
- **Tile-targeted** mutations (`PaintTile`, `PlaceObject`) also move the assistant cursor onto the target tile — the activity is followable on the map.
- New `ApplicationWindow.ensureAssistantPresence()`: presence without a cursor move (works in atlas/library views; mirrors into the engine when live).
- `GetStatus().assistantPresent` now reports window-level presence OR engine-side active assistant (previously engine-only, contradicting the participants bar outside the scene editor).
- `HideAssistant` remains the explicit opt-out when a driver finishes.

## Validation (live over D-Bus)

- Single `OpenProject` → participants bar shows **"AI Assistant"**, the "AI assistant is now editing with you" toast fires, `GetStatus` reports `assistantPresent: true` (screenshot-verified).
- `PlaceObject` → assistant cursor lands on the target tile in the scene editor.

## Follow-up (out of scope)

Pause/stop semantics for control-plane drivers: pausing the assistant currently gates the *in-process* assistant ops, but Control-plane mutations bypass that gate. Routing Control mutations through the same pause check is a separate, deliberate change.