### PR TITLE
fix(engine): resolve paint commands via layer tier

### DIFF
--- a/packages/engine/src/commands/object-placement.command.spec.ts
+++ b/packages/engine/src/commands/object-placement.command.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Apply/revert behaviour of `PlaceObjectCommand` / `RemoveObjectCommand`
+ * at the data level: `mapData.objectPlacements` is the persisted +
+ * collab-synced source of truth the commands mutate. Live entity
+ * spawn/despawn rides the same code path but resolves through the
+ * entity library — with an empty library the spawn half no-ops, which
+ * keeps these tests free of graphics/runtime scaffolding.
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+import type { Scene } from 'excalibur'
+
+import type { MapResource } from '../resource/MapResource.ts'
+import { MapScene } from '../scenes/map.scene.ts'
+import type { ObjectPlacement } from '../types/data/index.ts'
+import { PlaceObjectCommand, RemoveObjectCommand } from './object-placement.command.ts'
+
+interface PlacementFixture {
+  scene: MapScene
+  placements: () => ObjectPlacement[]
+}
+
+/**
+ * Duck-typed `MapScene` (via `Object.create` so `instanceof MapScene`
+ * holds without the constructor's engine wiring). `spawnPlacement` /
+ * `despawnPlacement` are the real prototype methods: the empty
+ * `entityLibrary` makes spawn resolve to null (no-op) and despawn
+ * iterates the empty world.
+ */
+function makePlacementScene(initial: ObjectPlacement[] = []): PlacementFixture {
+  const mapData = {
+    layers: [{ id: 'l1', name: 'L', visible: true }],
+    objectPlacements: [...initial],
+  }
+  const scene = Object.create(MapScene.prototype) as MapScene
+  Object.assign(scene, {
+    mapResource: { mapData } as unknown as MapResource,
+    entityLibrary: [],
+    world: { entityManager: { entities: [] } },
+  })
+  return { scene, placements: () => scene.mapResource.mapData?.objectPlacements ?? [] }
+}
+
+function makePlacement(id: string, tileX = 1, tileY = 2): ObjectPlacement {
+  return { id, layerId: 'l1', tileX, tileY, defId: 'crate' }
+}
+
+export default async () => {
+  await describe('PlaceObjectCommand — apply/revert', async () => {
+    await it('apply appends the placement to mapData.objectPlacements', async () => {
+      const fixture = makePlacementScene()
+      new PlaceObjectCommand({ placement: makePlacement('p1') }).apply(fixture.scene)
+
+      expect(fixture.placements().map((p) => p.id)).toStrictEqual(['p1'])
+    })
+
+    await it('apply replaces an existing placement with the same id (no duplicate)', async () => {
+      const fixture = makePlacementScene([makePlacement('p1', 0, 0)])
+      new PlaceObjectCommand({ placement: makePlacement('p1', 3, 3) }).apply(fixture.scene)
+
+      expect(fixture.placements().length).toBe(1)
+      expect(fixture.placements()[0].tileX).toBe(3)
+    })
+
+    await it('revert removes the placed object again', async () => {
+      const fixture = makePlacementScene([makePlacement('keep')])
+      const command = new PlaceObjectCommand({ placement: makePlacement('p1') })
+      command.apply(fixture.scene)
+      command.revert(fixture.scene)
+
+      expect(fixture.placements().map((p) => p.id)).toStrictEqual(['keep'])
+    })
+
+    await it('is a no-op on a non-MapScene scene (defensive)', async () => {
+      const command = new PlaceObjectCommand({ placement: makePlacement('p1') })
+      // Plain object scene — apply/revert must not throw.
+      command.apply({} as Scene)
+      command.revert({} as Scene)
+    })
+  })
+
+  await describe('RemoveObjectCommand — apply/revert', async () => {
+    await it('apply removes exactly the targeted placement', async () => {
+      const fixture = makePlacementScene([makePlacement('p1'), makePlacement('p2')])
+      new RemoveObjectCommand({ placement: makePlacement('p1') }).apply(fixture.scene)
+
+      expect(fixture.placements().map((p) => p.id)).toStrictEqual(['p2'])
+    })
+
+    await it('revert restores the captured placement (remove → undo round-trip)', async () => {
+      const fixture = makePlacementScene([makePlacement('p1'), makePlacement('p2')])
+      const command = new RemoveObjectCommand({ placement: makePlacement('p1') })
+      command.apply(fixture.scene)
+      command.revert(fixture.scene)
+
+      expect(
+        fixture
+          .placements()
+          .map((p) => p.id)
+          .sort(),
+      ).toStrictEqual(['p1', 'p2'])
+    })
+  })
+}

