### PR TITLE
fix(gjs): guard null vadjustment in objects-tab

### DIFF
--- a/packages/gjs/src/widgets/editor/objects-tab.ts
+++ b/packages/gjs/src/widgets/editor/objects-tab.ts
@@ -190,6 +190,7 @@ export class ObjectsTab extends Adw.Bin {
       const [ok, bounds] = row.compute_bounds(content)
       if (!ok) return GLib.SOURCE_REMOVE
       const adj = viewport.vadjustment
+      if (!adj) return GLib.SOURCE_REMOVE
       const target = bounds.get_y() - (adj.get_page_size() - bounds.get_height()) / 2
       adj.set_value(Math.max(adj.get_lower(), Math.min(target, adj.get_upper() - adj.get_page_size())))
       return GLib.SOURCE_REMOVE


### PR DESCRIPTION
Un-breaks main: PR #185 merged with a failing type-check — `Gtk.Viewport.vadjustment` is nullable, `_scrollRowIntoView` dereferenced it unguarded (TS18047 ×5 in `objects-tab.ts`). Adds the missing null-guard.