### PR TITLE
ci: run maker + signalling suites, pin cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,19 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Install @gjsify/cli globally
-        run: npm install -g @gjsify/cli
+      - name: Install @gjsify/cli globally (pinned to the lockfile)
+        # Bootstrap chicken-and-egg: the global CLI is needed for the
+        # initial `gjsify install`, so it can't come from node_modules.
+        # Pin it to the exact version gjsify-lock.json resolves for the
+        # workspace (apps pin `@gjsify/cli: ^0.4.36`), so the bootstrap
+        # CLI and the workspace-local CLI are always the same build and
+        # CI never silently adopts a newer release — a broken latest must
+        # not break CI without a repo change (global 0.4.40 e.g. could
+        # not even build the test bundles). Bumps happen by updating the
+        # lockfile in dedicated commits.
+        run: |
+          version=$(node -p "require('./gjsify-lock.json').packages['node_modules/@gjsify/cli'].version")
+          npm install -g "@gjsify/cli@${version}"
 
       - name: Install dependencies (gjsify install --immutable)
         run: gjsify install --immutable
@@ -99,3 +110,21 @@ jobs:
         # registered. Runs under both gjs + node. Keeps "new feature must
         # stay collab-compatible" enforced, not just documented.
         run: gjsify foreach test -v -p --include @pixelrpg/engine
+
+      - name: Run maker tests (collab transport + session services)
+        # The @pixelrpg/maker-gjs suite (18 suites): SessionService
+        # host/join e2e over REAL LAN signalling (WebSocket on loopback,
+        # exercises @gjsify/ws over Soup), collab-session (+e2e),
+        # lan-discovery/-signalling, relay signalling, pause policy,
+        # engine-state sync, sandbox paths… Headless-safe: no display or
+        # WebGL needed; LAN specs bind 127.0.0.1 only, and the real-Avahi
+        # discovery integration spec skips itself when no avahi-daemon is
+        # available (this runner). Runs under both gjs + node.
+        run: gjsify foreach test -v -p --include @pixelrpg/maker-gjs
+
+      - name: Run signalling-server tests (room manager + relay e2e)
+        # The @pixelrpg/signalling-server suite: RoomManager unit tests
+        # plus the end-to-end relay test, which spawns the GJS bundle
+        # built in the build step above (via the pinned global `gjsify`
+        # on PATH) and drives it with real `ws` clients from Node.
+        run: gjsify foreach test -v -p --include @pixelrpg/signalling-server

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ refs: https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1-latest/css-variables
 
 ## Build / format / lint / test (root-level scripts)
 