--- a/packages/engine/src/commands/paint-tile.command.spec.ts
+++ b/packages/engine/src/commands/paint-tile.command.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * Apply/revert behaviour of `PaintTileCommand` / `EraseTileCommand`
+ * against a three-tier scene (ground / hero / overlay tilemaps).
+ *
+ * Regression focus: the commands' internal `resolveContext` used to
+ * grab the FIRST `TileMap` in the scene — always the ground tier,
+ * because `MapResource.createTileMaps` adds tiers in ground → hero →
+ * overlay order. Every hero/overlay-layer paint therefore mutated the
+ * ground tilemap's shadow state (wrong render z), while the
+ * `previousSprites` snapshot was read from the tier-correct shadow
+ * that never saw the paint — so undoing a second paint ERASED the
+ * first one instead of restoring it (silent data loss, replayed
+ * identically on every collab peer). The commands must resolve the
+ * tilemap by the layer's tier, exactly like the interactive paths
+ * (`TileEditorSystem`, `Engine.paintTileAt`).
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+import { TileMap } from 'excalibur'
+
+import { MapEditorComponent } from '../components/map-editor.component.ts'
+import { TileMapTierComponent } from '../components/tilemap-tier.component.ts'
+import type { MapResource } from '../resource/MapResource.ts'
+import { MapScene } from '../scenes/map.scene.ts'
+import { getSpritesAt } from '../services/map-editor-shadow.service.ts'
+import { findTileMapForLayer, snapshotPreviousSprites } from '../services/tile-paint.service.ts'
+import type { LayerTier } from '../types/data/index.ts'
+import { EraseTileCommand, PaintTileCommand } from './paint-tile.command.ts'
+
+/**
+ * Minimal stand-in for an Excalibur `Sprite`: `rebuildAllTileGraphics`
+ * clones every graphic before attaching, and `Tile.addGraphic` only
+ * pushes onto an array — no real texture needed.
+ */
+function makeFakeSprite(): { clone: () => unknown } {
+  return { clone: () => ({}) }
+}
+
+interface TierFixture {
+  scene: MapScene
+  ground: TileMap
+  hero: TileMap
+  overlay: TileMap
+}
+
+/**
+ * Build a duck-typed `MapScene` (via `Object.create` so `instanceof
+ * MapScene` holds without running the constructor's engine wiring)
+ * holding one real `TileMap` per tier, in the same order
+ * `MapResource.createTileMaps` adds them — ground first, which is
+ * exactly what made the old first-TileMap scan always pick ground.
+ *
+ * One sprite set `terrain` with `firstGid: 1` and local sprites 0+1,
+ * so global tile ids 1 and 2 are paintable.
+ */
+function makeTierScene(): TierFixture {
+  const spriteSet = { sprites: { 0: makeFakeSprite(), 1: makeFakeSprite() }, animations: {} }
+  const mapResource = {
+    mapData: {
+      layers: [
+        { id: 'ground-layer', name: 'Ground', visible: true, tier: 'ground' },
+        { id: 'hero-layer', name: 'Decor', visible: true, tier: 'hero' },
+        { id: 'overlay-layer', name: 'Treetops', visible: true, tier: 'overlay' },
+        { id: 'legacy-layer', name: 'Legacy (no tier)', visible: true },
+      ],
+      spriteSets: [{ id: 'terrain', firstGid: 1 }],
+    },
+    getSpriteSetResource: () => spriteSet,
+    getAllSpriteSetResources: () => new Map([['terrain', spriteSet]]),
+    refreshTileSolidFromEditor: () => {},
+    // biome-ignore lint/suspicious/noExplicitAny: test stub mirrors only the surface the commands exercise
+  } as any as MapResource
+
+  const makeTierTileMap = (tier: LayerTier): TileMap => {
+    const tileMap = new TileMap({ tileWidth: 16, tileHeight: 16, columns: 4, rows: 4 })
+    tileMap.addComponent(new TileMapTierComponent(tier))
+    tileMap.addComponent(new MapEditorComponent())
+    return tileMap
+  }
+
+  const ground = makeTierTileMap('ground')
+  const hero = makeTierTileMap('hero')
+  const overlay = makeTierTileMap('overlay')
+
+  const scene = Object.create(MapScene.prototype) as MapScene
+  Object.assign(scene, {
+    mapResource,
+    world: { entityManager: { entities: [ground, hero, overlay] } },
+  })
+  return { scene, ground, hero, overlay }
+}
+
+function editorOf(tileMap: TileMap): MapEditorComponent {
+  const editor = tileMap.get(MapEditorComponent)
+  if (!editor) throw new Error('fixture tilemap lost its MapEditorComponent')
+  return editor
+}
+
+/** Compact `spriteSetId#spriteId` view of a tile's shadow refs on one layer. */
+function refsAt(tileMap: TileMap, x: number, y: number, layerId: string): string[] {
+  return getSpritesAt(editorOf(tileMap), x, y, layerId).map((ref) => `${ref.spriteSetId}#${ref.spriteId}`)
+}
+
+/**
+ * Paint the way every real caller does: snapshot the previous sprites
+ * from the layer's tier-correct editor, then apply. Returns the
+ * command so tests can `revert` it later.
+ */
+function paint(fixture: TierFixture, layerId: string, x: number, y: number, spriteId: number): PaintTileCommand {
+  const found = findTileMapForLayer(fixture.scene, layerId)
+  if (!found) throw new Error(`fixture cannot resolve layer ${layerId}`)
+  const command = new PaintTileCommand({
+    layerId,
+    tileX: x,
+    tileY: y,
+    spriteId,
+    previousSprites: snapshotPreviousSprites(found.editor, layerId, x, y),
+  })
+  command.apply(fixture.scene)
+  return command
+}
+
+/** Erase counterpart of {@link paint} — same snapshot-then-apply flow. */
+function erase(fixture: TierFixture, layerId: string, x: number, y: number): EraseTileCommand {
+  const found = findTileMapForLayer(fixture.scene, layerId)
+  if (!found) throw new Error(`fixture cannot resolve layer ${layerId}`)
+  const command = new EraseTileCommand({
+    layerId,
+    tileX: x,
+    tileY: y,
+    previousSprites: snapshotPreviousSprites(found.editor, layerId, x, y),
+  })
+  command.apply(fixture.scene)
+  return command
+}
+
+/**
+ * Silence `console.warn` for the body of `fn` — @gjsify/unit has no
+ * `vi.spyOn` equivalent (same shim as sprite-info.resolver.spec).
+ */
+async function muteWarn<T>(fn: () => Promise<T> | T): Promise<T> {
+  const original = console.warn
+  console.warn = () => {}
+  try {
+    return await fn()
+  } finally {
+    console.warn = original
+  }
+}
+
+export default async () => {
+  await describe('PaintTileCommand.apply — tier routing', async () => {
+    await it('writes a hero-layer paint to the hero tilemap, not the first (ground) one', async () => {
+      const fixture = makeTierScene()
+      paint(fixture, 'hero-layer', 1, 1, 1)
+
+      expect(refsAt(fixture.hero, 1, 1, 'hero-layer')).toStrictEqual(['terrain#0'])
+      expect(getSpritesAt(editorOf(fixture.ground), 1, 1).length).toBe(0)
+      expect(getSpritesAt(editorOf(fixture.overlay), 1, 1).length).toBe(0)
+    })
+
+    await it('writes an overlay-layer paint to the overlay tilemap', async () => {
+      const fixture = makeTierScene()
+      paint(fixture, 'overlay-layer', 2, 3, 2)
+
+      expect(refsAt(fixture.overlay, 2, 3, 'overlay-layer')).toStrictEqual(['terrain#1'])
+      expect(getSpritesAt(editorOf(fixture.ground), 2, 3).length).toBe(0)
+      expect(getSpritesAt(editorOf(fixture.hero), 2, 3).length).toBe(0)
+    })
+
+    await it('routes a tier-less layer to the ground tilemap (legacy default)', async () => {
+      const fixture = makeTierScene()
+      paint(fixture, 'legacy-layer', 0, 0, 1)
+
+      expect(refsAt(fixture.ground, 0, 0, 'legacy-layer')).toStrictEqual(['terrain#0'])
+      expect(getSpritesAt(editorOf(fixture.hero), 0, 0).length).toBe(0)
+    })
+
+    await it('warns + no-ops for an unknown layer id instead of falling back to a tilemap', async () => {
+      const fixture = makeTierScene()
+      const command = new PaintTileCommand({
+        layerId: 'deleted-layer',
+        tileX: 1,
+        tileY: 1,
+        spriteId: 1,
+        previousSprites: [],
+      })
+      await muteWarn(() => command.apply(fixture.scene))
+
+      for (const tileMap of [fixture.ground, fixture.hero, fixture.overlay]) {
+        expect(getSpritesAt(editorOf(tileMap), 1, 1).length).toBe(0)
+      }
+    })
+  })
+
+  await describe('PaintTileCommand revert — paint → paint → undo round-trip', async () => {
+    await it('undo of a second hero-layer paint restores the first (regression: it erased it)', async () => {
+      const fixture = makeTierScene()
+      paint(fixture, 'hero-layer', 1, 1, 1)
+      const second = paint(fixture, 'hero-layer', 1, 1, 2)
+      expect(refsAt(fixture.hero, 1, 1, 'hero-layer')).toStrictEqual(['terrain#1'])
+
+      second.revert(fixture.scene)
+
+      // Pre-fix: `previousSprites` was snapshotted from the hero shadow
+      // (which the ground-targeted apply never touched) → empty → the
+      // revert removed everything. The first paint must survive.
+      expect(refsAt(fixture.hero, 1, 1, 'hero-layer')).toStrictEqual(['terrain#0'])
+      expect(getSpritesAt(editorOf(fixture.ground), 1, 1).length).toBe(0)
+    })
+
+    await it('undo of the first paint returns the tile to empty', async () => {
+      const fixture = makeTierScene()
+      const first = paint(fixture, 'hero-layer', 1, 1, 1)
+      const second = paint(fixture, 'hero-layer', 1, 1, 2)
+
+      second.revert(fixture.scene)
+      first.revert(fixture.scene)
+
+      expect(getSpritesAt(editorOf(fixture.hero), 1, 1).length).toBe(0)
+    })
+  })
+
+  await describe('EraseTileCommand — tier routing + revert', async () => {
+    await it('erases only the targeted layer tier, leaving congruent tiles on other tiers', async () => {
+      const fixture = makeTierScene()
+      paint(fixture, 'ground-layer', 1, 1, 1)
+      paint(fixture, 'hero-layer', 1, 1, 2)
+
+      erase(fixture, 'hero-layer', 1, 1)
+
+      expect(getSpritesAt(editorOf(fixture.hero), 1, 1).length).toBe(0)
+      // Pre-fix the erase cleared the ground tilemap instead.
+      expect(refsAt(fixture.ground, 1, 1, 'ground-layer')).toStrictEqual(['terrain#0'])
+    })
+
+    await it('undo of an erase restores the erased sprites on the correct tier', async () => {
+      const fixture = makeTierScene()
+      paint(fixture, 'hero-layer', 1, 1, 1)
+      const eraseCommand = erase(fixture, 'hero-layer', 1, 1)
+      expect(getSpritesAt(editorOf(fixture.hero), 1, 1).length).toBe(0)
+
+      eraseCommand.revert(fixture.scene)
+
+      expect(refsAt(fixture.hero, 1, 1, 'hero-layer')).toStrictEqual(['terrain#0'])
+      expect(getSpritesAt(editorOf(fixture.ground), 1, 1).length).toBe(0)
+    })
+  })
+}

