### PR TITLE
feat(maker+gjs): Props tab shows the selected object's settings

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -341,6 +341,16 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this._persistCurrentMap()
     })
 
+    // A placement was removed via the Props tab — refresh the
+    // inspector's placement list (the command already mutated the live
+    // MapData) and persist, mirroring the layer-flag flow.
+    this.signals.connect(this._scene_editor_view, 'object-removed', () => {
+      if (this._loadedProject && this._currentSceneId) {
+        void this._scene_editor_view.populateFromProject(this._loadedProject, this._currentSceneId)
+      }
+      this._persistCurrentMap()
+    })
+
     if (!this._castCtl) {
       this._castCtl = new CastController(this._cast_view, (msg) => this._showToast(msg))
       // Sprite-sets are shared project assets shown in BOTH the Cast
@@ -901,6 +911,18 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this._scene_editor_view.setArmedObjectBrush(defId || null)
     })
     winActions.add_action(setObjectBrushAction)
+
+    // Select a placement by id (`''` clears) — the driveable equivalent
+    // of a select-tool canvas click, so external tooling (MCP bridge,
+    // tests) can exercise the selection → Objects-row → Props flow.
+    const selectPlacementAction = Gio.SimpleAction.new('select-placement', GLib.VariantType.new('s'))
+    selectPlacementAction.connect('activate', (_a, parameter) => {
+      const id = parameter?.get_string()[0] ?? ''
+      this._engineCtl.engine?.setSelectedPlacements(id ? [id] : [])
+      this._scene_editor_view.highlightPlacement(id || null)
+      if (id) this.set_property('show-inspector', true)
+    })
+    winActions.add_action(selectPlacementAction)
 
     // Switch the scene-editor inspector to a tab by name (tiles / layers /
     // objects / props). The tab bar is otherwise click-only — this lets

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -95,6 +95,11 @@ export class SceneEditorView extends ResponsiveEditorView {
   private _armedObjectId: string | null = null
   /** The active editor tool — decides what the context chip quick-selects (tiles vs objects). */
   private _activeTool: EditorTool = 'select'
+  /** Per-placement info for the Props tab's "Selected object" group. */
+  private _placementInfo = new Map<
+    string,
+    { name: string; defId: string | null; tileX: number; tileY: number; layerId: string }
+  >()
   private _activeLayerId: string | null = null
   private _tilesetName = ''
   /**
@@ -142,6 +147,9 @@ export class SceneEditorView extends ResponsiveEditorView {
           // listens because it tracks the project + scene paths
           // needed by `MapFormat.serialize` + `writeTextFile`.
           'persist-requested': { param_types: [] },
+          // A placement was removed via the Props tab — the host
+          // refreshes the inspector's placement list.
+          'object-removed': { param_types: [] },
         },
       },
       SceneEditorView,
@@ -262,6 +270,13 @@ export class SceneEditorView extends ResponsiveEditorView {
    */
   highlightPlacement(placementId: string | null): void {
     this._inspector.objectsTab.selectObject(placementId)
+    this._syncSelectedObjectProps(placementId)
+  }
+
+  /** Push the selected placement into the Props tab's "Selected object" group (`null` hides it). */
+  private _syncSelectedObjectProps(placementId: string | null): void {
+    const info = placementId ? this._placementInfo.get(placementId) : null
+    this._inspector.propsTab.setSelectedObject(info && placementId ? { placementId, ...info } : null)
   }
 
   /**
@@ -407,6 +422,18 @@ export class SceneEditorView extends ResponsiveEditorView {
       }
     })
     this._inspector.objectsTab.setObjects(placements)
+    this._placementInfo = new Map(
+      resolvedDefs.map(({ placement, def }) => [
+        placement.id,
+        {
+          name: def?.name ?? placement.id,
+          defId: placement.defId ?? null,
+          tileX: placement.tileX,
+          tileY: placement.tileY,
+          layerId: placement.layerId,
+        },
+      ]),
+    )
     // Feed the Tiles tab's Objects grid every brush candidate WITH a
     // sprite thumbnail (its `visual` component resolved against the
     // loaded sheets) or its marker colour as the fallback swatch, so
@@ -768,6 +795,7 @@ export class SceneEditorView extends ResponsiveEditorView {
     const objects = this._inspector.objectsTab
     objects.connect('object-selected', (_o: typeof objects, placementId: string) => {
       this._engine?.setSelectedPlacements([placementId])
+      this._syncSelectedObjectProps(placementId)
       // Smoothly pan the canvas to the picked object. Fire-and-forget —
       // we don't care about the promise here, the engine resolves it
       // when the camera move ends (or rejects on an interrupted move,
@@ -775,6 +803,21 @@ export class SceneEditorView extends ResponsiveEditorView {
       // finished — also fine, the new pan supersedes).
       void this._engine?.focusOnPlacement(placementId)
     })
+    // Selected-object actions from the Props tab. Open routes through
+    // the existing `win.open-object` navigation; remove dispatches the
+    // undoable RemoveObjectCommand and asks the host to refresh the
+    // placement list.
+    const props = this._inspector.propsTab
+    props.connect('object-open-requested', (_p: typeof props, defId: string) => {
+      this.activate_action('win.open-object', GLib.Variant.new_string(defId))
+    })
+    props.connect('object-remove-requested', (_p: typeof props, placementId: string) => {
+      if (!this._engine?.excalibur?.removeObject(placementId)) return
+      this._syncSelectedObjectProps(null)
+      this._inspector.objectsTab.selectObject(null)
+      this.emit('object-removed')
+    })
+
     // Object brush picked in the Tiles tab's Objects grid → arm it +
     // switch to the Object tool via the window action (it sets both the
     // engine brush and the tool state) — picking what to place activates

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -10,7 +10,7 @@ import {
   TileMap,
   Vector,
 } from 'excalibur'
-import { type Command, PlaceObjectCommand } from './commands/index.ts'
+import { type Command, PlaceObjectCommand, RemoveObjectCommand } from './commands/index.ts'
 import {
   ActiveLayerComponent,
   ActiveObjectComponent,
@@ -449,6 +449,23 @@ export class Engine {
       defId,
     }
     this.executeCommand(new PlaceObjectCommand({ placement }))
+    return true
+  }
+
+  /**
+   * Remove an object placement by id — the driveable equivalent of a
+   * delete action in the inspector. Goes through
+   * {@link RemoveObjectCommand} so it undoes (restoring the captured
+   * placement) + syncs to peers. Returns `false` if there's no active
+   * map or the id doesn't resolve to a placement.
+   */
+  removeObject(placementId: string): boolean {
+    if (this._assistantPaused) return false
+    const scene = this._activeMapScene()
+    if (!scene) return false
+    const placement = scene.mapResource?.mapData?.objectPlacements?.find((p) => p.id === placementId)
+    if (!placement) return false
+    this.executeCommand(new RemoveObjectCommand({ placement }))
     return true
   }
 

--- a/packages/gjs/src/widgets/editor/props-tab.blp
+++ b/packages/gjs/src/widgets/editor/props-tab.blp
@@ -2,55 +2,96 @@ using Gtk 4.0;
 using Adw 1;
 
 template $PixelRpgPropsTab : Adw.Bin {
-  Adw.PreferencesGroup props_group {
-    margin-top: 12;
-    margin-bottom: 12;
-    margin-start: 12;
-    margin-end: 12;
+  Gtk.Box {
+    orientation: vertical;
 
-    Adw.EntryRow name_row {
-      title: _("Name");
-    }
+    // Settings for the placement currently selected on the canvas
+    // (select tool) or in the Objects tab. Hidden without a selection.
+    Adw.PreferencesGroup object_group {
+      title: _("Selected object");
+      visible: false;
+      margin-top: 12;
+      margin-start: 12;
+      margin-end: 12;
 
-    Adw.ActionRow size_row {
-      title: _("Size");
-      subtitle: bind template.size-text;
-    }
+      Adw.ActionRow object_def_row {
+        title: _("Object");
 
-    Adw.ActionRow tile_size_row {
-      title: _("Tile size");
-      subtitle: bind template.tile-size-text;
-    }
+        [suffix]
+        Gtk.Button object_open_button {
+          icon-name: "document-edit-symbolic";
+          tooltip-text: _("Edit in library");
+          valign: center;
+          styles ["flat"]
+        }
+      }
 
-    Adw.EntryRow music_row {
-      title: _("Music");
-    }
+      Adw.ActionRow object_position_row {
+        title: _("Position");
+      }
 
-    Adw.EntryRow battle_bg_row {
-      title: _("Battle BG");
-    }
+      Adw.ActionRow object_remove_row {
+        title: _("Remove from map");
+        activatable: true;
+        styles ["error"]
 
-    Adw.ActionRow encounters_row {
-      title: _("Encounters");
-      subtitle: bind template.encounters-text;
-      activatable: true;
-
-      [suffix]
-      Gtk.Image {
-        icon-name: "go-next-symbolic";
-        styles ["dim-label"]
+        [suffix]
+        Gtk.Image {
+          icon-name: "user-trash-symbolic";
+        }
       }
     }
 
-    Adw.ActionRow on_enter_row {
-      title: _("On Enter");
-      subtitle: bind template.on-enter-text;
-      activatable: true;
+    Adw.PreferencesGroup props_group {
+      margin-top: 12;
+      margin-bottom: 12;
+      margin-start: 12;
+      margin-end: 12;
 
-      [suffix]
-      Gtk.Image {
-        icon-name: "go-next-symbolic";
-        styles ["dim-label"]
+      Adw.EntryRow name_row {
+        title: _("Name");
+      }
+
+      Adw.ActionRow size_row {
+        title: _("Size");
+        subtitle: bind template.size-text;
+      }
+
+      Adw.ActionRow tile_size_row {
+        title: _("Tile size");
+        subtitle: bind template.tile-size-text;
+      }
+
+      Adw.EntryRow music_row {
+        title: _("Music");
+      }
+
+      Adw.EntryRow battle_bg_row {
+        title: _("Battle BG");
+      }
+
+      Adw.ActionRow encounters_row {
+        title: _("Encounters");
+        subtitle: bind template.encounters-text;
+        activatable: true;
+
+        [suffix]
+        Gtk.Image {
+          icon-name: "go-next-symbolic";
+          styles ["dim-label"]
+        }
+      }
+
+      Adw.ActionRow on_enter_row {
+        title: _("On Enter");
+        subtitle: bind template.on-enter-text;
+        activatable: true;
+
+        [suffix]
+        Gtk.Image {
+          icon-name: "go-next-symbolic";
+          styles ["dim-label"]
+        }
       }
     }
   }

--- a/packages/gjs/src/widgets/editor/props-tab.ts
+++ b/packages/gjs/src/widgets/editor/props-tab.ts
@@ -1,5 +1,6 @@
 import Adw from '@girs/adw-1'
 import GObject from '@girs/gobject-2.0'
+import type Gtk from '@girs/gtk-4.0'
 
 import Template from './props-tab.blp'
 
@@ -19,11 +20,31 @@ export interface ScenePropsDescriptor {
 }
 
 /**
+ * The placement shown in the "Selected object" group, fed into
+ * {@link PropsTab.setSelectedObject}.
+ */
+export interface SelectedObjectDescriptor {
+  /** Placement id (unique within the map). */
+  placementId: string
+  /** Resolved definition display name. */
+  name: string
+  /** Library definition id — `null` for an inline definition. */
+  defId: string | null
+  tileX: number
+  tileY: number
+  layerId: string
+}
+
+/**
  * Inspector's "Props" tab — a vertical list of `Adw.EntryRow` /
- * `Adw.ActionRow`s for the active scene's metadata.
+ * `Adw.ActionRow`s for the active scene's metadata, topped by a
+ * "Selected object" group (visible while a placement is selected via
+ * the select tool or the Objects tab) offering per-placement actions:
+ * edit-in-library + remove-from-map.
  *
  * Writes are emitted as `prop-changed::<key, value>` for the parent
- * inspector to relay into the project model.
+ * inspector to relay into the project model; object actions as
+ * `object-open-requested::<defId>` / `object-remove-requested::<id>`.
  */
 export class PropsTab extends Adw.Bin {
   declare _name_row: Adw.EntryRow
@@ -33,8 +54,14 @@ export class PropsTab extends Adw.Bin {
   declare _battle_bg_row: Adw.EntryRow
   declare _encounters_row: Adw.ActionRow
   declare _on_enter_row: Adw.ActionRow
+  declare _object_group: Adw.PreferencesGroup
+  declare _object_def_row: Adw.ActionRow
+  declare _object_position_row: Adw.ActionRow
+  declare _object_remove_row: Adw.ActionRow
+  declare _object_open_button: Gtk.Button
 
   private _scene: ScenePropsDescriptor = {}
+  private _selectedObject: SelectedObjectDescriptor | null = null
 
   static {
     GObject.registerClass(
@@ -49,6 +76,11 @@ export class PropsTab extends Adw.Bin {
           'battle_bg_row',
           'encounters_row',
           'on_enter_row',
+          'object_group',
+          'object_def_row',
+          'object_position_row',
+          'object_remove_row',
+          'object_open_button',
         ],
         Properties: {
           'size-text': GObject.ParamSpec.string(
@@ -82,6 +114,10 @@ export class PropsTab extends Adw.Bin {
         },
         Signals: {
           'prop-changed': { param_types: [GObject.TYPE_STRING, GObject.TYPE_STRING] },
+          // "Edit in library" on the selected object (defId).
+          'object-open-requested': { param_types: [GObject.TYPE_STRING] },
+          // "Remove from map" on the selected object (placementId).
+          'object-remove-requested': { param_types: [GObject.TYPE_STRING] },
         },
       },
       PropsTab,
@@ -93,6 +129,27 @@ export class PropsTab extends Adw.Bin {
     this._name_row.connect('changed', () => this.emit('prop-changed', 'name', this._name_row.get_text()))
     this._music_row.connect('changed', () => this.emit('prop-changed', 'music', this._music_row.get_text()))
     this._battle_bg_row.connect('changed', () => this.emit('prop-changed', 'battleBg', this._battle_bg_row.get_text()))
+    this._object_open_button.connect('clicked', () => {
+      if (this._selectedObject?.defId) this.emit('object-open-requested', this._selectedObject.defId)
+    })
+    this._object_remove_row.connect('activated', () => {
+      if (this._selectedObject) this.emit('object-remove-requested', this._selectedObject.placementId)
+    })
+  }
+
+  /**
+   * Show (descriptor) or hide (`null`) the "Selected object" group.
+   * Driven by the host from the engine's `PLACEMENT_SELECTED` event +
+   * the Objects-tab row selection.
+   */
+  setSelectedObject(desc: SelectedObjectDescriptor | null): void {
+    this._selectedObject = desc
+    this._object_group.set_visible(!!desc)
+    if (!desc) return
+    this._object_def_row.set_title(desc.name)
+    this._object_def_row.set_subtitle(desc.defId ?? 'inline')
+    this._object_open_button.set_visible(!!desc.defId)
+    this._object_position_row.set_subtitle(`(${desc.tileX}, ${desc.tileY}) · ${desc.layerId}`)
   }
 
   setScene(scene: ScenePropsDescriptor): void {


### PR DESCRIPTION
## What

Part 4 of "objects look + behave like tiles": **the Props tab now carries the selected object's settings**.

Selecting an object (select tool on the canvas, or the Objects-tab list) shows a **"Selected object"** group in Props:

- Resolved definition — name + `defId` (or *inline*)
- Position + layer
- **Edit in library** (routes to `win.open-object`; hidden for inline defs)
- **Remove from map** — undoable (`RemoveObjectCommand`), refreshes the placement list + persists

Also:
- New engine API `Engine.removeObject(placementId)` — the driveable counterpart of `placeObjectAt` (undo restores the captured placement, syncs to peers).
- New `win.select-placement` action (string id, `''` clears) — the driveable equivalent of a select-tool canvas click; closes the MCP-bridge gap that selection wasn't drive-able (used to validate this PR).

## Validation

- Engine tests green (528, GJS + Node); `check`/`build` green across engine/gjs/maker.
- Live over D-Bus: `win.select-placement "p-layer_12-76"` → Props shows "Grass 76 / inline / (39, 37) · layer_decorations / Remove from map" (screenshot-verified). Row-activation (remove click) can't be simulated externally — the handler is a two-line dispatch through the validated engine API.

## Follow-up (noted in TODO)

Per-placement **override editing** (name/components) in Props needs an UpdateObjectCommand with correct undo for the replace case — deliberate future work.

Next: Objects visibility row in the Layers tab.