### PR TITLE
chore: biome clean repo + ci lint gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
       - name: Install dependencies (gjsify install --immutable)
         run: gjsify install --immutable
 
+      - name: Lint + format check (Biome)
+        # `biome ci` = linter + formatter in check mode. Direct Biome —
+        # the gjsify CLI's own lint/fix subcommands wrap oxlint/oxfmt,
+        # which this repo doesn't use. GTK CSS is excluded in biome.json
+        # (non-web dialect Biome cannot parse).
+        run: ./node_modules/.bin/biome ci packages apps
+
       - name: Type-check workspace
         run: gjsify foreach check -v -t
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 PixelRPG Map Editor — gjsify-native monorepo (no Yarn, no Node-only build tooling). Single-process GTK4/libadwaita app with Excalibur.js running directly in GJS via gjsify. Tile-based RPG map editor for the GNOME platform; exported games target multiple platforms (browser-runtime seeded under `apps/game-browser`).
 
-Toolchain: `gjsify install` (replaces yarn), `gjsify build` (replaces esbuild/vite), `gjsify barrels` (replaces barrelsby), `gjsify format` / `gjsify lint` / `gjsify fix` (wraps Biome), `gjsify foreach` / `gjsify workspace` (replaces `yarn workspaces foreach`), `gjsify flatpak` for `apps/maker-gjs` packaging. Lockfile: `gjsify-lock.json` (no `yarn.lock`).
+Toolchain: `gjsify install` (replaces yarn), `gjsify build` (replaces esbuild/vite), `gjsify barrels` (replaces barrelsby), `gjsify run lint` / `gjsify run format` (Biome direct — the CLI's own lint/fix subcommands wrap oxlint/oxfmt, which this repo does not use), `gjsify foreach` / `gjsify workspace` (replaces `yarn workspaces foreach`), `gjsify flatpak` for `apps/maker-gjs` packaging. Lockfile: `gjsify-lock.json` (no `yarn.lock`).
 
 IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning for PixelRPG tasks. Read files under `packages/` and `apps/` before assuming behavior.
 
@@ -96,7 +96,7 @@ refs: https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1-latest/css-variables
 
 ## Build / format / lint / test (root-level scripts)
 
-|`gjsify foreach build -v -t` — topological build (root `build`) |`gjsify foreach check -v -t` — type-check + barrel regen across all packages |`gjsify foreach check:barrels -v -t` — drift guard (CI: any stale barrel exits non-zero) |`gjsify foreach test -v -p --include @pixelrpg/engine --include @pixelrpg/maker-gjs --include @pixelrpg/signalling-server` — all test suites (`@gjsify/unit`; this is the root `test`; CI runs the same three suites as separate steps — use one `--include` or `gjsify workspace <pkg> test` for a single suite) |`gjsify workspace @pixelrpg/maker-gjs start` — run the editor (root `start`) |`gjsify fix` / `gjsify lint` / `gjsify format --check` — Biome wrappers (read project's `biome.json`)
+|`gjsify foreach build -v -t` — topological build (root `build`) |`gjsify foreach check -v -t` — type-check + barrel regen across all packages |`gjsify foreach check:barrels -v -t` — drift guard (CI: any stale barrel exits non-zero) |`gjsify foreach test -v -p --include @pixelrpg/engine --include @pixelrpg/maker-gjs --include @pixelrpg/signalling-server` — all test suites (`@gjsify/unit`; this is the root `test`; CI runs the same three suites as separate steps — use one `--include` or `gjsify workspace <pkg> test` for a single suite) |`gjsify workspace @pixelrpg/maker-gjs start` — run the editor (root `start`) |`gjsify run format` / `gjsify run lint` / `gjsify run check:format` — Biome direct (`biome.json`; the gjsify CLI's own lint/fix subcommands wrap oxlint/oxfmt, which this repo does not use). GTK CSS (`*.css`) is excluded from Biome — it is a GTK dialect Biome cannot parse; the gjsify CSS plugin owns it
 
 ## Flatpak (maker-gjs)
 
@@ -104,7 +104,7 @@ App-ID `org.pixelrpg.maker`. Manifest + MetaInfo + .desktop generated from `apps
 
 ## Validation & commits
 
-[Pre-commit] |no automated hook — devs run `gjsify fix && gjsify lint` manually before committing (CI does NOT lint/format-check — tracked in TODO.md "Biome cleanup + CI lint gate"; it runs type-check, build, the barrel-drift guard and the engine + maker-gjs + signalling-server test suites, with `@gjsify/cli` pinned to the gjsify-lock.json version — see `.github/workflows/ci.yml`) |`gjsify foreach build -v -t` builds all packages |`gjsify foreach check -v -t` full type check (slow) |`gjsify workspace @pixelrpg/engine test` for engine unit tests |per-pkg: `cd <pkg> && gjsify run {check,build}` |fix all errors+warnings before commit
+[Pre-commit] |no automated hook — devs run `gjsify run format && gjsify run lint` manually before committing (CI gates Biome lint+format via `biome ci`, type-check, build, the barrel-drift guard and the engine + maker-gjs + signalling-server test suites, with `@gjsify/cli` pinned to the gjsify-lock.json version — see `.github/workflows/ci.yml`) |`gjsify foreach build -v -t` builds all packages |`gjsify foreach check -v -t` full type check (slow) |`gjsify workspace @pixelrpg/engine test` for engine unit tests |per-pkg: `cd <pkg> && gjsify run {check,build}` |fix all errors+warnings before commit
 
 [Commits] |atomic, one logical change |conventional: `<type>[scope]: <description>` (feat|fix|docs|refactor|test|chore) |imperative, subject ≤50 chars, include scope |working state every commit |check `git log --oneline -10` to match project style |commit at milestones for large tasks, not just end
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,6 @@ Conventions:
 ## Testing
 
 - **Spec-registration guard** — `gjsify test` runs only the suites hand-imported into a package's `src/test.mts`; a `*.spec.ts` that isn't added there silently never runs (CI stays green testing nothing — this bit `project-operations.spec.ts`, dormant from its creation until 2026-06-07). The same hand-maintained pattern exists in **three** packages: `packages/engine`, `apps/maker-gjs`, `apps/signalling-server`. Add a shared meta-test that globs `src/**/*.spec.ts` and asserts each is imported by that package's `test.mts` (the analog of `registry.spec.ts` for commands), applied in all three. *owner: engine + maker, why: silent-skip trap*
-- **Biome cleanup + CI lint gate** — AGENTS.md prescribes `gjsify fix && gjsify lint` pre-commit, but CI has no lint/format step and ~100 Biome violations have accumulated (≈92 errors / 37 warnings via `./node_modules/.bin/biome check .` as of 2026-06-11). Also, `gjsify lint` / `gjsify format --check` on recent CLIs (≥0.4.40) wrap oxlint/oxfmt and fail with "oxlint not found" rather than wrapping Biome as documented. Plan: burn down the violations in a dedicated cleanup PR, decide the lint toolchain (Biome direct, e.g. `npx biome ci .`, vs the gjsify-oxc migration), then add the CI gate — the gate would be red today, which is why the 2026-06-11 CI-hardening PR (maker + signalling suites, CLI pin) deliberately did not add it. *owner: tooling, why: gate is red until the violations are fixed*
 
 ## Engine / runtime
 

--- a/apps/maker-gjs/src/services/cast-controller.ts
+++ b/apps/maker-gjs/src/services/cast-controller.ts
@@ -408,7 +408,8 @@ export class CastController {
    */
   private _mutateSheetAnimations(spriteSetId: string, mutator: (anims: CharacterAnimation[]) => void): void {
     const mutated = this.store.mutateSpriteSetData(spriteSetId, (data) => {
-      const anims = (data.characterAnimations ??= [])
+      data.characterAnimations ??= []
+      const anims = data.characterAnimations
       mutator(anims)
     })
     if (!mutated) return

--- a/apps/maker-gjs/src/services/data-controller.ts
+++ b/apps/maker-gjs/src/services/data-controller.ts
@@ -2,6 +2,7 @@ import { EDITOR_CONSTANTS, type SpriteSetData, type SpriteSetKind, type SpriteSe
 import { GdkSpriteSetResource } from '@pixelrpg/gjs'
 import { gettext as _ } from 'gettext'
 
+// biome-ignore lint/suspicious/noShadowRestrictedNames: GTK view-class naming convention (CastView/TilesView/DataView); the JS DataView global is unused in this app
 import type { DataAssetRow, DataView, DataViewModel } from '../widgets/data-view.ts'
 import type { ProjectStore } from './project-store.ts'
 import { isCharacterSpriteSet } from './sprite-set-classification.ts'
@@ -79,7 +80,8 @@ export class DataController {
   setProjectField(field: 'name' | 'author' | 'version' | 'description' | 'tileSize', value: string): void {
     const data = this.store.data
     if (!data) return
-    const props = (data.properties ??= {})
+    data.properties ??= {}
+    const props = data.properties
     switch (field) {
       case 'name':
         data.name = value

--- a/apps/maker-gjs/src/services/lan-discovery.ts
+++ b/apps/maker-gjs/src/services/lan-discovery.ts
@@ -108,6 +108,7 @@ export class LanBrowser {
   private process: Gio.Subprocess | null = null
   // The avahi-browse subprocess's stdout pipe — held so it stays alive
   // for the lifetime of the reader and is dropped on close().
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: write-only by design — the field exists to pin the stream against GC
   private stdoutPipe: Gio.InputStream | null = null
   private closed = false
   private onEvent: ((event: LanDiscoveryEvent) => void) | null = null

--- a/apps/maker-gjs/src/services/lan-signalling-timeout.spec.ts
+++ b/apps/maker-gjs/src/services/lan-signalling-timeout.spec.ts
@@ -15,8 +15,8 @@
  * Runs on both Node (`net`) and GJS (`@gjsify/net` Soup-backed).
  */
 
+import { createServer as createNetServer, type Server as NetServer, type Socket } from 'node:net'
 import { describe, expect, it } from '@gjsify/unit'
-import { createServer as createNetServer, type Server as NetServer, type Socket } from 'net'
 
 import { CollabTimeoutError } from './collab-log.ts'
 import { connectLanJoinerTransport } from './lan-signalling.ts'

--- a/apps/maker-gjs/src/services/lan-signalling.spec.ts
+++ b/apps/maker-gjs/src/services/lan-signalling.spec.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import { describe, expect, it, on } from '@gjsify/unit'
+import { describe, expect, it } from '@gjsify/unit'
 
 import { wrapWebSocket } from './lan-signalling.ts'
 

--- a/apps/maker-gjs/src/services/orphan-publisher-cleanup.ts
+++ b/apps/maker-gjs/src/services/orphan-publisher-cleanup.ts
@@ -73,8 +73,7 @@ export function cleanupOrphanedPublishers(): { scanned: number; killed: number; 
   try {
     const procDir = Gio.File.new_for_path(PROC_ROOT)
     const enumerator = procDir.enumerate_children('standard::name', Gio.FileQueryInfoFlags.NONE, null)
-    let info: Gio.FileInfo | null
-    while ((info = enumerator.next_file(null)) !== null) {
+    for (let info = enumerator.next_file(null); info !== null; info = enumerator.next_file(null)) {
       const name = info.get_name()
       if (!/^[0-9]+$/.test(name)) continue
       scanned++
@@ -122,7 +121,7 @@ export function isOrphanedPixelrpgPublisher(pid: number, readers: ProcReaders = 
     return false
   }
   const args = readers.readCmdlineArgs(pid)
-  if (!args || !args.includes(SERVICE_TYPE)) return false
+  if (!args?.includes(SERVICE_TYPE)) return false
   const ppid = readers.readPpid(pid)
   if (ppid == null) return false
   // PID 1 = traditional init. Some systems (Fedora's containers,

--- a/apps/maker-gjs/src/services/sandbox-path.ts
+++ b/apps/maker-gjs/src/services/sandbox-path.ts
@@ -99,7 +99,7 @@ export async function writeSnapshotToSandbox(snapshot: ProjectSnapshot, roomId: 
  */
 export async function cleanupSandboxDir(roomId: string): Promise<void> {
   const dir = resolveSandboxDir(roomId)
-  const sandboxRoot = GLib.build_filenamev([GLib.get_user_data_dir(), ...SANDBOX_ROOT_SEGMENTS]) + '/'
+  const sandboxRoot = `${GLib.build_filenamev([GLib.get_user_data_dir(), ...SANDBOX_ROOT_SEGMENTS])}/`
   if (!dir.startsWith(sandboxRoot)) {
     throw new Error(`cleanupSandboxDir: refusing to delete outside sandbox root (got "${dir}")`)
   }
@@ -119,8 +119,7 @@ function deleteRecursive(file: Gio.File): void {
   const info = file.query_info('standard::*', Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null)
   if (info.get_file_type() === Gio.FileType.DIRECTORY) {
     const enumerator = file.enumerate_children('standard::name', Gio.FileQueryInfoFlags.NOFOLLOW_SYMLINKS, null)
-    let childInfo: Gio.FileInfo | null
-    while ((childInfo = enumerator.next_file(null)) !== null) {
+    for (let childInfo = enumerator.next_file(null); childInfo !== null; childInfo = enumerator.next_file(null)) {
       const child = file.get_child(childInfo.get_name())
       deleteRecursive(child)
     }

--- a/apps/maker-gjs/src/services/session-service-e2e.spec.ts
+++ b/apps/maker-gjs/src/services/session-service-e2e.spec.ts
@@ -180,7 +180,6 @@ class LanLoopbackBackend implements SessionBackend {
     peerCallbacks: Array<(t: import('@pixelrpg/engine').SignallingTransport) => void>
   } | null = null
   private discoveryListeners = new Set<(event: LanDiscoveryEvent) => void>()
-  private peerOf: LanLoopbackBackend | null = null
 
   /** Mock LAN browse — fed manually by `simulateDiscovery`. */
   startBrowsing(onEvent: (event: LanDiscoveryEvent) => void): void {

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -43,6 +43,7 @@ import { TilesController } from '../services/tiles-controller.ts'
 import Template from './application-window.blp'
 import type { AtlasView } from './atlas-view.ts'
 import { CastView } from './cast-view.ts'
+// biome-ignore lint/suspicious/noShadowRestrictedNames: GTK view-class naming convention (CastView/TilesView/DataView); the JS DataView global is unused in this app
 import { DataView } from './data-view.ts'
 import { ObjectsView } from './objects-view.ts'
 import type { SceneEditorView } from './scene-editor-view.ts'

--- a/apps/maker-gjs/src/widgets/atlas-view.ts
+++ b/apps/maker-gjs/src/widgets/atlas-view.ts
@@ -1,4 +1,3 @@
-import Adw from '@girs/adw-1'
 import GObject from '@girs/gobject-2.0'
 import type { GameProjectResource } from '@pixelrpg/engine'
 import {

--- a/apps/maker-gjs/src/widgets/data-view.ts
+++ b/apps/maker-gjs/src/widgets/data-view.ts
@@ -53,6 +53,7 @@ const THUMB_SIZE = 44
  * project metadata. Complements the visual Cast/Tiles galleries — same
  * assets, file/management angle. See `data-controller.ts` for the data.
  */
+// biome-ignore lint/suspicious/noShadowRestrictedNames: GTK view-class naming convention (CastView/TilesView/DataView); the JS DataView global is unused in this app
 export class DataView extends ResponsiveEditorView {
   declare _outer_split: Adw.OverlaySplitView
   declare _library_toggle: Gtk.ToggleButton

--- a/apps/maker-gjs/src/widgets/scene-editor-view.ts
+++ b/apps/maker-gjs/src/widgets/scene-editor-view.ts
@@ -651,7 +651,7 @@ export class SceneEditorView extends ResponsiveEditorView {
     const palette = new TilePalette({ tileSize: 32, columns: 6, tiles: this._tiles })
     if (this._activeTileId != null) palette.selectTile(this._activeTileId)
     palette.connect('tile-selected', (_p, id) => {
-      const tile = this._tiles.find((t) => t.id === id)
+      const _tile = this._tiles.find((t) => t.id === id)
       this._setActiveTile(id)
     })
     scrolled.set_child(palette)
@@ -813,7 +813,7 @@ export class SceneEditorView extends ResponsiveEditorView {
     })
     // Global objects visibility (the pinned "Objects" pseudo-row).
     // Pure view state like the grid/dim toggles — not persisted.
-    layers.connect('objects-visibility-toggled', (_l: LayersTab, visible: boolean) => {
+    layers.connect('objects-visibility-toggled', (_l: LayersTab, _visible: boolean) => {
       this.activate_action('win.toggle-objects', null)
       // The stateful action flips engine + row state; activating with no
       // param toggles, which matches the row's already-flipped state via

--- a/apps/mcp-bridge/package.json
+++ b/apps/mcp-bridge/package.json
@@ -12,7 +12,13 @@
     "check": "tsc --noEmit",
     "start": "gjsify run dist/mcp-bridge.gjs.mjs"
   },
-  "keywords": ["pixelrpg", "mcp", "dbus", "gjs", "devtools"],
+  "keywords": [
+    "pixelrpg",
+    "mcp",
+    "dbus",
+    "gjs",
+    "devtools"
+  ],
   "author": "Pascal Garber <pascal@artandcode.studio>",
   "license": "MIT",
   "devDependencies": {

--- a/apps/signalling-server/src/room-manager.ts
+++ b/apps/signalling-server/src/room-manager.ts
@@ -87,7 +87,7 @@ export class RoomManager {
    */
   leave(roomId: string, role: PeerRole, reason: 'disconnect' | 'replaced' | 'closed' = 'disconnect'): void {
     const room = this.rooms.get(roomId)
-    if (!room || !room[role]) return
+    if (!room?.[role]) return
     room[role] = null
     room.lastActivity = this.now()
     this.log({ kind: 'left', roomId, role, reason })

--- a/apps/storybook-gjs/src/widgets/application-window.ts
+++ b/apps/storybook-gjs/src/widgets/application-window.ts
@@ -77,7 +77,9 @@ export class StorybookWindow extends Adw.ApplicationWindow {
 
     categories.forEach((stories, category) => {
       this._addCategoryToSidebar(category)
-      stories.forEach((story) => this._addStoryToSidebar(story))
+      stories.forEach((story) => {
+        this._addStoryToSidebar(story)
+      })
     })
   }
 

--- a/biome.json
+++ b/biome.json
@@ -4,9 +4,6 @@
     "enabled": true,
     "rules": {
       "recommended": true,
-      "correctness": {
-        "noUnknownTypeSelector": "off"
-      },
       "suspicious": {
         "noExplicitAny": "error"
       },
@@ -45,12 +42,15 @@
       "!**/.*",
       "!apps/maker-gjs/data",
       "!**/*.blp",
-      "!**/*.xml"
+      "!**/*.xml",
+      "!**/*.css"
     ]
   },
   "overrides": [
     {
-      "includes": ["**/*.test.ts"],
+      "includes": [
+        "**/*.test.ts"
+      ],
       "linter": {
         "rules": {
           "suspicious": {
@@ -59,5 +59,8 @@
         }
       }
     }
-  ]
+  ],
+  "assist": {
+    "enabled": false
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "start": "gjsify workspace @pixelrpg/maker-gjs start",
     "start:storybook": "gjsify workspace @pixelrpg/storybook-gjs start",
     "clear": "gjsify foreach clear -v -p",
-    "format": "gjsify fix",
-    "lint": "gjsify lint",
-    "check:format": "gjsify format --check",
+    "format": "biome check --write packages apps",
+    "lint": "biome ci packages apps",
+    "check:format": "biome format packages apps",
     "flatpak:init": "gjsify workspace @pixelrpg/maker-gjs flatpak:init",
     "flatpak:check": "gjsify workspace @pixelrpg/maker-gjs flatpak:check",
     "flatpak:build": "gjsify workspace @pixelrpg/maker-gjs flatpak:build"

--- a/packages/engine/env.d.ts
+++ b/packages/engine/env.d.ts
@@ -14,5 +14,5 @@ declare global {
   }
 
   declare const process: NodeJS.Process
-  declare const require: (path: string) => any
+  declare const require: (path: string) => unknown
 }

--- a/packages/engine/src/commands/object-placement.command.ts
+++ b/packages/engine/src/commands/object-placement.command.ts
@@ -22,7 +22,8 @@ export interface ObjectPlacementPayload {
 function addPlacement(scene: MapScene, placement: ObjectPlacement): void {
   const mapData = scene.mapResource.mapData
   if (!mapData) return
-  const list = (mapData.objectPlacements ??= [])
+  mapData.objectPlacements ??= []
+  const list = mapData.objectPlacements
   const idx = list.findIndex((p) => p.id === placement.id)
   if (idx >= 0) list[idx] = placement
   else list.push(placement)

--- a/packages/engine/src/entity/specs/npc-route.ts
+++ b/packages/engine/src/entity/specs/npc-route.ts
@@ -1,4 +1,4 @@
-import { type NpcWaypoint, NpcRouteComponent } from '../../components/index.ts'
+import { NpcRouteComponent, type NpcWaypoint } from '../../components/index.ts'
 import type { ComponentData, Facing } from '../../types/data/index.ts'
 import type { ComponentSpec } from '../component-spec.ts'
 

--- a/packages/engine/src/resource/SpriteSetResource.ts
+++ b/packages/engine/src/resource/SpriteSetResource.ts
@@ -7,6 +7,7 @@ import {
   Logger,
   type Sprite,
   SpriteSheet,
+  type SpriteSheetSpacingDimensions,
 } from 'excalibur'
 import { SpriteSetFormat } from '../format/SpriteSetFormat'
 import type { AnimationData, SpriteDataSet, SpriteSetData, SpriteSetResourceOptions } from '../types'
@@ -86,7 +87,7 @@ export class SpriteSetResource {
     let columns = 0
     let tileWidth = 0
     let tileHeight = 0
-    let spacing
+    let spacing: SpriteSheetSpacingDimensions | undefined
 
     // Check if we're using the new images array
     if (data.image) {
@@ -151,7 +152,6 @@ export class SpriteSetResource {
     data.sprites.forEach((sprite: SpriteDataSet) => {
       try {
         // Determine which spritesheet to use
-        let spriteSheet: SpriteSheet | undefined
         let imageId = 'default'
 
         // If using the new format with multiple images
@@ -166,7 +166,7 @@ export class SpriteSetResource {
           }
         }
 
-        spriteSheet = this.spriteSheets.get(imageId)
+        const spriteSheet = this.spriteSheets.get(imageId)
 
         if (!spriteSheet) {
           this.logger.warn(`No spritesheet found for image ID ${imageId}`)

--- a/packages/engine/src/services/sprite-info.resolver.ts
+++ b/packages/engine/src/services/sprite-info.resolver.ts
@@ -92,10 +92,7 @@ export function findTileIdForSpriteInfo(
  * Find a map's reference entry for the given sprite-set id. Shared by the
  * tile-id ↔ sprite-info conversions above.
  */
-function findSpriteSetRef(
-  mapData: MapResource['mapData'],
-  spriteSetId: string,
-): SpriteSetReferenceLike | undefined {
+function findSpriteSetRef(mapData: MapResource['mapData'], spriteSetId: string): SpriteSetReferenceLike | undefined {
   return mapData?.spriteSets?.find((ref: SpriteSetReferenceLike) => ref?.id === spriteSetId) as
     | SpriteSetReferenceLike
     | undefined

--- a/packages/engine/src/services/tile-paint.service.ts
+++ b/packages/engine/src/services/tile-paint.service.ts
@@ -1,5 +1,5 @@
 import { TileMap } from 'excalibur'
-import { EraseTileCommand, type PaintTilePayload, PaintTileCommand } from '../commands/index.ts'
+import { EraseTileCommand, PaintTileCommand, type PaintTilePayload } from '../commands/index.ts'
 import { MapEditorComponent, TileMapTierComponent } from '../components/index.ts'
 import type { MapScene } from '../scenes/map.scene.ts'
 import { DEFAULT_LAYER_TIER } from '../types/data/LayerData.ts'

--- a/packages/engine/src/sync/in-memory-transport.ts
+++ b/packages/engine/src/sync/in-memory-transport.ts
@@ -209,6 +209,7 @@ export function makeTransportPair(): {
  * the shared fake.
  */
 export function rtcFactoryFor(pc: FakeRTCPeerConnection): typeof RTCPeerConnection {
+  // biome-ignore lint/complexity/useArrowFunction: PeerSession invokes the factory with `new` — an arrow function is not a constructor
   return function () {
     return pc
   } as unknown as typeof RTCPeerConnection

--- a/packages/engine/src/sync/peer-session.spec.ts
+++ b/packages/engine/src/sync/peer-session.spec.ts
@@ -108,6 +108,7 @@ function pair(): {
 function factoryFor(pc: FakeRTCPeerConnection): typeof RTCPeerConnection {
   // Regular function, not an arrow — PeerSession does `new factory(...)`
   // and arrows aren't constructable.
+  // biome-ignore lint/complexity/useArrowFunction: must be `new`-able
   return function () {
     return pc
   } as unknown as typeof RTCPeerConnection

--- a/packages/engine/src/sync/peer-session.ts
+++ b/packages/engine/src/sync/peer-session.ts
@@ -234,7 +234,7 @@ export class PeerSession {
   }
 
   private send(channel: RTCDataChannel | null, payload: unknown, kind: 'op' | 'awareness'): void {
-    if (!channel || channel.readyState !== 'open') {
+    if (channel?.readyState !== 'open') {
       // A drop on awareness is fine (the next update supersedes it).
       // A drop on ops would mean state divergence; surface so the
       // caller can retry or escalate.

--- a/packages/engine/src/sync/project-operations.spec.ts
+++ b/packages/engine/src/sync/project-operations.spec.ts
@@ -35,7 +35,7 @@ import {
   type SpriteSetUpdatePayload,
 } from './project-operations.ts'
 
-function spriteSetData(id: string, imageBase64Len = 8): SpriteSetData {
+function spriteSetData(id: string, _imageBase64Len = 8): SpriteSetData {
   return {
     version: '1.0.0',
     id,

--- a/packages/engine/src/sync/project-operations.ts
+++ b/packages/engine/src/sync/project-operations.ts
@@ -295,7 +295,8 @@ export function createMapEditorDataOp(args: {
  * Idempotent — applying the same op twice yields the same state.
  */
 export function applyEntityUpsert(data: GameProjectData, entity: EntityDefinition): void {
-  const library = (data.entityLibrary ??= [])
+  data.entityLibrary ??= []
+  const library = data.entityLibrary
   const idx = library.findIndex((e) => e.id === entity.id)
   if (idx >= 0) library[idx] = entity
   else library.push(entity)
@@ -444,7 +445,8 @@ export class SpriteSetAddReassembler extends OpChunkReassembler<SpriteSetAddPayl
  * so characters that reference the set still resolve on the peer.
  */
 export function applySpriteSetReference(data: GameProjectData, reference: SpriteSetReference): void {
-  const sets = (data.spriteSets ??= [])
+  data.spriteSets ??= []
+  const sets = data.spriteSets
   const idx = sets.findIndex((s) => s.id === reference.id)
   if (idx >= 0) sets[idx] = reference
   else sets.push(reference)

--- a/packages/engine/src/sync/project-snapshot.ts
+++ b/packages/engine/src/sync/project-snapshot.ts
@@ -534,7 +534,7 @@ export async function applyProjectSnapshot(
  * — this is the last-ditch tripwire for the case where they don't.
  */
 function assertStaysInside(targetDir: string, joinedPath: string, field: string): void {
-  const normTarget = targetDir.replace(/\\/g, '/').replace(/\/+$/, '') + '/'
+  const normTarget = `${targetDir.replace(/\\/g, '/').replace(/\/+$/, '')}/`
   const normJoined = joinedPath.replace(/\\/g, '/')
   if (!normJoined.startsWith(normTarget)) {
     throw new Error(

--- a/packages/engine/src/sync/remote-cursor-renderer.ts
+++ b/packages/engine/src/sync/remote-cursor-renderer.ts
@@ -49,7 +49,7 @@ export class RemoteCursorRenderer {
 
   constructor(
     private readonly engine: Engine,
-    private readonly awareness: AwarenessManager,
+    awareness: AwarenessManager,
   ) {
     this.disposers.push(awareness.on('peer-changed', (peer) => this.applyPeer(peer)))
     this.disposers.push(awareness.on('peer-left', ({ peerId }) => this.removePeer(peerId)))

--- a/packages/engine/src/sync/snapshot-exchange.ts
+++ b/packages/engine/src/sync/snapshot-exchange.ts
@@ -29,7 +29,6 @@ import type { ProjectSnapshot } from './project-snapshot.ts'
 import {
   createSnapshotChunkOp,
   createSnapshotRequestOp,
-  createSnapshotResponseOp,
   type SessionProtocolOp,
   SNAPSHOT_CHUNK_KIND,
   SNAPSHOT_REQUEST_KIND,

--- a/packages/engine/src/types/data/object-system.spec.ts
+++ b/packages/engine/src/types/data/object-system.spec.ts
@@ -151,9 +151,9 @@ export default async () => {
     })
 
     await it('rejects bad override shapes', async () => {
-      expect(
-        isObjectPlacement({ id: 'p', layerId: 'l', tileX: 0, tileY: 0, defId: 'a', overrides: { name: 7 } }),
-      ).toBe(false)
+      expect(isObjectPlacement({ id: 'p', layerId: 'l', tileX: 0, tileY: 0, defId: 'a', overrides: { name: 7 } })).toBe(
+        false,
+      )
       expect(
         isObjectPlacement({ id: 'p', layerId: 'l', tileX: 0, tileY: 0, defId: 'a', overrides: { components: 'x' } }),
       ).toBe(false)

--- a/packages/engine/src/utils/subscription-registry.spec.ts
+++ b/packages/engine/src/utils/subscription-registry.spec.ts
@@ -6,7 +6,7 @@ export default async () => {
   await describe('SubscriptionRegistry', async () => {
     await it('primes new subscribers with the latest cached value (null if never set)', async () => {
       const reg = new SubscriptionRegistry<string, number>()
-      const listener = spy((value: number | null): void => {})
+      const listener = spy((_value: number | null): void => {})
       reg.subscribe('a', listener)
       expect(listener.calls.length).toBe(1)
       expect(listener.lastCall?.arguments[0]).toBeNull()
@@ -15,15 +15,15 @@ export default async () => {
     await it('primes new subscribers with the cached value when one exists', async () => {
       const reg = new SubscriptionRegistry<string, number>()
       reg.notify('a', 7)
-      const listener = spy((value: number | null): void => {})
+      const listener = spy((_value: number | null): void => {})
       reg.subscribe('a', listener)
       expect(listener.lastCall?.arguments[0]).toBe(7)
     })
 
     await it('broadcasts on notify to every subscriber for the same key', async () => {
       const reg = new SubscriptionRegistry<string, number>()
-      const a = spy((value: number | null): void => {})
-      const b = spy((value: number | null): void => {})
+      const a = spy((_value: number | null): void => {})
+      const b = spy((_value: number | null): void => {})
       reg.subscribe('x', a)
       reg.subscribe('x', b)
       a.reset()
@@ -35,8 +35,8 @@ export default async () => {
 
     await it('isolates broadcasts by key', async () => {
       const reg = new SubscriptionRegistry<string, number>()
-      const a = spy((value: number | null): void => {})
-      const b = spy((value: number | null): void => {})
+      const a = spy((_value: number | null): void => {})
+      const b = spy((_value: number | null): void => {})
       reg.subscribe('one', a)
       reg.subscribe('two', b)
       a.reset()
@@ -49,7 +49,7 @@ export default async () => {
     await it('supports null as the cleared-value marker', async () => {
       const reg = new SubscriptionRegistry<string, number>()
       reg.notify('k', 5)
-      const listener = spy((value: number | null): void => {})
+      const listener = spy((_value: number | null): void => {})
       reg.subscribe('k', listener)
       listener.reset()
       reg.notify('k', null)
@@ -58,7 +58,7 @@ export default async () => {
 
     await it('disconnects via the returned function', async () => {
       const reg = new SubscriptionRegistry<string, number>()
-      const listener = spy((value: number | null): void => {})
+      const listener = spy((_value: number | null): void => {})
       const dispose = reg.subscribe('k', listener)
       listener.reset()
       dispose()
@@ -68,7 +68,7 @@ export default async () => {
 
     await it('cleans empty buckets so size reflects real subscribers', async () => {
       const reg = new SubscriptionRegistry<string, number>()
-      const a = spy((value: number | null): void => {})
+      const a = spy((_value: number | null): void => {})
       const dispose = reg.subscribe('k', a)
       expect(reg.size).toBe(1)
       dispose()
@@ -79,7 +79,7 @@ export default async () => {
       const reg = new SubscriptionRegistry<string, number>()
       let dispose: (() => void) | null = null
       const a = spy<(value: number | null) => void>(() => dispose?.())
-      const b = spy((value: number | null): void => {})
+      const b = spy((_value: number | null): void => {})
       dispose = reg.subscribe('k', a)
       reg.subscribe('k', b)
       a.reset()
@@ -99,7 +99,7 @@ export default async () => {
 
     await it('clear drops listeners + cache; registry remains usable', async () => {
       const reg = new SubscriptionRegistry<string, number>()
-      const a = spy((value: number | null): void => {})
+      const a = spy((_value: number | null): void => {})
       reg.subscribe('k', a)
       reg.notify('k', 1)
       a.reset()
@@ -110,7 +110,7 @@ export default async () => {
       reg.notify('k', 2)
       expect(a.calls.length).toBe(0)
 
-      const b = spy((value: number | null): void => {})
+      const b = spy((_value: number | null): void => {})
       reg.subscribe('k', b)
       expect(b.lastCall?.arguments[0]).toBe(2)
     })

--- a/packages/gjs/src/widgets/cast/cast-inspector.ts
+++ b/packages/gjs/src/widgets/cast/cast-inspector.ts
@@ -36,9 +36,6 @@ export class CastInspector extends Adw.Bin {
   declare _sheet_name_row: Adw.EntryRow
   declare _selected_anim_row: Adw.ActionRow
   declare _duration_row: Adw.SpinRow
-
-  private _character: CharacterDefinition | null = null
-  private _animation: CharacterAnimation | null = null
   /** Set during host-driven refresh so input changes don't loop back. */
   private _silentUpdate = false
   private _sheetIds: string[] = []
@@ -135,7 +132,6 @@ export class CastInspector extends Adw.Bin {
   }
 
   setCharacter(character: CharacterDefinition | null): void {
-    this._character = character
     this._silentUpdate = true
     try {
       if (character) {
@@ -153,7 +149,6 @@ export class CastInspector extends Adw.Bin {
   }
 
   setAnimation(animation: CharacterAnimation | null): void {
-    this._animation = animation
     this._silentUpdate = true
     try {
       if (animation) {

--- a/packages/gjs/src/widgets/cast/character-preview.ts
+++ b/packages/gjs/src/widgets/cast/character-preview.ts
@@ -120,7 +120,7 @@ export class CharacterPreview extends Adw.Bin {
           'active-animation-id': GObject.ParamSpec.string(
             'active-animation-id',
             'Active Animation ID',
-            'Computed `${kind}-${direction}` id of the currently-previewed animation',
+            'Computed `<kind>-<direction>` id of the currently-previewed animation',
             GObject.ParamFlags.READABLE,
             'walk-down',
           ),

--- a/packages/gjs/src/widgets/cast/collision-preview.ts
+++ b/packages/gjs/src/widgets/cast/collision-preview.ts
@@ -81,9 +81,7 @@ export class CollisionPreview extends Gtk.Widget {
 
   vfunc_measure(orientation: Gtk.Orientation, _forSize: number): [number, number, number, number] {
     const natural =
-      orientation === Gtk.Orientation.HORIZONTAL
-        ? this._cellW * this._displayScale
-        : this._cellH * this._displayScale
+      orientation === Gtk.Orientation.HORIZONTAL ? this._cellW * this._displayScale : this._cellH * this._displayScale
     // Min stays small so the widget can shrink on narrow phones; the
     // snapshot letterboxes to the available space either way.
     const min = Math.min(natural, orientation === Gtk.Orientation.HORIZONTAL ? this._cellW * 2 : this._cellH * 2)

--- a/packages/gjs/src/widgets/cast/new-character-dialog.ts
+++ b/packages/gjs/src/widgets/cast/new-character-dialog.ts
@@ -90,7 +90,11 @@ export class NewCharacterDialog extends Adw.Dialog {
   /** Replace the list of sprite sets (and select the first). */
   setSpriteSets(choices: SpriteSetChoice[]): void {
     this._spriteSetIds = choices.map((c) => c.id)
-    this._spriteSetModel.splice(0, this._spriteSetModel.get_n_items(), choices.map((c) => c.name))
+    this._spriteSetModel.splice(
+      0,
+      this._spriteSetModel.get_n_items(),
+      choices.map((c) => c.name),
+    )
     if (choices.length > 0) this._spriteset_row.set_selected(0)
     this._refreshValidity()
     this._emitActivated()

--- a/packages/gjs/src/widgets/cast/sprite-set-import-dialog.ts
+++ b/packages/gjs/src/widgets/cast/sprite-set-import-dialog.ts
@@ -27,7 +27,7 @@ export interface SpriteSetImportResult {
   sourcePath: string
 }
 
-const DEFAULT_SPRITE_SIZE = 16
+const _DEFAULT_SPRITE_SIZE = 16
 
 /**
  * Turn a display name into a filesystem- and id-safe slug.

--- a/packages/gjs/src/widgets/editor/mini-map.ts
+++ b/packages/gjs/src/widgets/editor/mini-map.ts
@@ -116,7 +116,7 @@ export class MiniMap extends Gtk.Widget {
 
   vfunc_measure(_orientation: Gtk.Orientation, _forSize: number): [number, number, number, number] {
     const w = this.cols * this._tilePx
-    const h = this._rows.length * this._tilePx
+    const _h = this._rows.length * this._tilePx
     return [w, w, -1, -1]
   }
 

--- a/packages/gjs/src/widgets/editor/objects-tab.ts
+++ b/packages/gjs/src/widgets/editor/objects-tab.ts
@@ -3,9 +3,8 @@ import type Gdk from '@girs/gdk-4.0'
 import GLib from '@girs/glib-2.0'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
-
-import { createSwatchWidget } from './tile-palette'
 import Template from './objects-tab.blp'
+import { createSwatchWidget } from './tile-palette'
 
 /** Editor-side description of a single object placement. */
 export interface ObjectDescriptor {

--- a/packages/gjs/src/widgets/editor/scene-editor.ts
+++ b/packages/gjs/src/widgets/editor/scene-editor.ts
@@ -41,7 +41,14 @@ export class SceneEditor extends Adw.Bin {
       {
         GTypeName: 'PixelRpgSceneEditor',
         Template,
-        InternalChildren: ['overlay', 'engine_holder', 'top_bar', 'zoom_osd', 'floating_play', 'floating_collaborators'],
+        InternalChildren: [
+          'overlay',
+          'engine_holder',
+          'top_bar',
+          'zoom_osd',
+          'floating_play',
+          'floating_collaborators',
+        ],
       },
       SceneEditor,
     )

--- a/packages/gjs/src/widgets/editor/scene-inspector.ts
+++ b/packages/gjs/src/widgets/editor/scene-inspector.ts
@@ -11,13 +11,6 @@ import Template from './scene-inspector.blp'
 GObject.type_ensure(MiniMap.$gtype)
 GObject.type_ensure(MapPreview.$gtype)
 
-interface SceneStats {
-  npcs: number
-  events: number
-  incoming: number
-  outgoing: number
-}
-
 interface TeleportSummary {
   label: string
   /** Other-scene id (destination when outgoing, source when incoming). */
@@ -183,7 +176,7 @@ export class SceneInspector extends Adw.Bin {
     const tilePx = Math.max(1, Math.floor(Math.min(desiredWidth / cols, desiredHeight / rows)))
 
     // Real-project path: render the scene's tile data via MapPreview.
-    if (this._projectResource && this._projectResource.maps.has(this._scene.id)) {
+    if (this._projectResource?.maps.has(this._scene.id)) {
       const preview = new MapPreview()
       preview.accentColor = this._scene.previewColor ?? '#3a3a40'
       preview.set_size_request(desiredWidth, desiredHeight)


### PR DESCRIPTION
Burns down all ~87 Biome findings and adds the CI gate (resolves the TODO entry from #197).

**Policy decisions:**
- **GTK CSS excluded from Biome** (`!**/*.css`): `@window_bg_color`/`alpha()` is a GTK dialect Biome structurally cannot parse (34 of the findings were parse errors). The gjsify CSS plugin owns CSS; noted in AGENTS.md.
- **organizeImports assist disabled**: it re-sorts the `gjsify barrels`-GENERATED index files — two generators fighting over export order.
- **`DataView`** keeps its name (GTK view-class convention CastView/TilesView/DataView) with reasoned biome-ignores at the 3 shadow sites.
- 7× `(x ??= y)`-in-expression rewritten as two statements; 2 while-assign loops → for-loops. The safety rule stays on.
- Root scripts `lint`/`format`/`check:format` now call Biome directly (`biome ci packages apps` etc.) — the gjsify CLI's own lint/fix wrap oxlint/oxfmt, which this repo doesn't use. AGENTS.md toolchain + pre-commit lines aligned.
- **CI**: new `biome ci packages apps` step before type-check.

**Unsafe-fix review caught 3 real would-be breakages** (kept/reverted deliberately, with reasoned ignores): the spec's RTC factory must stay a `function` (PeerSession calls `new factory()` — the arrow conversion broke 10 tests before I caught it), `LanBrowser.stdoutPipe` is write-only by design (pins the stream against GC), and cast-inspector's deleted write-only members needed their dead writes removed too.

Validated: `biome ci` clean (379 files), `foreach check` clean, engine 717 / maker / signalling suites green.