-|`gjsify foreach build -v -t` — topological build (root `build`) |`gjsify foreach check -v -t` — type-check + barrel regen across all packages |`gjsify foreach check:barrels -v -t` — drift guard (CI: any stale barrel exits non-zero) |`gjsify foreach test -v -p --include @pixelrpg/engine` — engine unit tests (`@gjsify/unit`; root `test` only includes the engine — run `gjsify workspace @pixelrpg/maker-gjs test` / `… signalling-server test` for the app suites) |`gjsify workspace @pixelrpg/maker-gjs start` — run the editor (root `start`) |`gjsify fix` / `gjsify lint` / `gjsify format --check` — Biome wrappers (read project's `biome.json`)
+|`gjsify foreach build -v -t` — topological build (root `build`) |`gjsify foreach check -v -t` — type-check + barrel regen across all packages |`gjsify foreach check:barrels -v -t` — drift guard (CI: any stale barrel exits non-zero) |`gjsify foreach test -v -p --include @pixelrpg/engine --include @pixelrpg/maker-gjs --include @pixelrpg/signalling-server` — all test suites (`@gjsify/unit`; this is the root `test`; CI runs the same three suites as separate steps — use one `--include` or `gjsify workspace <pkg> test` for a single suite) |`gjsify workspace @pixelrpg/maker-gjs start` — run the editor (root `start`) |`gjsify fix` / `gjsify lint` / `gjsify format --check` — Biome wrappers (read project's `biome.json`)
 
 ## Flatpak (maker-gjs)
 
@@ -104,7 +104,7 @@ App-ID `org.pixelrpg.maker`. Manifest + MetaInfo + .desktop generated from `apps
 
 ## Validation & commits
 
-[Pre-commit] |no automated hook — devs run `gjsify fix && gjsify lint` manually before committing (CI does NOT lint/format-check; it runs type-check, build, the barrel-drift guard and the engine tests — see `.github/workflows/ci.yml`) |`gjsify foreach build -v -t` builds all packages |`gjsify foreach check -v -t` full type check (slow) |`gjsify workspace @pixelrpg/engine test` for engine unit tests |per-pkg: `cd <pkg> && gjsify run {check,build}` |fix all errors+warnings before commit
+[Pre-commit] |no automated hook — devs run `gjsify fix && gjsify lint` manually before committing (CI does NOT lint/format-check — tracked in TODO.md "Biome cleanup + CI lint gate"; it runs type-check, build, the barrel-drift guard and the engine + maker-gjs + signalling-server test suites, with `@gjsify/cli` pinned to the gjsify-lock.json version — see `.github/workflows/ci.yml`) |`gjsify foreach build -v -t` builds all packages |`gjsify foreach check -v -t` full type check (slow) |`gjsify workspace @pixelrpg/engine test` for engine unit tests |per-pkg: `cd <pkg> && gjsify run {check,build}` |fix all errors+warnings before commit
 
 [Commits] |atomic, one logical change |conventional: `<type>[scope]: <description>` (feat|fix|docs|refactor|test|chore) |imperative, subject ≤50 chars, include scope |working state every commit |check `git log --oneline -10` to match project style |commit at milestones for large tasks, not just end
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,7 @@ Conventions:
 ## Testing
 
 - **Spec-registration guard** — `gjsify test` runs only the suites hand-imported into a package's `src/test.mts`; a `*.spec.ts` that isn't added there silently never runs (CI stays green testing nothing — this bit `project-operations.spec.ts`, dormant from its creation until 2026-06-07). The same hand-maintained pattern exists in **three** packages: `packages/engine`, `apps/maker-gjs`, `apps/signalling-server`. Add a shared meta-test that globs `src/**/*.spec.ts` and asserts each is imported by that package's `test.mts` (the analog of `registry.spec.ts` for commands), applied in all three. *owner: engine + maker, why: silent-skip trap*
+- **Biome cleanup + CI lint gate** — AGENTS.md prescribes `gjsify fix && gjsify lint` pre-commit, but CI has no lint/format step and ~100 Biome violations have accumulated (≈92 errors / 37 warnings via `./node_modules/.bin/biome check .` as of 2026-06-11). Also, `gjsify lint` / `gjsify format --check` on recent CLIs (≥0.4.40) wrap oxlint/oxfmt and fail with "oxlint not found" rather than wrapping Biome as documented. Plan: burn down the violations in a dedicated cleanup PR, decide the lint toolchain (Biome direct, e.g. `npx biome ci .`, vs the gjsify-oxc migration), then add the CI gate — the gate would be red today, which is why the 2026-06-11 CI-hardening PR (maker + signalling suites, CLI pin) deliberately did not add it. *owner: tooling, why: gate is red until the violations are fixed*
 
 ## Engine / runtime
 

--- a/apps/maker-gjs/src/services/session-service-e2e.spec.ts
+++ b/apps/maker-gjs/src/services/session-service-e2e.spec.ts
@@ -116,10 +116,18 @@ function makeHostEngineStub(): Engine {
       data: FAKE_SNAPSHOT.project,
       getMapResource(id: string) {
         const entry = FAKE_SNAPSHOT.maps.find((m) => m.path.endsWith(`${id}.json`))
-        return entry ? { mapData: entry.data } : null
+        // `syncShadowToMapData` is called by `captureProjectSnapshot`
+        // to fold the live editor shadow back into mapData — the stub
+        // has no shadow, so it no-ops (mirrors a freshly-loaded map).
+        return entry ? { mapData: entry.data, syncShadowToMapData: () => false } : null
       },
     },
     onPointerMoved(_cb: unknown) {
+      return () => {
+        /* no-op disposer */
+      }
+    },
+    onSelectionChanged(_cb: unknown) {
       return () => {
         /* no-op disposer */
       }
@@ -141,6 +149,11 @@ function makeJoinerEngineStub(): Engine {
       },
     },
     onPointerMoved(_cb: unknown) {
+      return () => {
+        /* no-op disposer */
+      }
+    },
+    onSelectionChanged(_cb: unknown) {
       return () => {
         /* no-op disposer */
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "gjsify foreach build -v -t",
     "check": "gjsify foreach check -v -t",
     "check:barrels-clean": "gjsify foreach check:barrels -v -t",
-    "test": "gjsify foreach test -v -p --include @pixelrpg/engine",
+    "test": "gjsify foreach test -v -p --include @pixelrpg/engine --include @pixelrpg/maker-gjs --include @pixelrpg/signalling-server",
     "start": "gjsify workspace @pixelrpg/maker-gjs start",
     "start:storybook": "gjsify workspace @pixelrpg/storybook-gjs start",
     "clear": "gjsify foreach clear -v -p",


### PR DESCRIPTION
## What

Hardens CI around the test suites and the toolchain (audit findings):

- **Run the maker-gjs + signalling-server suites in CI.** CI only gated `@pixelrpg/engine`; `apps/maker-gjs` registers 18 suites (the whole collab transport layer: session-service host/join e2e over real LAN signalling, collab-session + e2e, lan-discovery/-signalling, relay signalling, pause policy, engine-state sync, sandbox paths…) and `apps/signalling-server` registers 2 (room manager + relay e2e against the built GJS bundle) — none of them ran in CI. Both are added as separate steps in the existing job (the GNOME deps install is expensive — one job, three test steps), and the root `test` script now covers all three.
- **Pin the bootstrap CLI to the lockfile.** `npm install -g @gjsify/cli` (latest) let every new release into CI unseen while `gjsify-lock.json` pins a known-good version for the workspace — and a broken latest (global 0.4.40 demonstrably could not build the test bundles) would break CI with no repo change. The bootstrap step now reads the exact version from `gjsify-lock.json` (`node -p`), so the global bootstrap CLI and the workspace-local CLI are always the same build. Bumps happen via lockfile updates in dedicated commits.
- **Fix the pre-existing `session-service-e2e` failure** instead of quarantining it: the join-flow test failed on clean main (1/311) because the engine stubs drifted behind the real surface — `CollabSession.attachEngine` now calls `engine.onSelectionChanged` and `captureProjectSnapshot` calls `mapResource.syncShadowToMapData`, neither of which the stubs implemented, so host-side `openSession` threw and the joiner's snapshot request timed out. Two no-op stub members fix it (exactly the update the spec's stub-contract comment prescribes).
- **Docs kept truthful:** AGENTS.md's CI description now lists the three suites + the pin (and still truthfully says CI does NOT lint); TODO.md gains the **"Biome cleanup + CI lint gate"** follow-up — ~100 Biome violations have accumulated, so the gate needs a dedicated cleanup PR first and is deliberately NOT added here.

## Headless-safety of the new suites

- LAN/signalling specs bind `127.0.0.1` only (real WebSocket over Soup, no display).
- The real-Avahi discovery integration spec probes for `avahi-browse` and skips itself when no daemon is available (this runner).
- The signalling relay e2e spawns the GJS bundle built earlier in the job via the pinned global `gjsify` on PATH.
- No WebGL/display anywhere in these suites.

## Validation

Locally in a clean worktree with the lockfile CLI (0.4.41): `gjsify install --immutable` → `foreach build` → all three suites green under **both** runtimes (engine 673, maker 311 — gjs 318/node 307 incl. runtime-gated skips, signalling 26).