### PR TITLE
feat(engine+gjs+maker): Objects visibility row in the Layers tab

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -1024,6 +1024,17 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     // focus). The engine mirrors that split as `setShowGrid` +
     // `setDimInactiveLayers` against the same session-singleton
     // component, so each toggle drives just its own flag.
+    // Global objects visibility — the Layers tab's "Objects" row as a
+    // driveable stateful action (MCP bridge / shortcuts).
+    const objectsAction = Gio.SimpleAction.new_stateful('toggle-objects', null, GLib.Variant.new_boolean(true))
+    objectsAction.connect('change-state', (action, value) => {
+      action.set_state(value!)
+      const visible = value!.get_boolean()
+      this._engineCtl.engine?.setObjectsVisible(visible)
+      this._scene_editor_view.setObjectsVisible(visible)
+    })
+    winActions.add_action(objectsAction)
+
     const gridAction = Gio.SimpleAction.new_stateful('toggle-grid', null, GLib.Variant.new_boolean(false))
     gridAction.connect('change-state', (action, value) => {
       action.set_state(value!)

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -213,6 +213,11 @@ export class SceneEditorView extends ResponsiveEditorView {
     this._editor.floatingPlay.playing = playing
   }
 
+  /** Mirror the global objects visibility into the Layers tab's Objects row (no re-emit). */
+  setObjectsVisible(visible: boolean): void {
+    this._inspector.layersTab.setObjectsState(this._placementInfo.size, visible)
+  }
+
   /** Push the live participant roster (AI + peers) to the collaborators bar. */
   setCollaborators(participants: CollaboratorEntry[], followedId: string | null): void {
     this._editor.floatingCollaborators.setParticipants(participants, followedId)
@@ -347,6 +352,10 @@ export class SceneEditorView extends ResponsiveEditorView {
     }))
     this._layers = layers
     this._inspector.layersTab.setLayers(layers)
+    this._inspector.layersTab.setObjectsState(
+      mapData.objectPlacements?.length ?? 0,
+      this._engine?.excalibur?.getEditorViewFlags().objectsVisible ?? true,
+    )
     if (layers.length) {
       this._inspector.layersTab.selectLayer(layers[0].id)
       this._setActiveLayer(layers[0].id)
@@ -785,6 +794,14 @@ export class SceneEditorView extends ResponsiveEditorView {
       const idx = this._layers.findIndex((l) => l.id === layerId)
       if (idx >= 0) this._layers[idx] = { ...this._layers[idx], locked }
       this._persistMapData()
+    })
+    // Global objects visibility (the pinned "Objects" pseudo-row).
+    // Pure view state like the grid/dim toggles — not persisted.
+    layers.connect('objects-visibility-toggled', (_l: LayersTab, visible: boolean) => {
+      this.activate_action('win.toggle-objects', null)
+      // The stateful action flips engine + row state; activating with no
+      // param toggles, which matches the row's already-flipped state via
+      // setObjectsVisible's no-re-emit sync.
     })
 
     // Object placements: forward inspector selection into the engine's

--- a/packages/engine/src/components/editor-view-mode.component.ts
+++ b/packages/engine/src/components/editor-view-mode.component.ts
@@ -8,6 +8,9 @@ import { Component } from 'excalibur'
  * - `dimInactiveLayers` — non-active-layer sprites + placements
  *   fade to {@link GRID_MODE_DIM_OPACITY} so the active layer's
  *   content is the dominant signal.
+ * - `objectsVisible` — global show/hide for object placements,
+ *   the Layers tab's "Objects" row toggle (combined with each
+ *   placement's per-layer visibility).
  *
  * Earlier shape (`mode: 'normal' | 'grid'`) coupled the two — the
  * user could only get the dimming alongside the grid lines, or
@@ -27,6 +30,7 @@ export class EditorViewModeComponent extends Component {
   constructor(
     public showGrid: boolean,
     public dimInactiveLayers: boolean,
+    public objectsVisible: boolean = true,
   ) {
     super()
   }
@@ -36,4 +40,5 @@ export class EditorViewModeComponent extends Component {
 export interface EditorViewFlags {
   showGrid: boolean
   dimInactiveLayers: boolean
+  objectsVisible: boolean
 }

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -30,7 +30,7 @@ import { entityToCharacter } from './entity/convert.ts'
 import { GameProjectResource } from './resource/GameProjectResource.ts'
 import { MapScene } from './scenes/map.scene.ts'
 import { executeCommandOnScene } from './services/command-dispatch.ts'
-import { applyEditorViewMode } from './services/editor-view.ts'
+import { applyEditorViewMode, areObjectsVisible } from './services/editor-view.ts'
 import { refreshAllTileGraphics } from './services/tile-graphics.manager.ts'
 import { buildTilePaintCommand, findTileMapForLayer } from './services/tile-paint.service.ts'
 import {
@@ -803,7 +803,9 @@ export class Engine {
       // `TileTransformComponent`, so just match by layer.
       const transform = entity.get(TileTransformComponent)
       if (transform?.layerId === layerId && entity instanceof Actor) {
-        entity.graphics.visible = visible
+        // Combine with the global objects toggle (Layers tab "Objects"
+        // row) — a placement renders only when BOTH are on.
+        entity.graphics.visible = visible && areObjectsVisible(scene)
       }
     }
     return true
@@ -894,14 +896,26 @@ export class Engine {
     this._updateViewFlags({ dimInactiveLayers })
   }
 
+  /**
+   * Globally show / hide object placements — the Layers tab's
+   * "Objects" row toggle. Combined with each placement's per-layer
+   * visibility ({@link setLayerVisible}): a placement renders only when
+   * its layer is visible AND objects are globally visible. Pure view
+   * state (like {@link setShowGrid}) — never persisted to map data.
+   */
+  setObjectsVisible(objectsVisible: boolean): void {
+    this._updateViewFlags({ objectsVisible })
+  }
+
   /** Read both flags from the active scene (defaults to `{ false, false }`). */
   getEditorViewFlags(): EditorViewFlags {
     const scene = this._activeMapScene()
-    if (!scene) return { showGrid: false, dimInactiveLayers: false }
+    if (!scene) return { showGrid: false, dimInactiveLayers: false, objectsVisible: true }
     const current = SessionState.get(scene, EditorViewModeComponent)
     return {
       showGrid: current?.showGrid ?? false,
       dimInactiveLayers: current?.dimInactiveLayers ?? false,
+      objectsVisible: current?.objectsVisible ?? true,
     }
   }
 
@@ -917,9 +931,16 @@ export class Engine {
     const next: EditorViewFlags = {
       showGrid: partial.showGrid ?? current?.showGrid ?? false,
       dimInactiveLayers: partial.dimInactiveLayers ?? current?.dimInactiveLayers ?? false,
+      objectsVisible: partial.objectsVisible ?? current?.objectsVisible ?? true,
     }
-    if (current && current.showGrid === next.showGrid && current.dimInactiveLayers === next.dimInactiveLayers) return
-    SessionState.set(scene, new EditorViewModeComponent(next.showGrid, next.dimInactiveLayers))
+    if (
+      current &&
+      current.showGrid === next.showGrid &&
+      current.dimInactiveLayers === next.dimInactiveLayers &&
+      current.objectsVisible === next.objectsVisible
+    )
+      return
+    SessionState.set(scene, new EditorViewModeComponent(next.showGrid, next.dimInactiveLayers, next.objectsVisible))
     this._configureExcaliburDebugForShowGrid(next.showGrid)
     applyEditorViewMode(scene)
   }
@@ -985,13 +1006,14 @@ export class Engine {
       inner = null
       const scene = this._activeMapScene()
       if (!scene) {
-        cb({ showGrid: false, dimInactiveLayers: false })
+        cb({ showGrid: false, dimInactiveLayers: false, objectsVisible: true })
         return
       }
       inner = SessionState.subscribe(scene, EditorViewModeComponent, (component) => {
         cb({
           showGrid: component?.showGrid ?? false,
           dimInactiveLayers: component?.dimInactiveLayers ?? false,
+          objectsVisible: component?.objectsVisible ?? true,
         })
       })
     }

--- a/packages/engine/src/scenes/map.scene.ts
+++ b/packages/engine/src/scenes/map.scene.ts
@@ -1,6 +1,7 @@
-import { type EventEmitter, Logger, Scene } from 'excalibur'
+import { Actor, type EventEmitter, Logger, Scene } from 'excalibur'
 import { EditorModeComponent, PlacementIdComponent } from '../components/index.ts'
 import { buildPlacementEntity, resolvePlacementDefinition } from '../entity/spawn-placement.ts'
+import { areObjectsVisible } from '../services/editor-view.ts'
 import type { MapResource } from '../resource/MapResource.ts'
 import type { SpriteSetResource } from '../resource/SpriteSetResource.ts'
 import {
@@ -92,7 +93,10 @@ export class MapScene extends Scene {
     const def = resolvePlacementDefinition(placement, this.entityLibrary)
     if (!def) return
     const layersById = new Map(mapData.layers.map((l) => [l.id, l]))
-    this.add(buildPlacementEntity(placement, def, this.mapResource, layersById))
+    const entity = buildPlacementEntity(placement, def, this.mapResource, layersById)
+    // Respect the global objects toggle for live spawns (place / undo).
+    if (entity instanceof Actor && !areObjectsVisible(this)) entity.graphics.visible = false
+    this.add(entity)
   }
 
   /** Despawn the live entity for a placement id (used by `RemoveObjectCommand`). */

--- a/packages/engine/src/services/editor-view.ts
+++ b/packages/engine/src/services/editor-view.ts
@@ -1,7 +1,8 @@
-import { Actor, TileMap } from 'excalibur'
+import { Actor, type Scene, TileMap } from 'excalibur'
 import { ActiveLayerComponent, EditorViewModeComponent, TileTransformComponent } from '../components/index.ts'
 import type { MapScene } from '../scenes/map.scene.ts'
 import { SessionState } from '../utils/session-state.ts'
+import { isLayerVisible } from './layer-visibility.ts'
 import { refreshAllTileGraphics } from './tile-graphics.manager.ts'
 
 /**
@@ -58,11 +59,19 @@ export function applyEditorViewMode(scene: MapScene): void {
 
   // Pass 2: placement actors. `GraphicsComponent.opacity` is a
   // simple scalar multiplied into every draw, so flipping it back
-  // and forth between toggles is cheap.
+  // and forth between toggles is cheap. Visibility combines the
+  // global objects toggle with the placement's per-layer flag.
+  const objectsVisible = flags?.objectsVisible ?? true
   for (const entity of scene.world.entityManager.entities) {
     if (!(entity instanceof Actor)) continue
     const transform = entity.get(TileTransformComponent)
     if (!transform) continue
     entity.graphics.opacity = opacityFor(transform.layerId)
+    entity.graphics.visible = objectsVisible && isLayerVisible(mapResource, transform.layerId)
   }
+}
+
+/** Whether object placements are globally visible on this scene (default true). */
+export function areObjectsVisible(scene: Scene): boolean {
+  return SessionState.get(scene, EditorViewModeComponent)?.objectsVisible ?? true
 }

--- a/packages/engine/src/systems/object-spawn.system.ts
+++ b/packages/engine/src/systems/object-spawn.system.ts
@@ -1,5 +1,6 @@
-import { type Scene, System, SystemType, type World } from 'excalibur'
+import { Actor, type Scene, System, SystemType, type World } from 'excalibur'
 import { buildPlacementEntity, resolvePlacementDefinition } from '../entity/spawn-placement.ts'
+import { areObjectsVisible } from '../services/editor-view.ts'
 import type { MapResource } from '../resource/MapResource.ts'
 import type { EntityDefinition } from '../types/data/index.ts'
 
@@ -40,10 +41,14 @@ export class ObjectSpawnSystem extends System {
     // Cache layers by id once so per-placement layer lookup is O(1).
     const layersById = new Map(mapData.layers.map((l) => [l.id, l]))
 
+    const objectsVisible = areObjectsVisible(scene)
     for (const placement of mapData.objectPlacements) {
       const def = resolvePlacementDefinition(placement, this.entityLibrary)
       if (!def) continue
-      scene.add(buildPlacementEntity(placement, def, this.mapResource, layersById))
+      const entity = buildPlacementEntity(placement, def, this.mapResource, layersById)
+      // Respect the global objects toggle (Layers tab "Objects" row).
+      if (entity instanceof Actor && !objectsVisible) entity.graphics.visible = false
+      scene.add(entity)
     }
   }
 }

--- a/packages/gjs/src/widgets/editor/layers-tab.ts
+++ b/packages/gjs/src/widgets/editor/layers-tab.ts
@@ -22,16 +22,21 @@ export interface LayerDescriptor {
  * Inspector's "Layers" tab.
  *
  * Renders a `boxed-list` of {@link LayerRow} widgets, footer "New layer"
- * button. Emits:
+ * button, plus a pinned **Objects** row — a layer-like global toggle for
+ * object placements on the map (eye only, no lock, not selectable as
+ * the active layer). Emits:
  * - `layer-selected::<id>` when a row is activated.
  * - `layer-visibility-toggled::<id, visible>` when a row's eye toggle flips.
  * - `layer-lock-toggled::<id, locked>` for the lock toggle.
+ * - `objects-visibility-toggled::<visible>` for the Objects row's eye.
  */
 export class LayersTab extends Adw.Bin {
   declare _list: Gtk.ListBox
 
   private _layers: Map<string, { row: Gtk.ListBoxRow; widget: LayerRow }> = new Map()
   private _activeId: string | null = null
+  private _objectsRow: { row: Gtk.ListBoxRow; widget: LayerRow } | null = null
+  private _objectsVisible = true
 
   static {
     GObject.registerClass(
@@ -47,6 +52,8 @@ export class LayersTab extends Adw.Bin {
           'layer-lock-toggled': {
             param_types: [GObject.TYPE_STRING, GObject.TYPE_BOOLEAN],
           },
+          // The Objects pseudo-row's eye flipped (global placement visibility).
+          'objects-visibility-toggled': { param_types: [GObject.TYPE_BOOLEAN] },
         },
       },
       LayersTab,
@@ -101,6 +108,44 @@ export class LayersTab extends Adw.Bin {
       this._list.append(boxRow)
       this._layers.set(layer.id, { row: boxRow, widget: row })
     }
+    this._appendObjectsRow()
+  }
+
+  /**
+   * Update the Objects pseudo-row's placement count + eye state without
+   * re-emitting `objects-visibility-toggled`.
+   */
+  setObjectsState(count: number, visible: boolean): void {
+    this._objectsVisible = visible
+    if (!this._objectsRow) return
+    this._objectsRow.widget.tileCount = count
+    if (this._objectsRow.widget.visible !== visible) this._objectsRow.widget.visible = visible
+  }
+
+  /**
+   * Pinned "Objects" row at the end of the layer list: a layer-LIKE
+   * global toggle for object placements. Eye only (placements lock via
+   * their layer), and not selectable as the active layer. Rebuilt by
+   * every `setLayers` so it always sits below the real layers.
+   */
+  private _appendObjectsRow(): void {
+    const widget = new LayerRow({
+      layerName: 'Objects',
+      tileCount: 0,
+      visible: this._objectsVisible,
+      locked: false,
+      active: false,
+    })
+    widget._lock_button.set_visible(false)
+    widget.connect('notify::visible', () => {
+      if (this._objectsVisible === widget.visible) return
+      this._objectsVisible = widget.visible
+      this.emit('objects-visibility-toggled', widget.visible)
+    })
+    const boxRow = new Gtk.ListBoxRow({ selectable: false })
+    boxRow.set_child(widget)
+    this._list.append(boxRow)
+    this._objectsRow = { row: boxRow, widget }
   }
 
   selectLayer(id: string): void {

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -198,6 +198,11 @@ export class Engine extends Adw.Bin {
     return this._excalibur?.setLayerVisible(layerId, visible) ?? false
   }
 
+  /** Forward to `Engine.setObjectsVisible` — global show/hide for object placements. */
+  public setObjectsVisible(visible: boolean): void {
+    this._excalibur?.setObjectsVisible(visible)
+  }
+
   /** Forward to `Engine.setShowGrid` — toggles Excalibur's debug grid lines. */
   public setShowGrid(showGrid: boolean): void {
     this._excalibur?.setShowGrid(showGrid)
@@ -210,7 +215,7 @@ export class Engine extends Adw.Bin {
 
   /** Forward to `Engine.getEditorViewFlags`. */
   public getEditorViewFlags(): EditorViewFlags {
-    return this._excalibur?.getEditorViewFlags() ?? { showGrid: false, dimInactiveLayers: false }
+    return this._excalibur?.getEditorViewFlags() ?? { showGrid: false, dimInactiveLayers: false, objectsVisible: true }
   }
 
   /** Forward to `Engine.setRuntimeMode` — toggles editor ↔ playtest. */


### PR DESCRIPTION
## What

Part 5 (final) of "objects look + behave like tiles": the **Layers tab gets a pinned "Objects" row** — show/hide for placed objects, comparable to layer visibility.

- Eye toggle + placement-count badge; **no lock** (placements lock via their layer); not selectable as the active layer.
- Hiding it hides **every** placed object (framed cells); painted tiles stay. Per-layer visibility still applies — a placement renders only when its layer is visible AND objects are globally visible.
- Pure **view state** (like grid/dim) — never persisted to map data.
- New stateful **`win.toggle-objects`** action so the MCP bridge / shortcuts can drive it; UI row + action state stay in sync in both directions.

## Implementation

`EditorViewModeComponent` grows `objectsVisible` (default true); `Engine.setObjectsVisible()` routes through the shared `_updateViewFlags` + `applyEditorViewMode` (placement pass recomputes `graphics.visible`); `setLayerVisible` + live spawn paths combine with the flag via the new `areObjectsVisible(scene)` helper.

## Validation (live over D-Bus, screenshot diffs)

- Toggle **off** → all framed placements vanish from the canvas (20k-pixel diff across the map), tiles untouched.
- Toggle **on** → restored (residual diff = water animation frames only).
- Layers tab renders the Objects row with count badge **300** for kokiri-forest.
- Engine tests green (**528**, GJS + Node); `check`/`build` green across engine/gjs/maker.