### PR TITLE
fix(engine): npc placement sprites + one resolver

### DIFF
--- a/apps/maker-gjs/src/services/project-loader.spec.ts
+++ b/apps/maker-gjs/src/services/project-loader.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from '@gjsify/unit'
+import type { EntityDefinition, MapData } from '@pixelrpg/engine'
+import { collectAtlasTeleports } from './project-loader.ts'
+
+const makeMap = (id: string, objectPlacements: MapData['objectPlacements']): MapData =>
+  ({
+    id,
+    name: id,
+    columns: 10,
+    rows: 10,
+    tileWidth: 16,
+    tileHeight: 16,
+    layers: [],
+    objectPlacements,
+  }) as unknown as MapData
+
+const teleportDef: EntityDefinition = {
+  id: 'cave-door',
+  name: 'Cave Door',
+  components: [{ type: 'teleport', targetMapId: 'cave', targetTileX: 1, targetTileY: 2 }],
+}
+
+export default async () => {
+  await describe('collectAtlasTeleports', async () => {
+    await it('surfaces inline teleport placements', async () => {
+      const maps = [makeMap('overworld', [{ id: 'p1', layerId: 'l1', tileX: 3, tileY: 4, inline: teleportDef }])]
+      const teleports = collectAtlasTeleports(maps, [])
+      expect(teleports).toStrictEqual([
+        { from: 'overworld', fx: 3, fy: 4, to: 'cave', tx: 1, ty: 2, label: 'Cave Door' },
+      ])
+    })
+
+    await it('surfaces defId teleport placements via the entity library', async () => {
+      // REGRESSION: the overlay used to read `placement.inline` only, so a
+      // teleport placed with the object brush (a defId reference) never
+      // showed its atlas connection.
+      const maps = [makeMap('overworld', [{ id: 'p1', layerId: 'l1', tileX: 5, tileY: 6, defId: 'cave-door' }])]
+      const teleports = collectAtlasTeleports(maps, [teleportDef])
+      expect(teleports).toStrictEqual([
+        { from: 'overworld', fx: 5, fy: 6, to: 'cave', tx: 1, ty: 2, label: 'Cave Door' },
+      ])
+    })
+
+    await it('honours per-placement overrides on a defId reference', async () => {
+      const maps = [
+        makeMap('overworld', [
+          {
+            id: 'p1',
+            layerId: 'l1',
+            tileX: 0,
+            tileY: 0,
+            defId: 'cave-door',
+            overrides: {
+              components: [{ type: 'teleport', targetMapId: 'dungeon', targetTileX: 9, targetTileY: 9, label: 'Down' }],
+            },
+          },
+        ]),
+      ]
+      const teleports = collectAtlasTeleports(maps, [teleportDef])
+      expect(teleports).toStrictEqual([{ from: 'overworld', fx: 0, fy: 0, to: 'dungeon', tx: 9, ty: 9, label: 'Down' }])
+    })
+
+    await it('skips non-teleport placements and unresolvable defIds', async () => {
+      const npc: EntityDefinition = {
+        id: 'npc',
+        name: 'Npc',
+        components: [{ type: 'visual', spriteSetId: 's', spriteId: 0 }],
+      }
+      const maps = [
+        makeMap('overworld', [
+          { id: 'p1', layerId: 'l1', tileX: 0, tileY: 0, inline: npc },
+          { id: 'p2', layerId: 'l1', tileX: 1, tileY: 1, defId: 'ghost' },
+        ]),
+      ]
+      expect(collectAtlasTeleports(maps, [teleportDef])).toStrictEqual([])
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/project-loader.ts
+++ b/apps/maker-gjs/src/services/project-loader.ts
@@ -1,4 +1,10 @@
-import { GameProjectResource, getComponentData } from '@pixelrpg/engine'
+import {
+  type EntityDefinition,
+  GameProjectResource,
+  getComponentData,
+  type MapData,
+  resolvePlacementDefinition,
+} from '@pixelrpg/engine'
 import type { SampleScene, SampleTeleport } from '@pixelrpg/gjs'
 
 const SOLID_PALETTE = ['#3d6b3a', '#3a5e7b', '#7a5a3a', '#6b3a3a', '#4a4a6b', '#6b6b3a', '#3a6b6b']
@@ -91,14 +97,30 @@ export async function loadProjectAsAtlas(projectPath: string): Promise<LoadedPro
     })
   })
 
-  // Aggregate teleports for the atlas overlay by walking every map's
-  // `objectPlacements` and picking out entities that carry a `teleport`
-  // component. This replaces the legacy project-level `teleports[]` array.
-  const teleports: SampleTeleport[] = maps.flatMap((mapResource) => {
-    const data = mapResource.mapData
+  const teleports = collectAtlasTeleports(
+    maps.map((m) => m.mapData),
+    resource.data?.entityLibrary ?? [],
+  )
+
+  return { projectPath, projectName, scenes, teleports, resource }
+}
+
+/**
+ * Aggregate teleports for the atlas overlay by walking every map's
+ * `objectPlacements` and picking out entities that carry a `teleport`
+ * component. This replaces the legacy project-level `teleports[]` array.
+ * Placements resolve through the canonical `resolvePlacementDefinition`,
+ * so `defId` references into the entity library (created by the object
+ * brush) show up on the atlas exactly like inline definitions.
+ */
+export function collectAtlasTeleports(
+  maps: readonly MapData[],
+  entityLibrary: readonly EntityDefinition[],
+): SampleTeleport[] {
+  return maps.flatMap((data) => {
     const placements = data?.objectPlacements ?? []
     return placements.flatMap((placement) => {
-      const def = placement.inline // editor inlines placements; library refs are an editor concern
+      const def = resolvePlacementDefinition(placement, entityLibrary)
       const teleport = def ? getComponentData(def, 'teleport') : undefined
       if (
         !teleport ||
@@ -121,6 +143,4 @@ export async function loadProjectAsAtlas(projectPath: string): Promise<LoadedPro
       ]
     })
   })
-
-  return { projectPath, projectName, scenes, teleports, resource }
 }

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -14,6 +14,7 @@ import lanSignallingIntegrationSuite from './services/lan-signalling-integration
 import lanSignallingTimeoutSuite from './services/lan-signalling-timeout.spec.js'
 import orphanPublisherCleanupSuite from './services/orphan-publisher-cleanup.spec.js'
 import pixelrpgUrlSuite from './services/pixelrpg-url.spec.js'
+import projectLoaderSuite from './services/project-loader.spec.js'
 import relaySignallingSuite from './services/relay-signalling.spec.js'
 import sandboxPathSuite from './services/sandbox-path.spec.js'
 import sessionServiceSuite from './services/session-service.spec.js'
@@ -34,6 +35,7 @@ run({
   lanSignallingTimeoutSuite,
   orphanPublisherCleanupSuite,
   pixelrpgUrlSuite,
+  projectLoaderSuite,
   relaySignallingSuite,
   sandboxPathSuite,
   sessionServiceSuite,

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -9,6 +9,7 @@ import {
   type EntityDefinition,
   getComponentData,
   markerColorFor,
+  resolvePlacementDefinition,
 } from '@pixelrpg/engine'
 import {
   type CollaboratorEntry,
@@ -376,10 +377,10 @@ export class SceneEditorView extends ResponsiveEditorView {
     }
 
     // Surface the map's object placements in the Objects tab. Each
-    // placement resolves its display name from the inline definition
-    // (when present) or from the project's `objectLibrary` (when
-    // referenced by `defId`); falling back to the placement id keeps
-    // the row labelled even if the library lookup misses.
+    // placement resolves through the canonical resolver (inline, or
+    // entity-library lookup by `defId`, with per-instance overrides
+    // merged); falling back to the placement id keeps the row labelled
+    // even if the library lookup misses.
     //
     // Placements with a `sprite` ref additionally get a `Gdk.Paintable`
     // preview attached so the Objects tab renders the actual sprite
@@ -389,7 +390,7 @@ export class SceneEditorView extends ResponsiveEditorView {
     const library = project.resource.data?.entityLibrary ?? []
     const resolvedDefs = (mapData.objectPlacements ?? []).map((p) => ({
       placement: p,
-      def: p.inline ?? library.find((d) => d.id === p.defId) ?? null,
+      def: resolvePlacementDefinition(p, library),
     }))
     // The placement-brush palette lists every library entity except the
     // player actor (it spawns at the player spawn-point, not via the brush).

--- a/docs/concepts/object-system.md
+++ b/docs/concepts/object-system.md
@@ -83,6 +83,8 @@ interface ObjectPlacement {
 
 `overrides` is **not** deep-merged. `name` replaces the display name; each entry in `overrides.components` **replaces the base component of the same `type` in its entirety** (a type absent from the base is appended). See `mergePlacementComponents` in `packages/engine/src/entity/data-access.ts`.
 
+Placement → definition resolution (inline, or `defId` library lookup, with `overrides` merged) has **one** implementation: `resolvePlacementDefinition` in `packages/engine/src/entity/data-access.ts`. Every consumer — the spawn pipeline, the maker's Objects tab, the atlas teleport overlay — goes through it; hand-rolled partial resolution (e.g. reading `placement.inline` only) is a bug, since the object brush creates `defId` placements.
+
 If a user wants "same as library but with a different teleport label", they put the **entire** `teleport` component config in `overrides.components` with the new label included. Deterministic behaviour beats convenience for the editor's mutation surface.
 
 ### Layer changes
@@ -169,11 +171,11 @@ The shipped surface (entity-composition C2–C6 + the tile-like-object UX, PRs #
 
 - **Objects view** — a top-level master-detail view over the whole `entityLibrary` (world objects AND cast characters, the latter with a "Cast" badge), edited through the generated component inspector (`ObjectsController`, `win.new-object` / `win.open-object`).
 - **Object brushes in the scene editor's Tiles tab** — a visual sprite-thumbnail palette (shared `TilePalette` / `createSwatchWidget`) below the tile palette; single-click a card to arm the brush (`win.set-object-brush`), which switches to the `'object'` tool.
-- **Object tool** — part of the `EditorTool` union; stamps the armed brush onto the clicked tile as an undoable, collab-synced `PlaceObjectCommand`. Placements render framed with a shared hover ghost. The FloatingTopBar context chip quick-selects tiles or objects depending on the active tool.
+- **Object tool** — part of the `EditorTool` union; stamps the armed brush onto the clicked tile as an undoable, collab-synced `PlaceObjectCommand`. Placements render framed with a shared hover ghost (`entity/placement-graphic.ts`): the definition's `visual` sprite/animation contain-fitted into the cell — for a Cast character that's the sheet-owned `characterAnimations` default (e.g. `idle-down`) — or a type-coloured marker only when no appearance resolves. The FloatingTopBar context chip quick-selects tiles or objects depending on the active tool.
 - **Props tab "Selected object" group** — selecting a placement (`'select'` tool or `win.select-placement`) shows its name/position + an undoable Remove (`RemoveObjectCommand`).
 - **Objects visibility row** in the Layers tab (`win.toggle-objects`).
 - **Tile properties** — edited in the Sheets view's tile-property inspector (Solid switch, surface); persists to the sprite-set JSON.
-- **Atlas teleport curves** — built by aggregating placements carrying a `teleport` component across all maps (`project-loader.ts`; replaced the legacy projectwide `teleports[]`).
+- **Atlas teleport curves** — built by aggregating placements carrying a `teleport` component across all maps via `resolvePlacementDefinition` — inline AND `defId` placements both surface (`project-loader.ts`; replaced the legacy projectwide `teleports[]`).
 
 Remaining follow-ups (per-placement override editing, palette layout) are tracked in `TODO.md` § "Object-system editor UI follow-ups".
 

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -225,12 +225,11 @@ export class Engine {
     const playerCharacter = playerEntity
       ? (entityToCharacter(playerEntity, projectData?.playerActorId) ?? undefined)
       : undefined
-    // Resolve the player's sprite-set directly from the project. We
-    // cannot rely on `MapResource.getSpriteSetResource` because that
-    // map only copies in the sprite-sets the map JSON references —
-    // the scientist (and any other character-only sprite-set) is on
-    // the project but not on the map. Look it up at the project
-    // level and pass it through.
+    // Resolve the player's sprite-set directly from the project —
+    // character-only sprite-sets (e.g. the scientist) live on the
+    // project, not in any map JSON. (`MapResource.getSpriteSetResource`
+    // also falls back to these project-level sets now, but the player
+    // sheet is project data, so look it up at the project level.)
     const playerSpriteSet = playerCharacter
       ? this._gameProjectResource.spriteSets.get(playerCharacter.spriteSetId)
       : undefined

--- a/packages/engine/src/entity/data-access.spec.ts
+++ b/packages/engine/src/entity/data-access.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from '@gjsify/unit'
+import type { EntityDefinition } from '../types/data/index.ts'
+import { getComponentData, mergePlacementComponents, resolvePlacementDefinition } from './data-access.ts'
+
+export default async () => {
+  await describe('getComponentData', async () => {
+    await it('returns the first component of the requested type', async () => {
+      const def = { components: [{ type: 'collision' }, { type: 'item', itemId: 'apple' }] }
+      expect(getComponentData(def, 'item')?.itemId).toBe('apple')
+    })
+
+    await it('returns undefined when the type is absent', async () => {
+      expect(getComponentData({ components: [] }, 'visual')).toBe(undefined)
+    })
+  })
+
+  await describe('mergePlacementComponents', async () => {
+    await it('copies the base when there are no overrides', async () => {
+      const base = [{ type: 'collision' }]
+      const merged = mergePlacementComponents(base)
+      expect(merged).toStrictEqual(base)
+      expect(merged[0] === base[0]).toBe(false) // fresh copies, inputs untouched
+    })
+
+    await it('wholesale-replaces per type and appends new types', async () => {
+      const base = [{ type: 'item', itemId: 'apple', qty: 1 }, { type: 'collision' }]
+      const merged = mergePlacementComponents(base, [
+        { type: 'item', itemId: 'gold-apple' },
+        { type: 'trigger', on: 'walk-onto' },
+      ])
+      expect(merged).toStrictEqual([
+        { type: 'item', itemId: 'gold-apple' }, // replaced wholesale — no deep merge of `qty`
+        { type: 'collision' },
+        { type: 'trigger', on: 'walk-onto' },
+      ])
+    })
+  })
+
+  await describe('resolvePlacementDefinition', async () => {
+    const library: EntityDefinition[] = [
+      { id: 'apple', name: 'Apple', components: [{ type: 'item', itemId: 'apple' }] },
+      {
+        id: 'cave-door',
+        name: 'Cave Door',
+        components: [{ type: 'teleport', targetMapId: 'cave', targetTileX: 1, targetTileY: 2 }],
+      },
+    ]
+
+    await it('returns the inline definition verbatim', async () => {
+      const inline: EntityDefinition = { id: 'd', name: 'D', components: [] }
+      const placement = { id: 'p', layerId: 'l1', tileX: 0, tileY: 0, inline }
+      expect(resolvePlacementDefinition(placement, library)).toBe(inline)
+    })
+
+    await it('looks up a library entry by defId', async () => {
+      const placement = { id: 'p', layerId: 'l1', tileX: 0, tileY: 0, defId: 'apple' }
+      expect(resolvePlacementDefinition(placement, library)?.name).toBe('Apple')
+    })
+
+    await it('resolves a defId teleport — the atlas-overlay case', async () => {
+      // The atlas teleport overlay used to read `placement.inline` only,
+      // so an object-brush placement (defId into the entity library)
+      // never showed its connection. The canonical resolver covers it.
+      const placement = { id: 'p', layerId: 'l1', tileX: 3, tileY: 4, defId: 'cave-door' }
+      const resolved = resolvePlacementDefinition(placement, library)
+      expect(getComponentData(resolved ?? { components: [] }, 'teleport')?.targetMapId).toBe('cave')
+    })
+
+    await it('merges overrides — name replace + wholesale-replace component per type', async () => {
+      const placement = {
+        id: 'p',
+        layerId: 'l1',
+        tileX: 0,
+        tileY: 0,
+        defId: 'apple',
+        overrides: { name: 'Golden', components: [{ type: 'item', itemId: 'gold-apple', qty: 5 }] },
+      }
+      const resolved = resolvePlacementDefinition(placement, library)
+      expect(resolved?.name).toBe('Golden')
+      expect(resolved?.components).toStrictEqual([{ type: 'item', itemId: 'gold-apple', qty: 5 }])
+    })
+
+    await it('returns null when neither inline nor a known defId resolves', async () => {
+      expect(resolvePlacementDefinition({ id: 'p', layerId: 'l1', tileX: 0, tileY: 0, defId: 'ghost' }, library)).toBe(
+        null,
+      )
+    })
+  })
+}

--- a/packages/engine/src/entity/data-access.ts
+++ b/packages/engine/src/entity/data-access.ts
@@ -1,4 +1,4 @@
-import type { ComponentData, EntityDefinition } from '../types/data/index.ts'
+import type { ComponentData, EntityDefinition, ObjectPlacement } from '../types/data/index.ts'
 
 /**
  * Read one component's data off a definition by `type`. Returns the
@@ -39,4 +39,31 @@ export function mergePlacementComponents(
   // Override types not on the base are additive.
   for (const o of overrideByType.values()) merged.push({ ...o })
   return merged
+}
+
+/**
+ * Resolve a placement to its effective {@link EntityDefinition}: an inline
+ * definition, or a library lookup by `defId` with per-instance
+ * `overrides` merged (name replace + wholesale-replace components per
+ * `type`). Returns `null` if neither resolves.
+ *
+ * This is the **single** placement→definition resolver — the spawn
+ * pipeline, the maker's Objects tab and the atlas teleport overlay all
+ * go through it, so `defId` placements (created by the object brush
+ * since C3b) and per-placement overrides behave identically everywhere.
+ */
+export function resolvePlacementDefinition(
+  placement: ObjectPlacement,
+  library: readonly EntityDefinition[],
+): EntityDefinition | null {
+  let base: EntityDefinition | null = null
+  if (placement.inline) base = placement.inline
+  else if (placement.defId) base = library.find((d) => d.id === placement.defId) ?? null
+  if (!base) return null
+  if (!placement.overrides) return base
+  return {
+    ...base,
+    name: placement.overrides.name ?? base.name,
+    components: mergePlacementComponents(base.components, placement.overrides.components),
+  }
 }

--- a/packages/engine/src/entity/placement-graphic.spec.ts
+++ b/packages/engine/src/entity/placement-graphic.spec.ts
@@ -1,12 +1,39 @@
 import { describe, expect, it } from '@gjsify/unit'
-import { GraphicsGroup, Polygon, Rectangle } from 'excalibur'
+import { Animation, GraphicsGroup, Polygon, Rectangle, type Sprite } from 'excalibur'
 import type { MapResource } from '../resource/MapResource.ts'
-import type { EntityDefinition } from '../types/data/index.ts'
+import type { SpriteSetResource } from '../resource/SpriteSetResource.ts'
+import type { ComponentData, EntityDefinition } from '../types/data/index.ts'
 import { buildPlacementGraphic, fitContainScale, frameInset, markerColorFor } from './placement-graphic.ts'
+import { buildVisualGraphic } from './visual-graphic.ts'
 
 const fakeMapResource = {
   mapData: { tileWidth: 16, tileHeight: 16, layers: [] },
   getSpriteSetResource: () => undefined,
+} as unknown as MapResource
+
+/** Minimal Sprite stand-in: just the surface buildVisualGraphic touches. */
+const fakeSprite = (width = 16, height = 32): Sprite => {
+  const sprite = { width, height, clone: () => fakeSprite(width, height) }
+  return sprite as unknown as Sprite
+}
+
+/**
+ * A character appearance sheet the way C5 ships it: roles live in the
+ * sheet-owned `characterAnimations`, the engine-level `animations`
+ * lookup stays empty (verified: the starter scientist has
+ * `animations: []`).
+ */
+const fakeCharacterSheet = {
+  sprites: { 0: fakeSprite(), 1: fakeSprite() },
+  animations: {},
+  data: {
+    characterAnimations: [{ id: 'idle-down', frames: [0, 1], durationMs: 200 }],
+  },
+} as unknown as SpriteSetResource
+
+const characterMapResource = {
+  mapData: { tileWidth: 16, tileHeight: 16, layers: [] },
+  getSpriteSetResource: (id: string) => (id === 'scientist' ? fakeCharacterSheet : undefined),
 } as unknown as MapResource
 
 /** Unwrap a GraphicsGrouping | Graphic member to its Graphic. */
@@ -55,6 +82,29 @@ export default async () => {
     })
   })
 
+  await describe('buildVisualGraphic', async () => {
+    await it('resolves a character appearance via the sheet-owned characterAnimations', async () => {
+      // A placed Cast NPC's visual component (characterToEntity output).
+      const visual: ComponentData = { type: 'visual', spriteSetId: 'scientist', spriteId: 0, animationId: 'idle-down' }
+      const graphic = buildVisualGraphic(visual, characterMapResource)
+      expect(graphic instanceof Animation).toBe(true)
+      expect((graphic as Animation).frames.length).toBe(2)
+    })
+
+    await it('falls back to the static sprite for an unknown animation id', async () => {
+      const visual: ComponentData = { type: 'visual', spriteSetId: 'scientist', spriteId: 0, animationId: 'ghost' }
+      const graphic = buildVisualGraphic(visual, characterMapResource)
+      expect(graphic !== null).toBe(true)
+      expect(graphic instanceof Animation).toBe(false)
+      expect(graphic?.height).toBe(32)
+    })
+
+    await it('returns null when the sprite set is missing', async () => {
+      const visual: ComponentData = { type: 'visual', spriteSetId: 'ghost-set', spriteId: 0 }
+      expect(buildVisualGraphic(visual, characterMapResource)).toBe(null)
+    })
+  })
+
   await describe('buildPlacementGraphic', async () => {
     // Raster graphics (Rectangle / Polygon) need a DOM canvas — present
     // under GJS / the browser, absent on a bare Node run (same gate as
@@ -83,6 +133,29 @@ export default async () => {
       const group = buildPlacementGraphic(def, fakeMapResource, 16, 16)
       expect(group.members.length).toBe(2)
       expect(memberGraphic(group, 1) instanceof Polygon).toBe(true)
+    })
+
+    await it('renders a placed Cast NPC with its appearance animation, not the marker', async () => {
+      if (!domAvailable) return
+      // characterToEntity output for a Cast character — the C6 "Cast NPCs
+      // placeable" path. Must resolve the sheet's idle-down animation
+      // instead of the diamond fallback.
+      const def: EntityDefinition = {
+        id: 'scientist',
+        name: 'Scientist',
+        components: [
+          { type: 'visual', spriteSetId: 'scientist', spriteId: 0, animationId: 'idle-down' },
+          { type: 'movement', tilesPerSec: 4 },
+        ],
+        editorData: { template: 'character' },
+      }
+      const group = buildPlacementGraphic(def, characterMapResource, 16, 16)
+      expect(group.members.length).toBe(2)
+      const content = memberGraphic(group, 1)
+      expect(content instanceof Animation).toBe(true)
+      expect(content instanceof Polygon).toBe(false)
+      // Contain-fitted into the 14×14 framed area: 16×32 cell → bound by height.
+      expect((content as Animation).scale.y).toBe(14 / 32)
     })
   })
 }

--- a/packages/engine/src/entity/spawn-placement.spec.ts
+++ b/packages/engine/src/entity/spawn-placement.spec.ts
@@ -11,7 +11,7 @@ import {
 import { TIER_Z } from '../components/tilemap-tier.component.ts'
 import type { MapResource } from '../resource/MapResource.ts'
 import type { EntityDefinition, LayerData } from '../types/data/index.ts'
-import { buildPlacementEntity, resolvePlacementDefinition } from './spawn-placement.ts'
+import { buildPlacementEntity } from './spawn-placement.ts'
 
 const layer: LayerData = { id: 'l1', name: 'L', visible: true, sprites: [] }
 const fakeMapResource = {
@@ -21,43 +21,6 @@ const fakeMapResource = {
 const layersById = new Map([[layer.id, layer]])
 
 export default async () => {
-  await describe('resolvePlacementDefinition', async () => {
-    const library: EntityDefinition[] = [
-      { id: 'apple', name: 'Apple', components: [{ type: 'item', itemId: 'apple' }] },
-    ]
-
-    await it('returns the inline definition verbatim', async () => {
-      const inline: EntityDefinition = { id: 'd', name: 'D', components: [] }
-      const placement = { id: 'p', layerId: 'l1', tileX: 0, tileY: 0, inline }
-      expect(resolvePlacementDefinition(placement, library)).toBe(inline)
-    })
-
-    await it('looks up a library entry by defId', async () => {
-      const placement = { id: 'p', layerId: 'l1', tileX: 0, tileY: 0, defId: 'apple' }
-      expect(resolvePlacementDefinition(placement, library)?.name).toBe('Apple')
-    })
-
-    await it('merges overrides — name replace + wholesale-replace component per type', async () => {
-      const placement = {
-        id: 'p',
-        layerId: 'l1',
-        tileX: 0,
-        tileY: 0,
-        defId: 'apple',
-        overrides: { name: 'Golden', components: [{ type: 'item', itemId: 'gold-apple', qty: 5 }] },
-      }
-      const resolved = resolvePlacementDefinition(placement, library)
-      expect(resolved?.name).toBe('Golden')
-      expect(resolved?.components).toStrictEqual([{ type: 'item', itemId: 'gold-apple', qty: 5 }])
-    })
-
-    await it('returns null when neither inline nor a known defId resolves', async () => {
-      expect(resolvePlacementDefinition({ id: 'p', layerId: 'l1', tileX: 0, tileY: 0, defId: 'ghost' }, library)).toBe(
-        null,
-      )
-    })
-  })
-
   await describe('buildPlacementEntity — runtime parity', async () => {
     // Building an entity attaches Excalibur graphics (sprite or the outline
     // marker Rectangle), which need a DOM canvas. The spawn pipeline only

--- a/packages/engine/src/entity/spawn-placement.ts
+++ b/packages/engine/src/entity/spawn-placement.ts
@@ -6,31 +6,8 @@ import { isLayerVisible } from '../services/layer-visibility.ts'
 import type { EntityDefinition, ObjectPlacement } from '../types/data/index.ts'
 import { DEFAULT_LAYER_TIER, type LayerData } from '../types/data/LayerData.ts'
 import type { ComponentSpecRegistry } from './component-spec.ts'
-import { mergePlacementComponents } from './data-access.ts'
 import { buildPlacementGraphic } from './placement-graphic.ts'
 import { BUILT_IN_COMPONENT_SPECS } from './registry.ts'
-
-/**
- * Resolve a placement to its effective {@link EntityDefinition}: an inline
- * definition, or a library lookup by `defId` with per-instance
- * `overrides` merged (name replace + wholesale-replace components per
- * `type`). Returns `null` if neither resolves.
- */
-export function resolvePlacementDefinition(
-  placement: ObjectPlacement,
-  library: readonly EntityDefinition[],
-): EntityDefinition | null {
-  let base: EntityDefinition | null = null
-  if (placement.inline) base = placement.inline
-  else if (placement.defId) base = library.find((d) => d.id === placement.defId) ?? null
-  if (!base) return null
-  if (!placement.overrides) return base
-  return {
-    ...base,
-    name: placement.overrides.name ?? base.name,
-    components: mergePlacementComponents(base.components, placement.overrides.components),
-  }
-}
 
 /**
  * Build one Excalibur entity from a placement + its resolved definition,

--- a/packages/engine/src/entity/visual-graphic.ts
+++ b/packages/engine/src/entity/visual-graphic.ts
@@ -1,18 +1,27 @@
 import type { Graphic } from 'excalibur'
 import type { MapResource } from '../resource/MapResource.ts'
+import type { SpriteSetResource } from '../resource/SpriteSetResource.ts'
 import type { ComponentData } from '../types/data/index.ts'
+import { buildCharacterAnimation } from '../utils/character.ts'
 
 /**
  * Build the Excalibur graphic for a `visual` component's data, resolving
  * the sprite/animation through the map's loaded sprite-set resources.
- * Returns `null` when the set/sprite is missing (the caller falls back to
- * the outline marker). Mirrors the shipped `attachSpriteGraphic`:
- * `animationId` takes precedence over the static `spriteId`.
+ * Returns `null` when the set is missing or nothing resolves (the caller
+ * falls back to the outline marker).
  *
- * v1 handles the flat sprite-reference shape (`spriteSetId` + `spriteId` +
- * optional `animationId`). PR-4 extends this to the appearance-driven
- * `Visual` union (sheet `characterAnimations` → default animation) when
- * characters fold into the entity library.
+ * Resolution order for an `animationId` (e.g. a Cast character's
+ * `idle-down` default):
+ *
+ * 1. the set's engine-level `animations` lookup (animated tiles /
+ *    object graphics, built from `SpriteSetData.animations`),
+ * 2. the sheet-owned `characterAnimations` (post-C5 home of the
+ *    directional roles — what the Cast preview plays), built into a
+ *    runtime animation on the fly,
+ * 3. the static `spriteId` sprite, so a stale/unknown animation id
+ *    still renders the appearance instead of the fallback marker.
+ *
+ * Without an `animationId` the static `spriteId` resolves directly.
  */
 export function buildVisualGraphic(data: ComponentData, mapResource: MapResource): Graphic | null {
   const spriteSetId = data.spriteSetId
@@ -21,6 +30,20 @@ export function buildVisualGraphic(data: ComponentData, mapResource: MapResource
   if (!spriteSet) return null
   const animationId = typeof data.animationId === 'string' ? data.animationId : undefined
   const spriteId = typeof data.spriteId === 'number' ? data.spriteId : 0
-  const graphic = animationId ? spriteSet.animations[animationId]?.clone() : spriteSet.sprites[spriteId]?.clone()
-  return graphic ?? null
+  const graphic = animationId
+    ? (spriteSet.animations[animationId]?.clone() ?? buildSheetCharacterAnimation(spriteSet, animationId))
+    : undefined
+  return graphic ?? spriteSet.sprites[spriteId]?.clone() ?? null
+}
+
+/**
+ * Resolve an animation id against the sheet-owned `characterAnimations`
+ * of a character sprite-set (disjoint from the engine-level `animations`
+ * lookup — see `SpriteSetData`). Returns `null` when the sheet carries
+ * no such animation or none of its frames resolve.
+ */
+function buildSheetCharacterAnimation(spriteSet: SpriteSetResource, animationId: string): Graphic | null {
+  const anim = spriteSet.data?.characterAnimations?.find((a) => a.id === animationId)
+  if (!anim) return null
+  return buildCharacterAnimation(anim, spriteSet.sprites)
 }

--- a/packages/engine/src/resource/MapResource.ts
+++ b/packages/engine/src/resource/MapResource.ts
@@ -324,8 +324,16 @@ export class MapResource implements Loadable<TileMap> {
     for (const t of this.tileMapsByTier.values()) yield t
   }
 
+  /**
+   * Look up a sprite-set resource by id: the map's own referenced sets
+   * first, then the pre-loaded project-level sets. The fallback makes
+   * project-only sets resolvable through the map — character appearance
+   * sheets (e.g. the scientist) live on the project but are not
+   * referenced by any map JSON, yet placed Cast NPCs must render their
+   * sprite on this map (`entity/visual-graphic.ts`).
+   */
   getSpriteSetResource(spriteSetId: string): SpriteSetResource | undefined {
-    return this.spriteSetResources.get(spriteSetId)
+    return this.spriteSetResources.get(spriteSetId) ?? this._preloadedSpriteSets.get(spriteSetId)
   }
 
   /**

--- a/packages/engine/src/resource/map-resource.spec.ts
+++ b/packages/engine/src/resource/map-resource.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from '@gjsify/unit'
+import { MapResource } from './MapResource.ts'
+import type { SpriteSetResource } from './SpriteSetResource.ts'
+
+export default async () => {
+  await describe('MapResource.getSpriteSetResource', async () => {
+    await it('falls back to the pre-loaded project-level sets', async () => {
+      // Character appearance sheets (e.g. the scientist) live on the
+      // project but are not referenced by any map JSON — without the
+      // fallback a placed Cast NPC could never resolve its sheet and
+      // rendered the diamond marker instead of its sprite.
+      const scientist = { data: { id: 'scientist' } } as unknown as SpriteSetResource
+      const resource = new MapResource('maps/main.json', {
+        headless: true,
+        preloadedSpriteSets: new Map([['scientist', scientist]]),
+      })
+      expect(resource.getSpriteSetResource('scientist')).toBe(scientist)
+      expect(resource.getSpriteSetResource('ghost')).toBe(undefined)
+    })
+  })
+}

--- a/packages/engine/src/scenes/map.scene.ts
+++ b/packages/engine/src/scenes/map.scene.ts
@@ -1,9 +1,10 @@
 import { Actor, type EventEmitter, Logger, Scene } from 'excalibur'
 import { EditorModeComponent, PlacementIdComponent } from '../components/index.ts'
-import { buildPlacementEntity, resolvePlacementDefinition } from '../entity/spawn-placement.ts'
-import { areObjectsVisible } from '../services/editor-view.ts'
+import { resolvePlacementDefinition } from '../entity/data-access.ts'
+import { buildPlacementEntity } from '../entity/spawn-placement.ts'
 import type { MapResource } from '../resource/MapResource.ts'
 import type { SpriteSetResource } from '../resource/SpriteSetResource.ts'
+import { areObjectsVisible } from '../services/editor-view.ts'
 import {
   CameraControlSystem,
   ItemPickupSystem,

--- a/packages/engine/src/systems/object-spawn.system.ts
+++ b/packages/engine/src/systems/object-spawn.system.ts
@@ -1,7 +1,8 @@
 import { Actor, type Scene, System, SystemType, type World } from 'excalibur'
-import { buildPlacementEntity, resolvePlacementDefinition } from '../entity/spawn-placement.ts'
-import { areObjectsVisible } from '../services/editor-view.ts'
+import { resolvePlacementDefinition } from '../entity/data-access.ts'
+import { buildPlacementEntity } from '../entity/spawn-placement.ts'
 import type { MapResource } from '../resource/MapResource.ts'
+import { areObjectsVisible } from '../services/editor-view.ts'
 import type { EntityDefinition } from '../types/data/index.ts'
 
 /**

--- a/packages/engine/src/test.mts
+++ b/packages/engine/src/test.mts
@@ -19,11 +19,13 @@ import objectPlacementCommandSuite from './commands/object-placement.command.spe
 import paintTileCommandSuite from './commands/paint-tile.command.spec.js'
 import registrySuite from './commands/registry.spec.js'
 import entityConvertSuite from './entity/convert.spec.js'
+import entityDataAccessSuite from './entity/data-access.spec.js'
 import entityPlacementGraphicSuite from './entity/placement-graphic.spec.js'
 import entityRegistrySuite from './entity/registry.spec.js'
 import entitySpawnPlacementSuite from './entity/spawn-placement.spec.js'
 import entityValidateSuite from './entity/validate.spec.js'
 import objectSystemValidationSuite from './format/object-system-validation.spec.js'
+import mapResourceSuite from './resource/map-resource.spec.js'
 import layerVisibilitySuite from './services/layer-visibility.spec.js'
 import spriteValidatorSuite from './services/sprite.validator.spec.js'
 import spriteInfoResolverSuite from './services/sprite-info.resolver.spec.js'
@@ -50,9 +52,11 @@ run({
   entityRegistrySuite,
   entityValidateSuite,
   entityConvertSuite,
+  entityDataAccessSuite,
   entityPlacementGraphicSuite,
   entitySpawnPlacementSuite,
   objectSystemValidationSuite,
+  mapResourceSuite,
   layerVisibilitySuite,
   spriteInfoResolverSuite,
   spriteValidatorSuite,

--- a/packages/engine/src/utils/character.ts
+++ b/packages/engine/src/utils/character.ts
@@ -34,7 +34,7 @@ export function buildCharacterAnimations(
   const sourceAnimations = spriteSet.data?.characterAnimations ?? character.animations ?? []
   for (const anim of sourceAnimations) {
     if (!REQUIRED_ROLES.includes(anim.id as CharacterAnimationRole)) continue
-    const built = buildAnimation(anim, spriteSet.sprites)
+    const built = buildCharacterAnimation(anim, spriteSet.sprites)
     if (built) animations[anim.id as CharacterAnimationRole] = built
   }
   // Plug holes with the placeholder so role transitions never miss.
@@ -49,8 +49,16 @@ export function buildCharacterAnimations(
   }
 }
 
-/** Build a single Excalibur {@link Animation} from a {@link CharacterAnimation}. */
-function buildAnimation(anim: CharacterAnimation, sprites: Record<number, Sprite>): Animation | null {
+/**
+ * Build a single Excalibur {@link Animation} from a {@link CharacterAnimation}
+ * (frame indices into the sheet's sprites, uniform `durationMs`, loop by
+ * default). Returns `null` when no frame resolves to a loaded sprite.
+ *
+ * Shared by the player path ({@link buildCharacterAnimations}) and the
+ * placement-graphic path (`entity/visual-graphic.ts`), so a placed Cast
+ * NPC animates exactly like the player would.
+ */
+export function buildCharacterAnimation(anim: CharacterAnimation, sprites: Record<number, Sprite>): Animation | null {
   const frames = anim.frames
     .map((spriteId) => sprites[spriteId])
     .filter((s): s is Sprite => s != null)


### PR DESCRIPTION
## Bug A — placed Cast NPCs rendered a diamond marker instead of their sprite

A placed Cast character (C6 \"Cast NPCs placeable\") showed its sprite in the Objects-tab thumbnail but a type-coloured diamond on the canvas. Headless-verified root cause is **two** independent gaps in the placement-graphic path:

1. **The appearance sheet was never resolvable through the map.** Character sheets (e.g. the scientist) are *project-level* sprite-sets — no map JSON references them (`blank-starter` maps ship `"spriteSets": []`) — and `MapResource.getSpriteSetResource` only knew the map-referenced sets, so `buildVisualGraphic` bailed at the set lookup before even reaching the animation. `getSpriteSetResource` now falls back to the pre-loaded project-level sets (the same map `GameProjectResource` already hands in).
2. **`characterAnimations` were invisible to the graphic builder.** Post-C5, character roles live in the sheet-owned `SpriteSetData.characterAnimations`, disjoint from the engine-level `animations` lookup that `buildVisualGraphic` consulted. It now resolves `animationId` as: engine `animations` → sheet `characterAnimations` (built via the shared `buildCharacterAnimation`, the exact builder the player path uses) → static `spriteId` fallback for stale/unknown ids — so the worst case is a static sprite, never the marker for an appearance-bearing entity.

A placed NPC therefore renders its **animated `idle-down` default** — the same animation source the Cast view's preview plays (sheet-owned roles, idle for the paused state). The hover ghost (`services/object-preview.ts`) shares `buildPlacementGraphic`, so it renders the appearance too; the brush swatches already used the static-sprite Gdk path and keep working. Rendering only — no behaviour/movement.

The stale `PR-4` comment in `visual-graphic.ts` (deferring this to \"when characters fold into the entity library\" — B2/C6 already landed) is replaced by the actual resolution-order doc.

## Bug B — placement→definition resolution deduped to ONE resolver

`resolvePlacementDefinition` (inline | `defId` lookup | `overrides` merge) is now the **single** implementation, moved to `entity/data-access.ts` next to `mergePlacementComponents`. The three formerly-diverging sites:

| Site | Before | Now |
|---|---|---|
| `entity/spawn-placement.ts` (spawn pipeline: `map.scene.ts`, `object-spawn.system.ts`) | canonical (full) | imports from `data-access.ts` |
| `apps/maker-gjs/src/services/project-loader.ts` (atlas teleport overlay) | read `placement.inline` **only** — `defId` teleports placed with the object brush never showed on the atlas (stale \"library refs are an editor concern\" comment, pre-C3b) | `resolvePlacementDefinition` |
| `apps/maker-gjs/src/widgets/scene-editor-view.ts` (Objects tab rows + `_placementInfo`) | `p.inline ?? library.find(...)` — silently dropped `overrides` | `resolvePlacementDefinition` |

The atlas aggregation is extracted into a pure `collectAtlasTeleports(maps, entityLibrary)` so the overlay fix is headless-verifiable: the new spec covers inline, **defId (the regression)**, overrides-on-defId, and skip cases.

## Tests

- `entity/data-access.spec.ts` (new): `getComponentData`, `mergePlacementComponents`, resolver — inline / defId / overrides / missing-def, incl. the defId-teleport atlas case (resolver tests moved out of `spawn-placement.spec.ts`).
- `entity/placement-graphic.spec.ts`: `buildVisualGraphic` resolves a character appearance via sheet `characterAnimations`, static-sprite fallback for unknown ids, null for a missing set; `buildPlacementGraphic` renders a placed Cast NPC as an `Animation` (contain-fitted 16×32 cell), not the marker.
- `resource/map-resource.spec.ts` (new): project-level sprite-set fallback.
- `apps/maker-gjs/.../project-loader.spec.ts` (new): `collectAtlasTeleports` suite (above).
- All registered in the hand-maintained `test.mts` files. Engine: 677 → **687**, both runtimes green. Maker: 322 (gjs) / 311 (node) green (the `snapshot-exchange` join-flow timeout flaked once locally — it fails identically on pristine `origin/main`, unrelated).
- `gjsify foreach check -v -t` green; `biome check` clean on touched files (the two `scene-editor-view.ts` warnings pre-exist on main).

No screenshots (headless run); the placed-NPC-renders-appearance claim is covered by the `buildPlacementGraphic` spec, which asserts the exact graphic the canvas actor and the hover ghost use.

`docs/concepts/object-system.md` aligned in the same commit: canonical-resolver note under override semantics, placement-rendering description (appearance animation for Cast characters, marker only when nothing resolves), atlas-curves bullet now mentions defId placements.