### PR TITLE
feat(gjs+maker): object brushes live in the Tiles tab (shared swatches)

### DIFF
--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -2,7 +2,13 @@ import Adw from '@girs/adw-1'
 import GLib from '@girs/glib-2.0'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
-import { BUILT_IN_COMPONENT_SPECS, type EditorTool, type EntityDefinition, getComponentData } from '@pixelrpg/engine'
+import {
+  BUILT_IN_COMPONENT_SPECS,
+  type EditorTool,
+  type EntityDefinition,
+  getComponentData,
+  markerColorFor,
+} from '@pixelrpg/engine'
 import {
   type EditorMode,
   type Engine,
@@ -367,20 +373,25 @@ export class SceneEditorView extends ResponsiveEditorView {
         tileY: placement.tileY,
         layerId: placement.layerId,
         paintable,
+        // No resolvable sprite → the def's marker colour, mirroring the
+        // type-coloured marker the placement shows on the map.
+        color: paintable ? undefined : def ? markerColorFor(def.components) : undefined,
       }
     })
     this._inspector.objectsTab.setObjects(placements)
-    // Feed the placement-brush palette every brush candidate WITH a sprite
-    // thumbnail (its `visual` component resolved against the loaded sheets),
-    // so the user sees what they're about to stamp. Characters (Cast NPCs)
-    // are placeable now too; the player is excluded above.
+    // Feed the Tiles tab's Objects grid every brush candidate WITH a
+    // sprite thumbnail (its `visual` component resolved against the
+    // loaded sheets) or its marker colour as the fallback swatch, so
+    // picking an object looks + feels exactly like picking a tile.
+    // Characters (Cast NPCs) are placeable too; the player is excluded
+    // above.
     const brushOptions = brushDefs.map((def) => {
       let paintable = null
       const vis = visualOf(def)
       if (vis) paintable = gdkSheets.get(vis.spriteSetId)?.sprites[vis.spriteId]?.createPaintable() ?? null
-      return { id: def.id, name: def.name, paintable, icon: iconOf(def) }
+      return { id: def.id, name: def.name, paintable, color: paintable ? undefined : markerColorFor(def.components) }
     })
-    this._inspector.objectsTab.setBrushOptions(brushOptions)
+    this._inspector.tilesTab.setObjectBrushes(brushOptions)
 
     // Pick the first sprite set referenced by *this map* — that's the
     // one whose `firstGid` we need to offset against. Fall back to the
@@ -647,9 +658,12 @@ export class SceneEditorView extends ResponsiveEditorView {
       // finished — also fine, the new pan supersedes).
       void this._engine?.focusOnPlacement(placementId)
     })