--- a/packages/engine/src/commands/paint-tile.command.ts
+++ b/packages/engine/src/commands/paint-tile.command.ts
@@ -1,9 +1,10 @@
-import { type Scene, TileMap } from 'excalibur'
+import type { Scene } from 'excalibur'
 import { MapEditorComponent } from '../components/map-editor.component.ts'
 import { MapScene } from '../scenes/map.scene.ts'
 import { addSpriteToTileForLayer, removeSpritesFromTileForLayer } from '../services/layer.manager.ts'
 import { setSpritesAt } from '../services/map-editor-shadow.service.ts'
 import { rebuildAllTileGraphics, updateTileMapZIndex } from '../services/tile-graphics.manager.ts'
+import { findTileMapForLayer } from '../services/tile-paint.service.ts'
 import type { Command } from './types.ts'
 
 /**
@@ -46,7 +47,7 @@ export class PaintTileCommand implements Command<PaintTilePayload> {
   }
 
   apply(scene: Scene): void {
-    const ctx = resolveContext(scene)
+    const ctx = resolveContext(scene, this.payload.layerId)
     if (!ctx) return
     const tile = ctx.tileMap.getTile(this.payload.tileX, this.payload.tileY)
     if (!tile) return
@@ -54,7 +55,7 @@ export class PaintTileCommand implements Command<PaintTilePayload> {
   }
 
   revert(scene: Scene): void {
-    const ctx = resolveContext(scene)
+    const ctx = resolveContext(scene, this.payload.layerId)
     if (!ctx) return
     const tile = ctx.tileMap.getTile(this.payload.tileX, this.payload.tileY)
     if (!tile) return
@@ -78,7 +79,7 @@ export class EraseTileCommand implements Command<Omit<PaintTilePayload, 'spriteI
   }
 
   apply(scene: Scene): void {
-    const ctx = resolveContext(scene)
+    const ctx = resolveContext(scene, this.payload.layerId)
     if (!ctx) return
     const tile = ctx.tileMap.getTile(this.payload.tileX, this.payload.tileY)
     if (!tile) return
@@ -86,7 +87,7 @@ export class EraseTileCommand implements Command<Omit<PaintTilePayload, 'spriteI
   }
 
   revert(scene: Scene): void {
-    const ctx = resolveContext(scene)
+    const ctx = resolveContext(scene, this.payload.layerId)
     if (!ctx) return
     const tile = ctx.tileMap.getTile(this.payload.tileX, this.payload.tileY)
     if (!tile) return
@@ -131,17 +132,35 @@ function restorePreviousSprites(
 }
 
 /**
- * Find the `TileMap` + `MapResource` on a `MapScene`. Returns `null`
- * if the scene isn't a `MapScene` or its tilemap isn't realised yet.
+ * Resolve the **tier-correct** `TileMap` + `MapResource` for the
+ * command's target layer. A `MapScene` holds one tilemap per
+ * `LayerTier` (ground / hero / overlay — see
+ * `TileMapTierComponent`), so "the" tilemap is ambiguous: an earlier
+ * version of this helper grabbed the *first* tilemap in the scene,
+ * which is always the ground tier (`MapResource.createTileMaps` adds
+ * tiers in ground → hero → overlay order). Every hero/overlay-layer
+ * paint then mutated the wrong tilemap's shadow state — wrong render
+ * z, and undo (whose `previousSprites` snapshot was read from the
+ * tier-correct shadow that never saw the paint) erased earlier paints
+ * instead of restoring them. Delegating to {@link findTileMapForLayer}
+ * keeps this resolution identical to the interactive paths
+ * (`TileEditorSystem`, `Engine.paintTileAt`).
+ *
+ * Returns `null` when the scene isn't a `MapScene` or isn't realised
+ * yet (silent — commands may legitimately arrive before/after a map
+ * is live). An unknown layer id or a missing tier tilemap is warned
+ * explicitly and skipped: it is non-critical (a remote peer can paint
+ * a layer the local map no longer has), but it must NOT silently fall
+ * back to another tier's tilemap.
  */
