### PR TITLE
fix(gjs+maker): object-UI polish — sprite rendering, select sync, OSD layout

### DIFF
--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -415,7 +415,10 @@ export class SceneEditorView extends ResponsiveEditorView {
       if (vis) {
         const sheet = gdkSheets.get(vis.spriteSetId)
         const sprite = sheet?.sprites[vis.spriteId]
-        paintable = sprite?.createPaintable() ?? null
+        // Aspect-preserving — these render in CONTAIN-fit swatches; the
+        // default stretching paintable distorts there (squashed in the
+        // grid cells, sliver-thin in the placement rows).
+        paintable = sprite?.createPaintable({ keepAspectRatio: true }) ?? null
       }
       return {
         id: placement.id,
@@ -452,7 +455,9 @@ export class SceneEditorView extends ResponsiveEditorView {
     const brushOptions = brushDefs.map((def) => {
       let paintable = null
       const vis = visualOf(def)
-      if (vis) paintable = gdkSheets.get(vis.spriteSetId)?.sprites[vis.spriteId]?.createPaintable() ?? null
+      if (vis)
+        paintable =
+          gdkSheets.get(vis.spriteSetId)?.sprites[vis.spriteId]?.createPaintable({ keepAspectRatio: true }) ?? null
       return { id: def.id, name: def.name, paintable, color: paintable ? undefined : markerColorFor(def.components) }
     })
     this._objectBrushes = brushOptions

--- a/packages/gjs/src/sprite/objects/GdkSpritePaintable.ts
+++ b/packages/gjs/src/sprite/objects/GdkSpritePaintable.ts
@@ -49,6 +49,10 @@ export class GdkSpritePaintable extends GObject.Object implements Gdk.Paintable.
   declare get_flags: Gdk.Paintable['get_flags']
   declare vfunc_get_flags: Gdk.Paintable['vfunc_get_flags']
   declare get_intrinsic_aspect_ratio: Gdk.Paintable['get_intrinsic_aspect_ratio']
+  // Type-only — deliberately NOT implemented at runtime (see the note
+  // above `vfunc_snapshot`): GJS mis-marshals the double return, so the
+  // GDK default (intrinsic width / height) supplies the behaviour.
+  declare vfunc_get_intrinsic_aspect_ratio: Gdk.Paintable['vfunc_get_intrinsic_aspect_ratio']
   declare get_intrinsic_height: Gdk.Paintable['get_intrinsic_height']
   declare get_intrinsic_width: Gdk.Paintable['get_intrinsic_width']
   declare snapshot: Gdk.Paintable['snapshot']
@@ -95,9 +99,15 @@ export class GdkSpritePaintable extends GObject.Object implements Gdk.Paintable.
     return this._height
   }
 
-  vfunc_get_intrinsic_aspect_ratio(): number {
-    return this._width / this._height || 1
-  }
+  // Deliberately NOT overriding `vfunc_get_intrinsic_aspect_ratio`:
+  // GJS's interface-vfunc bridge mis-marshals the double return — the
+  // JS implementation returned 1, but C callers saw ~5e-324 (an
+  // uninitialised double). `Gtk.Picture`'s `contain`/`scale-down`
+  // content-fit math multiplies by that ratio, collapsing the sprite
+  // to a sub-pixel sliver. Leaving the slot empty makes GDK's default
+  // implementation compute the ratio from the two (working) intrinsic
+  // size vfuncs above. Same GJS limitation family as
+  // `compute_concrete_size` below.
 
   // `vfunc_compute_concrete_size` would be the cleanest place to
   // enforce the sprite's intrinsic aspect ratio — that's the GTK-

--- a/packages/gjs/src/widgets/editor/floating-collaborators.blp
+++ b/packages/gjs/src/widgets/editor/floating-collaborators.blp
@@ -2,16 +2,12 @@ using Gtk 4.0;
 using Adw 1;
 
 template $PixelRpgFloatingCollaborators : Adw.Bin {
-  // Bottom-left OSD pill — stacked above the FloatingZoom pill (also
-  // bottom-left). Lists the live session participants (the AI assistant +
-  // any networked human peers); clicking a chip follows that participant
-  // with the camera. Hidden until there's at least one participant.
-  // Without explicit halign/valign an empty Adw.Bin fills the overlay and
-  // eats pointer events for the layers underneath.
+  // Bottom-left OSD pill — lives in the scene editor's bottom-left OSD
+  // stack, directly above the FloatingZoom pill. Lists the live session
+  // participants (the AI assistant + any networked human peers); clicking
+  // a chip follows that participant with the camera. Hidden until there's
+  // at least one participant (a hidden child takes no space in the stack).
   halign: start;
-  valign: end;
-  margin-start: 12;
-  margin-bottom: 60;
   visible: false;
 
   child: Gtk.Box {

--- a/packages/gjs/src/widgets/editor/floating-zoom.blp
+++ b/packages/gjs/src/widgets/editor/floating-zoom.blp
@@ -2,10 +2,8 @@ using Gtk 4.0;
 using Adw 1;
 
 template $PixelRpgFloatingZoom : Adw.Bin {
+  // Positioned by the scene editor's bottom-left OSD stack.
   halign: start;
-  valign: end;
-  margin-start: 12;
-  margin-bottom: 12;
 
   // WindowHandle wrap — pill padding + the cursor label area pick
   // up window-drag gestures.
@@ -27,10 +25,18 @@ template $PixelRpgFloatingZoom : Adw.Bin {
       tooltip-text: _("Reset zoom");
       styles ["flat"]
 
-      child: Gtk.Label zoom_label {
-        label: bind template.zoom-label;
+      // Inscription, NOT Label — same flicker fix as cursor_label
+      // below: Label re-measures when the text changes (e.g. wheel
+      // zoom "98%" -> "220%"), queue_resize bubbles up and the whole
+      // OSD pill flickers. Inscription's measure is fixed at
+      // nat-chars regardless of content.
+      child: Gtk.Inscription zoom_label {
+        text: bind template.zoom-label;
         styles ["numeric"]
-        width-chars: 5;
+        min-chars: 5;
+        nat-chars: 5;
+        xalign: 0.5;
+        valign: center;
       };
     }
 

--- a/packages/gjs/src/widgets/editor/objects-tab.ts
+++ b/packages/gjs/src/widgets/editor/objects-tab.ts
@@ -1,5 +1,6 @@
 import Adw from '@girs/adw-1'
 import type Gdk from '@girs/gdk-4.0'
+import GLib from '@girs/glib-2.0'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
 
@@ -59,6 +60,8 @@ export class ObjectsTab extends Adw.Bin {
   declare _new_object_button: Gtk.Button
 
   private _activeId: string | null = null
+  /** Guards {@link selectObject} from re-emitting `object-selected`. */
+  private _silentSelect = false
 
   static {
     GObject.registerClass(
@@ -81,7 +84,7 @@ export class ObjectsTab extends Adw.Bin {
       const id = (row as Gtk.ListBoxRow & { objectId?: string }).objectId
       if (!id || id === this._activeId) return
       this._activeId = id
-      this.emit('object-selected', id)
+      if (!this._silentSelect) this.emit('object-selected', id)
     })
   }
 
@@ -135,24 +138,62 @@ export class ObjectsTab extends Adw.Bin {
     }
     const swatch = createSwatchWidget(placement, 28, 28, 'contain')
     swatch.add_css_class('object-swatch')
+    // Keep the swatch square — without this the prefix stretches to the
+    // full ActionRow height (visible on the solid-colour fallbacks).
+    swatch.set_valign(Gtk.Align.CENTER)
     return swatch
   }
 
-  /** Programmatically set the active object. No-op if id not present. */
+  /**
+   * Programmatically set the active object (canvas select-tool sync).
+   * Does NOT re-emit `object-selected` — the engine-side selection is
+   * already in place, so re-emitting would bounce a `focusOnPlacement`
+   * camera pan back at every canvas click. Scrolls the row into view so
+   * the selection is visible in long placement lists. No-op if the id
+   * isn't present.
+   */
   selectObject(id: string | null): void {
     if (id === this._activeId) return
-    let row = this._list.get_first_child()
-    while (row) {
-      const objId = (row as Gtk.ListBoxRow & { objectId?: string }).objectId
-      if (objId === id) {
-        this._list.select_row(row as Gtk.ListBoxRow)
-        this._activeId = id
-        return
+    this._silentSelect = true
+    try {
+      let row = this._list.get_first_child()
+      while (row) {
+        const objId = (row as Gtk.ListBoxRow & { objectId?: string }).objectId
+        if (objId === id) {
+          this._list.select_row(row as Gtk.ListBoxRow)
+          this._activeId = id
+          this._scrollRowIntoView(row as Gtk.ListBoxRow)
+          return
+        }
+        row = row.get_next_sibling()
       }
-      row = row.get_next_sibling()
+      this._list.unselect_all()
+      this._activeId = null
+    } finally {
+      this._silentSelect = false
     }
-    this._list.unselect_all()
-    this._activeId = null
+  }
+
+  /**
+   * Scroll an off-screen row into the inspector's viewport (centred).
+   * The list lives inside the RightInspector's ScrolledWindow (implicit
+   * `Gtk.Viewport`); we position the vadjustment manually from the
+   * row's bounds — `Gtk.Viewport.scroll_to` proved unreliable across
+   * the ViewStack nesting — and defer to an idle so the row's
+   * allocation is valid even when the tab was just switched in.
+   */
+  private _scrollRowIntoView(row: Gtk.ListBoxRow): void {
+    GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+      const viewport = row.get_ancestor(Gtk.Viewport.$gtype) as Gtk.Viewport | null
+      const content = viewport?.get_child()
+      if (!viewport || !content) return GLib.SOURCE_REMOVE
+      const [ok, bounds] = row.compute_bounds(content)
+      if (!ok) return GLib.SOURCE_REMOVE
+      const adj = viewport.vadjustment
+      const target = bounds.get_y() - (adj.get_page_size() - bounds.get_height()) / 2
+      adj.set_value(Math.max(adj.get_lower(), Math.min(target, adj.get_upper() - adj.get_page_size())))
+      return GLib.SOURCE_REMOVE
+    })
   }
 }
 

--- a/packages/gjs/src/widgets/editor/scene-editor.blp
+++ b/packages/gjs/src/widgets/editor/scene-editor.blp
@@ -10,14 +10,25 @@ template $PixelRpgSceneEditor : Adw.Bin {
     [overlay]
     $PixelRpgFloatingTopBar top_bar {}
 
+    // Bottom-left OSD stack — collaborators pill above the zoom pill.
+    // One Box instead of two absolutely-margined overlays, so the pills
+    // can never collide regardless of their heights.
     [overlay]
-    $PixelRpgFloatingZoom zoom_osd {}
+    Gtk.Box bottom_left_osds {
+      orientation: vertical;
+      spacing: 8;
+      halign: start;
+      valign: end;
+      margin-start: 12;
+      margin-bottom: 12;
+
+      $PixelRpgFloatingCollaborators floating_collaborators {}
+
+      $PixelRpgFloatingZoom zoom_osd {}
+    }
 
     [overlay]
     $PixelRpgFloatingPlay floating_play {}
-
-    [overlay]
-    $PixelRpgFloatingCollaborators floating_collaborators {}
 
     child: Adw.Bin backdrop {
       // Diagonal-stripe scratchpad — visible wherever the engine canvas

--- a/packages/gjs/src/widgets/engine/engine.ts
+++ b/packages/gjs/src/widgets/engine/engine.ts
@@ -457,6 +457,9 @@ export class Engine extends Adw.Bin {
       fwd(EngineEvent.TILE_HOVERED),
       fwd(EngineEvent.TILE_PLACED),
       fwd(EngineEvent.TILE_PICKED),
+      // Select-tool canvas picks — without this relay the host never
+      // hears about them and the Objects-list / Props sync stays dead.
+      fwd(EngineEvent.PLACEMENT_SELECTED),
     )
   }
 


### PR DESCRIPTION
## Fixes (from live feedback on #179–#184)

1. **Distorted / sliver object sprites — root cause found**: `GdkSpritePaintable.vfunc_get_intrinsic_aspect_ratio` hits a GJS interface-vfunc **marshalling bug** — the JS impl returns `1`, C callers see `~5e-324`. `Gtk.Picture`'s contain/scale-down math multiplies by that ratio → sprites collapse to sub-pixel slivers (Objects rows) or distort (Tiles-tab grid, chip dropdown). Fix: omit the override (type-only `declare`); GDK's default derives the ratio from the two *working* intrinsic-size vfuncs. Object swatches additionally use aspect-preserving paintables now. *(This likely also fixes subtle aspect bugs in other contain-fit sprite consumers app-wide.)*
2. **Select tool → list/Props sync was dead**: the engine widget's `_forwardEvents` never relayed `PLACEMENT_SELECTED` — canvas picks never reached the host (my earlier validation used `win.select-placement`, which bypasses the bridge — exactly the path the bug hid behind). Now forwarded: a canvas pick selects the Objects-list row (**scrolled into view**, manual vadjustment centring) and fills the Props "Selected object" group. `selectObject` is silent now, so canvas picks no longer bounce a camera pan.
3. **AI/collaborators pill overlapped the zoom pill**: both bottom-left overlays now live in one vertical OSD stack — collision-free by construction.
4. **Zoom OSD flicker on wheel zoom**: percent label `Gtk.Label` → `Gtk.Inscription` (fixed measure), the same fix the cursor label already documents.
5. Row swatches valign-centred (colour fallbacks stretched to row height).

## Validation (live over D-Bus, screenshots)

- Shrubs/Grass placement rows render **crisp framed sprites** (before: 1px sliver/dot).
- Chip shows the armed brush sprite **undistorted**.
- `select-placement` → row selected + centred in the 300-row list, Props group filled.
- AI pill stacks cleanly above the zoom pill.
- Debug-traced the ratio bug live: `intrinsic 16 16, ratio 5e-324`.