-    // Object brush picked → arm it + switch to the Object tool via the
-    // window action (it sets both the engine brush and the tool state).
-    objects.connect('brush-selected', (_o: typeof objects, defId: string) => {
+    // Object brush picked in the Tiles tab's Objects grid → arm it +
+    // switch to the Object tool via the window action (it sets both the
+    // engine brush and the tool state) — picking what to place activates
+    // placement mode in one step, just like picking a tile arms the
+    // pencil's active tile.
+    tiles.connect('object-brush-selected', (_t: TilesTab, defId: string) => {
       this.activate_action('win.set-object-brush', GLib.Variant.new_string(defId))
     })
   }

--- a/packages/gjs/src/widgets/editor/objects-tab.blp
+++ b/packages/gjs/src/widgets/editor/objects-tab.blp
@@ -10,40 +10,9 @@ template $PixelRpgObjectsTab : Adw.Bin {
     margin-start: 12;
     margin-end: 12;
 
-    // Object "brush" palette: a wrapping grid of library-object cards
-    // (sprite thumbnail + name). Single-click a card to arm that brush,
-    // then click the canvas (Object tool) to stamp it. Picking one arms the
-    // brush + switches to the Object tool via win.set-object-brush.
-    Gtk.Box brush_section {
-      orientation: vertical;
-      spacing: 6;
-      visible: false;
-
-      Gtk.Label {
-        label: _("Place");
-        halign: start;
-        styles ["heading"]
-      }
-
-      Gtk.ScrolledWindow {
-        hscrollbar-policy: never;
-        vscrollbar-policy: automatic;
-        propagate-natural-height: true;
-        max-content-height: 220;
-
-        child: Gtk.FlowBox brush_palette {
-          selection-mode: single;
-          activate-on-single-click: true;
-          homogeneous: true;
-          min-children-per-line: 2;
-          max-children-per-line: 4;
-          row-spacing: 6;
-          column-spacing: 6;
-          styles ["object-brush-palette"]
-        };
-      }
-    }
-
+    // The placement-brush grid lives in the Tiles tab (below the tile
+    // palette) — this tab is a pure list of the objects PLACED on the
+    // active scene.
     Gtk.Box empty_state {
       orientation: vertical;
       spacing: 6;

--- a/packages/gjs/src/widgets/editor/objects-tab.ts
+++ b/packages/gjs/src/widgets/editor/objects-tab.ts
@@ -2,25 +2,9 @@ import Adw from '@girs/adw-1'
 import type Gdk from '@girs/gdk-4.0'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
-import Pango from '@girs/pango-1.0'
-import { gettext as _ } from 'gettext'
 
+import { createSwatchWidget } from './tile-palette'
 import Template from './objects-tab.blp'
-
-/** One pickable placement brush — a library object the user can stamp. */
-export interface BrushOption {
-  /** Library entity id. */
-  id: string
-  /** Display name. */
-  name: string
-  /**
-   * Sprite thumbnail (the object's `visual` component resolved to a
-   * paintable). Falls back to {@link icon} when absent.
-   */
-  paintable?: Gdk.Paintable | null
-  /** Symbolic fallback icon when no paintable is available. */
-  icon?: string
-}
 
 /** Editor-side description of a single object placement. */
 export interface ObjectDescriptor {
@@ -46,51 +30,44 @@ export interface ObjectDescriptor {
    * when `null` / unavailable.
    */
   paintable?: Gdk.Paintable | null
+  /**
+   * Solid fallback swatch colour (the def's marker colour) — used when
+   * no paintable resolves, so the row prefix matches the type-coloured
+   * marker the placement shows on the map. Falls back to {@link icon}.
+   */
+  color?: string
 }
 
-/** Symbolic icon used when a placement supplies neither a paintable nor an icon. */
+/** Symbolic icon used when a placement supplies neither a paintable, a colour, nor an icon. */
 const FALLBACK_ICON = 'view-grid-symbolic'
 
 /**
- * Inspector's "Objects" tab.
- *
- * Top: a **placement-brush palette** — a wrapping grid of library-object
- * cards (sprite thumbnail + name). Single-clicking a card emits
- * `brush-selected::<id>` (empty = the "(None)" card) so the host arms the
- * Object tool via `win.set-object-brush`; the user then clicks the canvas
- * to stamp it. The armed brush is highlighted + preserved across rebuilds.
- *
- * Below: one `Adw.ActionRow` per object PLACEMENT on the active scene
- * (sprite/kind icon, name, tile coordinates); selection emits
+ * Inspector's "Objects" tab — a pure list of the objects PLACED on the
+ * active scene: one `Adw.ActionRow` per placement (tile-like sprite
+ * swatch, name, tile coordinates); selection emits
  * `object-selected::<id>`. The empty state ("No objects yet") shows when
  * the scene has no placements.
  *
- * Drag-to-place is a follow-up (see TODO.md); the footer's "New object"
- * button seeds a library entry via `win.new-object`.
+ * Placement BRUSHES live in the Tiles tab's Objects grid (shared
+ * `TilePalette`), so picking what to place feels exactly like picking a
+ * tile. The footer's "New object" button seeds a library entry via
+ * `win.new-object`.
  */
 export class ObjectsTab extends Adw.Bin {
   declare _list: Gtk.ListBox
   declare _empty_state: Gtk.Box
   declare _new_object_button: Gtk.Button
-  declare _brush_section: Gtk.Box
-  declare _brush_palette: Gtk.FlowBox
 
   private _activeId: string | null = null
-  /** The currently-armed brush id (`null` = none), preserved across rebuilds. */
-  private _armedBrushId: string | null = null
-  /** Guards `setActiveBrush` / rebuild from re-emitting `brush-selected`. */
-  private _silentBrush = false
 
   static {
     GObject.registerClass(
       {
         GTypeName: 'PixelRpgObjectsTab',
         Template,
-        InternalChildren: ['list', 'empty_state', 'new_object_button', 'brush_section', 'brush_palette'],
+        InternalChildren: ['list', 'empty_state', 'new_object_button'],
         Signals: {
           'object-selected': { param_types: [GObject.TYPE_STRING] },
-          // A library object was chosen as the placement brush (empty = none).
-          'brush-selected': { param_types: [GObject.TYPE_STRING] },
         },
       },
       ObjectsTab,
@@ -106,104 +83,6 @@ export class ObjectsTab extends Adw.Bin {
       this._activeId = id
       this.emit('object-selected', id)
     })
-    // Single-click a palette card to arm that brush; the "(None)" card
-    // disarms. `child-activated` fires on a single click (the FlowBox is
-    // `activate-on-single-click`) + on keyboard activate.
-    this._brush_palette.connect('child-activated', (_fb: Gtk.FlowBox, child: Gtk.FlowBoxChild) => {
-      const id = (child as Gtk.FlowBoxChild & { brushId?: string }).brushId ?? ''
-      this._armedBrushId = id || null
-      if (!this._silentBrush) this.emit('brush-selected', id)
-    })
-  }
-
-  /**
-   * Populate the placement-brush palette with the project's library
-   * objects — a wrapping grid of cards (sprite thumbnail + name) the user
-   * single-clicks to arm a brush, then stamps on the canvas with the
-   * Object tool. A leading "(None)" card disarms. Hidden when there are no
-   * objects to place. The armed brush is preserved across rebuilds.
-   */
-  setBrushOptions(objects: ReadonlyArray<BrushOption>): void {
-    let child = this._brush_palette.get_first_child()
-    while (child) {
-      const next = child.get_next_sibling()
-      this._brush_palette.remove(child)
-      child = next
-    }
-    this._brush_palette.append(this._buildBrushCard({ id: '', name: _('None'), icon: 'edit-clear-symbolic' }))
-    for (const obj of objects) this._brush_palette.append(this._buildBrushCard(obj))
-    this._brush_section.set_visible(objects.length > 0)
-    // Re-arm the previous brush if it still exists, else fall back to None.
-    if (this._armedBrushId && !objects.some((o) => o.id === this._armedBrushId)) this._armedBrushId = null
-    this._reselectArmedBrush()
-  }
-
-  /** Build one palette card: a sprite thumbnail (or icon) above a name label. */
-  private _buildBrushCard(opt: BrushOption): Gtk.FlowBoxChild {
-    const box = new Gtk.Box({
-      orientation: Gtk.Orientation.VERTICAL,
-      spacing: 4,
-      marginTop: 6,
-      marginBottom: 6,
-      marginStart: 6,
-      marginEnd: 6,
-      halign: Gtk.Align.CENTER,
-    })
-    let thumb: Gtk.Widget
-    if (opt.paintable) {
-      const picture = new Gtk.Picture({
-        paintable: opt.paintable,
-        contentFit: Gtk.ContentFit.SCALE_DOWN,
-        widthRequest: 44,
-        heightRequest: 44,
-      })
-      picture.add_css_class('object-sprite-preview')
-      thumb = picture
-    } else {
-      thumb = new Gtk.Image({ iconName: opt.icon ?? FALLBACK_ICON, pixelSize: 28 })
-      thumb.add_css_class('dim-label')
-    }
-    thumb.set_halign(Gtk.Align.CENTER)
-    box.append(thumb)
-    box.append(
-      new Gtk.Label({
-        label: opt.name,
-        ellipsize: Pango.EllipsizeMode.END,
-        maxWidthChars: 9,
-        justify: Gtk.Justification.CENTER,
-        cssClasses: ['caption'],
-      }),
-    )
-    const child = new Gtk.FlowBoxChild({ child: box })
-    ;(child as Gtk.FlowBoxChild & { brushId?: string }).brushId = opt.id
-    return child
-  }
-
-  /** Highlight the card matching `_armedBrushId` without re-emitting. */
-  private _reselectArmedBrush(): void {
-    this._silentBrush = true
-    let child = this._brush_palette.get_first_child()
-    while (child) {
-      const id = (child as Gtk.FlowBoxChild & { brushId?: string }).brushId ?? ''
-      if ((id || null) === this._armedBrushId) {
-        this._brush_palette.select_child(child as Gtk.FlowBoxChild)
-        this._silentBrush = false
-        return
-      }
-      child = child.get_next_sibling()
-    }
-    this._brush_palette.unselect_all()
-    this._silentBrush = false
-  }
-
-  /**
-   * Programmatically arm a brush by id (`null`/`''` = none) — e.g. when the
-   * host re-syncs after a tool change. Highlights the matching card without
-   * re-emitting `brush-selected`.
-   */
-  setActiveBrush(id: string | null): void {
-    this._armedBrushId = id || null
-    this._reselectArmedBrush()
   }
 
   /**
@@ -241,32 +120,22 @@ export class ObjectsTab extends Adw.Bin {
 
   /**
    * Build the prefix widget shown to the left of an object row's
-   * title. Prefers the placement's `paintable` (the resolved sprite
-   * thumbnail) and falls back to the kind icon when no paintable is
-   * available — that way placements without an attached sprite
-   * still get a recognisable kind-specific badge.
-   *
-   * The sprite is rendered through a `Gtk.Picture` sized to roughly
-   * match the kind icon's footprint so rows stay vertically aligned.
-   * Pixel-art sprites stay crisp via `content-fit: scale-down` —
-   * smaller sprites render at native size + a transparent border,
-   * larger ones scale down preserving aspect.
+   * title: the SAME swatch renderer the tile/object palettes use
+   * (`createSwatchWidget`), framed via the `object-swatch` style —
+   * so a placement looks identical here, in the Tiles tab's Objects
+   * grid, and (engine-side) on the map. Sprite paintable → contain-fit
+   * picture; no sprite → the def's marker colour; neither → kind icon.
    */
   private _buildPrefix(placement: ObjectDescriptor): Gtk.Widget {
-    if (placement.paintable) {
-      const picture = new Gtk.Picture({
-        paintable: placement.paintable,
-        content_fit: Gtk.ContentFit.SCALE_DOWN,
-        width_request: 28,
-        height_request: 28,
+    if (!placement.paintable && !placement.color) {
+      return new Gtk.Image({
+        icon_name: placement.icon ?? FALLBACK_ICON,
+        pixel_size: 18,
       })
-      picture.add_css_class('object-sprite-preview')
-      return picture
     }
-    return new Gtk.Image({
-      icon_name: placement.icon ?? FALLBACK_ICON,
-      pixel_size: 18,
-    })
+    const swatch = createSwatchWidget(placement, 28, 28, 'contain')
+    swatch.add_css_class('object-swatch')
+    return swatch
   }
 
   /** Programmatically set the active object. No-op if id not present. */

--- a/packages/gjs/src/widgets/editor/scene-editor.css
+++ b/packages/gjs/src/widgets/editor/scene-editor.css
@@ -31,3 +31,29 @@
 .header-osd windowcontrols button:hover image {
   background-color: alpha(@window_fg_color, 0.16);
 }
+
+/*
+ * Tile-like object swatches — the SAME visual language as placements on
+ * the map (engine `placement-graphic.ts`): a thin frame in the object
+ * accent colour (#f5c211, the object hover-border hue) around the
+ * sprite/marker preview. Applied to the Tiles tab's Objects grid cells
+ * (`.object-brush-palette`) and the Objects tab's placement-row
+ * swatches (`.object-swatch`), so an object reads identically in the
+ * palette, in the placement list, and on the canvas.
+ */
+.object-brush-palette flowboxchild {
+  border: 1px solid alpha(#f5c211, 0.7);
+  border-radius: 4px;
+  padding: 1px;
+}
+
+.object-brush-palette flowboxchild:selected {
+  border-color: @accent_bg_color;
+  background-color: alpha(@accent_bg_color, 0.25);
+}
+
+.object-swatch {
+  border: 1px solid alpha(#f5c211, 0.7);
+  border-radius: 4px;
+  padding: 1px;
+}

--- a/packages/gjs/src/widgets/editor/tile-palette.ts
+++ b/packages/gjs/src/widgets/editor/tile-palette.ts
@@ -29,6 +29,32 @@ export interface TileDescriptor {
 }
 
 /**
+ * Build the swatch widget for one palette cell: a `Gtk.Picture` for a
+ * paintable, else a solid-colour {@link TileSwatch}. The single shared
+ * renderer for tile-like previews — {@link TilePalette} cells and the
+ * Objects tab's placement rows both go through here, so a sprite looks
+ * identical wherever it appears.
+ */
+export function createSwatchWidget(
+  desc: { color?: string; paintable?: Gdk.Paintable | null },
+  width: number,
+  height: number,
+  contentFit: 'fill' | 'contain' = 'fill',
+): Gtk.Widget {
+  let swatch: Gtk.Widget
+  if (desc.paintable) {
+    const picture = new Gtk.Picture()
+    picture.set_paintable(desc.paintable)
+    picture.set_content_fit(contentFit === 'contain' ? Gtk.ContentFit.CONTAIN : Gtk.ContentFit.FILL)
+    swatch = picture
+  } else {
+    swatch = new TileSwatch(desc.color ?? '#9aa0a6')
+  }
+  swatch.set_size_request(width, height)
+  return swatch
+}
+
+/**
  * 5-column FlowBox of tile swatches. Emits `tile-selected::<id>` when a
  * swatch is activated. Used by `tiles-tab` and the active-tile popover
  * surfaced inside `floating-top-bar`.
@@ -290,25 +316,21 @@ export class TilePalette extends Adw.Bin {
     return [Math.max(1, Math.round(this._tileSize * this._cellAspect)), this._tileSize]
   }
 
+  /** Clear the visual selection (no tile armed). */
+  clearSelection(): void {
+    this._flow.unselect_all()
+    this._selectedId = null
+  }
+
   private _buildSwatch(tile: TileDescriptor): Gtk.FlowBoxChild {
     const child = new Gtk.FlowBoxChild()
-
-    let swatch: Gtk.Widget
-    if (tile.paintable) {
-      const picture = new Gtk.Picture()
-      picture.set_paintable(tile.paintable)
-      // Picture's content-fit + the paintable's `keepAspectRatio`
-      // option pull in the same direction — both must match the
-      // aspect-mode setting. `fill` stretches the sprite to fill
-      // the square cell (tile-tab / scene-editor use case); contain
-      // preserves aspect inside cells sized by `_swatchDimensions`.
-      picture.set_content_fit(this._aspectMode === 'contain' ? Gtk.ContentFit.CONTAIN : Gtk.ContentFit.FILL)
-      swatch = picture
-    } else {
-      swatch = new TileSwatch(tile.color ?? '#9aa0a6')
-    }
+    // Picture's content-fit + the paintable's `keepAspectRatio` option
+    // pull in the same direction — both must match the aspect-mode
+    // setting. `fill` stretches the sprite to fill the square cell
+    // (tile-tab / scene-editor use case); `contain` preserves aspect
+    // inside cells sized by `_swatchDimensions`.
     const [w, h] = this._swatchDimensions()
-    swatch.set_size_request(w, h)
+    const swatch = createSwatchWidget(tile, w, h, this._aspectMode)
     if (tile.name) child.set_tooltip_text(tile.name)
     child.set_child(swatch)
     return child

--- a/packages/gjs/src/widgets/editor/tiles-tab.blp
+++ b/packages/gjs/src/widgets/editor/tiles-tab.blp
@@ -36,5 +36,24 @@ template $PixelRpgTilesTab : Adw.Bin {
       tile-size: 42;
       columns: 5;
     }
+
+    Gtk.Box objects_section {
+      orientation: vertical;
+      spacing: 6;
+      visible: false;
+
+      Gtk.Label {
+        label: _("Objects");
+        halign: start;
+        styles ["heading", "dim-label"]
+      }
+
+      $PixelRpgTilePalette object_palette {
+        tile-size: 42;
+        columns: 5;
+        aspect-mode: "contain";
+        styles ["object-brush-palette"]
+      }
+    }
   }
 }

--- a/packages/gjs/src/widgets/editor/tiles-tab.ts
+++ b/packages/gjs/src/widgets/editor/tiles-tab.ts
@@ -1,4 +1,5 @@
 import Adw from '@girs/adw-1'
+import type Gdk from '@girs/gdk-4.0'
 import GObject from '@girs/gobject-2.0'
 import type Gtk from '@girs/gtk-4.0'
 import { type TileDescriptor, TilePalette } from './tile-palette'
@@ -7,12 +8,26 @@ import Template from './tiles-tab.blp'
 
 GObject.type_ensure(TilePalette.$gtype)
 
+/** One placeable library object shown in the tab's Objects grid. */
+export interface ObjectBrushDescriptor {
+  /** Library entity id (string — unlike numeric tile ids). */
+  id: string
+  name?: string
+  /** Sprite thumbnail; falls back to {@link color}. */
+  paintable?: Gdk.Paintable | null
+  /** Solid fallback swatch colour (e.g. the def's marker colour). */
+  color?: string
+}
+
 /**
  * Inspector's "Tiles" tab.
  *
- * Hosts a search entry, the active tileset name + "Switch…" button, and
- * the {@link TilePalette}. Tile selections re-emit on the tab as
- * `tile-selected::<id>` for the parent inspector to relay.
+ * Hosts a search entry, the active tileset name + "Switch…" button, the
+ * {@link TilePalette}, and below it an **Objects grid** — the same
+ * palette widget fed with the project's placeable library objects, so
+ * picking an object feels exactly like picking a tile. Tile selections
+ * re-emit as `tile-selected::<id>`; object picks as
+ * `object-brush-selected::<defId>` (the host arms the Object tool).
  *
  * Stamps are deferred until the tileset editor lands — once tilesets
  * own a stamps collection, this tab will gain a configurable stamps
@@ -23,15 +38,19 @@ export class TilesTab extends Adw.Bin {
   declare _tileset_label: Gtk.Label
   declare _switch_button: Gtk.Button
   declare _palette: TilePalette
+  declare _objects_section: Gtk.Box
+  declare _object_palette: TilePalette
 
   private _tilesetName = ''
+  /** defIds by palette index — `TilePalette` ids are numeric, objects are strings. */
+  private _objectBrushIds: string[] = []
 
   static {
     GObject.registerClass(
       {
         GTypeName: 'PixelRpgTilesTab',
         Template,
-        InternalChildren: ['search', 'tileset_label', 'switch_button', 'palette'],
+        InternalChildren: ['search', 'tileset_label', 'switch_button', 'palette', 'objects_section', 'object_palette'],
         Properties: {
           'tileset-name': GObject.ParamSpec.string(
             'tileset-name',
@@ -43,6 +62,8 @@ export class TilesTab extends Adw.Bin {
         },
         Signals: {
           'tile-selected': { param_types: [GObject.TYPE_INT] },
+          // A library object was picked from the Objects grid (defId).
+          'object-brush-selected': { param_types: [GObject.TYPE_STRING] },
         },
       },
       TilesTab,
@@ -52,6 +73,10 @@ export class TilesTab extends Adw.Bin {
   constructor() {
     super()
     this._palette.connect('tile-selected', (_p, tileId) => this.emit('tile-selected', tileId))
+    this._object_palette.connect('tile-selected', (_p, idx: number) => {
+      const defId = this._objectBrushIds[idx]
+      if (defId) this.emit('object-brush-selected', defId)
+    })
   }
 
   get tilesetName(): string {
@@ -72,6 +97,36 @@ export class TilesTab extends Adw.Bin {
    * external selection (e.g. via the top-bar tile popover). */
   selectTile(id: number): void {
     this._palette.selectTile(id)
+  }
+
+  /**
+   * Populate the Objects grid with the project's placeable library
+   * objects. Hidden when there are none. Cells render the object's
+   * sprite contain-fitted into a tile-sized framed cell (or its marker
+   * colour as a solid swatch) — the same visual language as placements
+   * on the map.
+   */
+  setObjectBrushes(brushes: ReadonlyArray<ObjectBrushDescriptor>): void {
+    this._objectBrushIds = brushes.map((b) => b.id)
+    this._object_palette.setTiles(
+      brushes.map((b, idx) => ({
+        id: idx,
+        name: b.name,
+        color: b.color,
+        paintable: b.paintable ?? undefined,
+      })),
+    )
+    this._objects_section.set_visible(brushes.length > 0)
+  }
+
+  /**
+   * Mirror an externally-armed object brush (`null` clears) without
+   * re-emitting `object-brush-selected`.
+   */
+  selectObjectBrush(defId: string | null): void {
+    const idx = defId ? this._objectBrushIds.indexOf(defId) : -1
+    if (idx < 0) this._object_palette.clearSelection()
+    else this._object_palette.selectTile(idx)
   }
 }
 


### PR DESCRIPTION
## What

Part 2 of "objects look + behave like tiles": **picking an object now works exactly like picking a tile.**

- The **Tiles tab** gains an **Objects grid** below the tile palette — the *same* `TilePalette` widget, fed with the placeable library objects: sprite contain-fitted into a tile-sized framed cell, or the def's **marker colour** as a solid swatch (the same type-colour the placement shows on the map). Hidden when the library has no placeable defs.
- Picking an object **auto-arms the Object tool** (existing `win.set-object-brush` behavior) — one step, like a tile pick arming the pencil.
- The **Objects tab** becomes a pure list of *placed* objects; the card-style brush palette is gone. Row prefixes render through the **shared swatch builder** (`createSwatchWidget`) + the `object-swatch` frame, so an object reads identically in the palette, the placement list, and (engine-side, #179) on the canvas.
- New CSS: the tile-like object frame in the object accent (`#f5c211`, the hover-border hue) with an accent-coloured `:selected` state.

## Validation

- `check`/`build` green (gjs + maker), Biome clean.
- Live screenshots: Objects tab shows framed marker-colour swatches for functional placements + sprite swatches for decorations (the unified look); Tiles tab renders intact.
- Note: with the zelda-like tileset the Objects grid sits below a long tile palette — reachable by scrolling the inspector (as requested: "im Tiles-Reiter unter den Tiles"). If it feels buried, moving it above the palette or making the tileset section collapsible is a small follow-up.

Next: tool-dependent quick-select in the floating toolbar (objects under the Object tool, tiles under pencil).