-function resolveContext(scene: Scene) {
+function resolveContext(scene: Scene, layerId: string) {
   if (!(scene instanceof MapScene)) return null
   const mapResource = scene.mapResource
   if (!mapResource) return null
-  for (const entity of scene.world.entityManager.entities) {
-    if (entity instanceof TileMap) {
-      return { tileMap: entity, mapResource }
-    }
+  const found = findTileMapForLayer(scene, layerId)
+  if (!found) {
+    console.warn(`[PaintTile] no tier tilemap resolves for layer "${layerId}" — command skipped`)
+    return null
   }
-  return null
+  return { tileMap: found.tileMap, mapResource }
 }

--- a/packages/engine/src/systems/tile-editor.system.spec.ts
+++ b/packages/engine/src/systems/tile-editor.system.spec.ts
@@ -2,16 +2,16 @@
  * Regression tests for the tile-editor system's collab-broadcast
  * contract.
  *
- * The system's hot-path `dispatchCommand` applies a tile paint /
- * erase to the active scene INLINE (skipping `Engine.executeCommand`
- * to avoid the indirection on every click). It must mirror the
- * engine's emit of `EngineEvent.COMMAND_EXECUTED` afterwards so the
- * collab layer's `SessionController` can relay the paint to peers.
+ * The system's `dispatchCommand` routes every paint / erase through
+ * the shared `executeCommandOnScene` helper (apply + undo-stack push
+ * + `EngineEvent.COMMAND_EXECUTED` emit) so the collab layer's
+ * `SessionController` can relay the operation to peers.
  *
- * 2026-06-01 hand-test: a host that hosted a session + painted tiles
- * sent zero `op` frames on the WebRTC data channel — only awareness
- * frames. The joiner saw the initial snapshot but no live edits.
- * Trace: `dispatchCommand` was missing the COMMAND_EXECUTED emit.
+ * 2026-06-01 hand-test: an earlier INLINE copy of that body in this
+ * system dropped the COMMAND_EXECUTED emit — a host that hosted a
+ * session + painted tiles sent zero `op` frames on the WebRTC data
+ * channel (only awareness frames); the joiner saw the initial
+ * snapshot but no live edits. These tests pin the emit contract.
  */
 
 import { describe, expect, it } from '@gjsify/unit'
@@ -44,8 +44,9 @@ function makeFakePaintCommand(): Command {
     label: 'paint',
     payload: { tileMapId: 't', layerId: 'l', col: 1, row: 2, tile: 5 } as unknown,
     // No-op apply/revert — dispatchCommand only needs the call to
-    // not throw; the actual paint side-effect is exercised by the
-    // command's own spec, not by this regression test.
+    // not throw; the actual paint side-effect is exercised by
+    // `commands/paint-tile.command.spec.ts`, not by this
+    // regression test.
     apply: () => {},
     revert: () => {},
   } as unknown as Command

--- a/packages/engine/src/test.mts
+++ b/packages/engine/src/test.mts
@@ -14,6 +14,8 @@ import { run } from '@gjsify/unit'
 // stays green while testing nothing). When you add a `*.spec.ts`, add
 // its import + `run()` entry here. (Tracked in TODO.md as a guard
 // follow-up — a test that asserts every spec file is registered.)
+import objectPlacementCommandSuite from './commands/object-placement.command.spec.js'
+import paintTileCommandSuite from './commands/paint-tile.command.spec.js'
 import registrySuite from './commands/registry.spec.js'
 import entityConvertSuite from './entity/convert.spec.js'
 import entityPlacementGraphicSuite from './entity/placement-graphic.spec.js'
@@ -22,8 +24,8 @@ import entitySpawnPlacementSuite from './entity/spawn-placement.spec.js'
 import entityValidateSuite from './entity/validate.spec.js'
 import objectSystemValidationSuite from './format/object-system-validation.spec.js'
 import layerVisibilitySuite from './services/layer-visibility.spec.js'
-import spriteInfoResolverSuite from './services/sprite-info.resolver.spec.js'
 import spriteValidatorSuite from './services/sprite.validator.spec.js'
+import spriteInfoResolverSuite from './services/sprite-info.resolver.spec.js'
 import awarenessSuite from './sync/awareness.spec.js'
 import collabIntegrationSuite from './sync/collab-integration.spec.js'
 import inMemoryTransportSuite from './sync/in-memory-transport.spec.js'
@@ -40,6 +42,8 @@ import subscriptionRegistrySuite from './utils/subscription-registry.spec.js'
 
 run({
   registrySuite,
+  paintTileCommandSuite,
+  objectPlacementCommandSuite,
   entityRegistrySuite,
   entityValidateSuite,
   entityConvertSuite,


### PR DESCRIPTION
## What was broken

`PaintTileCommand` / `EraseTileCommand` resolved "the" `TileMap` via an internal `resolveContext` that scanned `scene.world.entityManager.entities` and returned the **first** `TileMap` found. `MapResource.createTileMaps` adds the tier tilemaps in `ground → hero → overlay` order, so the commands' own `apply`/`revert` **always wrote the ground tilemap**, regardless of which tier the target layer belongs to.

The tier-aware resolver (`findTileMapForLayer` in `services/tile-paint.service.ts`) already existed, and the interactive snapshot paths (`TileEditorSystem`, `Engine.paintTileAt`) already used it — only the command bodies, i.e. the path that runs on **undo/redo and on every collab peer**, used the first-TileMap scan.

## User-visible impact

- Paints on hero/overlay layers rendered at the wrong z (ground plane) when applied through the command path.
- **Undo data loss:** the `previousSprites` snapshot is captured from the tier-correct shadow — which the ground-targeted apply never touched — so it stayed empty. Undoing a *second* paint on the same tile therefore **erased the first paint** instead of restoring it. Silent, and replayed identically on every collab peer (same command, same wrong resolution).
- Persistence masked the bug at save time because `syncShadowToMapData` folds all tilemaps, which is why it survived unnoticed.

## Fix

`resolveContext(scene, layerId)` now delegates to `findTileMapForLayer` — one tier resolver for interactive and command paths. An unknown layer id / missing tier tilemap is **warned and skipped explicitly** (a remote peer may paint a layer the local map no longer has — non-critical per the repo error rules) instead of silently falling back to another tier's tilemap. The first-TileMap scan is gone.

## What the specs now guard

The command `apply`/`revert` bodies had **zero tests** — `tile-editor.system.spec.ts` stubbed the command with a comment claiming "the command's own spec" exercised the paint side-effect, but no such spec existed. Now:

- `commands/paint-tile.command.spec.ts` (new): against a real 3-tier scene (one `TileMap` per tier, ground first — the exact ordering that triggered the bug):
  - hero/overlay-layer paints write the **correct** tier tilemap's shadow, ground stays untouched (tier-less layers route to ground, the legacy default)
  - the data-loss scenario round-trips: paint → paint → undo restores the **first** paint
  - erase only clears the targeted tier; erase → undo restores on the correct tier
  - unknown layer id = warned no-op, no fallback writes
- `commands/object-placement.command.spec.ts` (new): `PlaceObjectCommand`/`RemoveObjectCommand` apply/revert at the `mapData.objectPlacements` level (append, same-id replace, remove → undo round-trip, non-MapScene no-op).
- Both registered in `packages/engine/src/test.mts` (the hand-maintained runner): 549 → 575 (gjs) / 528 → 554 (node) assertions, all green.
- Refreshed the stale `tile-editor.system.spec.ts` header that still described the obsolete inline-paint dispatch, and pointed the stub comment at the real command spec.

## Validation

- `gjsify workspace @pixelrpg/engine test` — green on gjs (575) and node (554)
- `gjsify workspace @pixelrpg/engine check` — clean (incl. barrel check)
- Biome check/format on the touched files