### PR TITLE
docs(zelda-like): credits + fan-project license

### DIFF
--- a/games/zelda-like/CREDITS.md
+++ b/games/zelda-like/CREDITS.md
@@ -1,0 +1,36 @@
+# Credits
+
+This is a **non-commercial, educational fan project** (see [LICENSE.md](LICENSE.md)).
+It exists to exercise and showcase the PixelRPG engine + editor — not to be
+distributed as a game.
+
+## Source material & inspiration
+
+- **The Legend of Zelda™: Ocarina of Time** — original game, characters,
+  locations and all related trademarks are the property of **Nintendo**.
+  This project is unofficial and is **not affiliated with or endorsed by
+  Nintendo** in any way.
+
+## Ported assets & maps
+
+- **Kokiri Forest map** — ported from the Tiled map in
+  [Colbydude/OoT2DUnity](https://github.com/Colbydude/OoT2DUnity)
+  (`Assets/Tiled/Maps/Kokiri Forest.tmx`), a fan remake of Ocarina of Time
+  in Unity by **Colbydude**. Thank you for the meticulously rebuilt map!
+- **Link character graphics** — from **OoT 2D 2014** (v.15.2) by the
+  [oot-2d.com](http://www.oot-2d.com/) team (`Graphics/Link.png`),
+  recomposed onto a uniform sprite grid for the PixelRPG sprite-set format.
+- The original pixel art in both projects derives from Nintendo's
+  *The Legend of Zelda* games; see the Nintendo notice above.
+
+## Engine & editor
+
+- Built with [PixelRPG](https://github.com/PixelRPG/map-editor) —
+  Excalibur.js running natively on GJS/GTK4 via
+  [gjsify](https://github.com/gjsify/gjsify).
+
+## How to credit additions
+
+When you port further assets or maps into this game, add an entry here
+**in the same commit** — source project, author, link, and which files
+were derived from it.

--- a/games/zelda-like/LICENSE.md
+++ b/games/zelda-like/LICENSE.md
@@ -1,0 +1,71 @@
+# Non-Commercial Educational Fan Project License (NCEFPL-PixelRPG 1.0)
+
+Copyright (c) 2026 the PixelRPG contributors
+
+This game project, **zelda-like**, is a non-commercial fan-made project
+developed for **educational, experimental, and technical learning purposes
+only** — it exists to exercise the PixelRPG engine and editor.
+
+> Adapted and extended from the "Non-Commercial Educational Fan Project
+> License" written by David Daumand for *Zelda – Ocarina of Time 2D (Unity)*.
+> Like the original, this is a custom license, not an OSI/SPDX-registered
+> one. It deliberately distinguishes what we CAN license (our own work)
+> from what we CANNOT (Nintendo's intellectual property).
+
+---
+
+## 1. Scope — what this license covers (and what it cannot)
+
+**Covered:** the original work in this directory — map-data files, JSON
+descriptors, scripts, configuration and documentation authored by the
+PixelRPG contributors.
+
+**NOT covered — and not licensable by us:** all trademarks, characters,
+names, locations, music, and pixel art derived from *The Legend of Zelda*.
+These remain the exclusive property of **Nintendo**. Nothing in this
+license grants you any right to Nintendo's intellectual property. This
+project is unofficial and is **not affiliated with or endorsed by
+Nintendo**.
+
+**Third-party fan work:** assets and maps ported from other fan projects
+(see [CREDITS.md](CREDITS.md)) remain subject to their authors' original
+terms. Credit entries must be preserved in any fork.
+
+## 2. Permissions
+
+You may:
+
+- view, study, run and modify this project locally for learning,
+  experimentation and engine development;
+- fork the repository for the same purposes, keeping this license and
+  [CREDITS.md](CREDITS.md) intact;
+- reuse the **original** data formats, scripts and tooling under the terms
+  of the surrounding PixelRPG repository's license.
+
+## 3. Restrictions
+
+You may not:
+
+- distribute builds of this game to the public (in stores, on websites,
+  bundled with other software, or otherwise);
+- sell, monetize, or commercially exploit any part of this project,
+  including via ads, sponsorship, paywalls or donations tied to it;
+- claim ownership of Nintendo's intellectual property or of the credited
+  third-party fan work;
+- remove or obscure the credits or this license in forks.
+
+## 4. Takedown
+
+If a rights holder objects to any content in this project, that content
+will be removed promptly. Forks are expected to honour takedowns the same
+way. This clause exists because fan projects live on goodwill.
+
+## 5. No warranty
+
+This project is provided **"as is"**, without warranty of any kind. The
+authors are not liable for any damage resulting from its use.
+
+## 6. Termination
+
+Violating these terms automatically ends your permission to use the
+covered work.


### PR DESCRIPTION
Adds the missing attribution for the zelda-like demo game and answers the licensing question for fan content:

- **CREDITS.md** — Kokiri Forest map ported from [Colbydude/OoT2DUnity](https://github.com/Colbydude/OoT2DUnity); Link graphics (upcoming port) from [oot-2d.com](http://www.oot-2d.com/)'s OoT 2D 2014; explicit Nintendo non-affiliation notice; a rule that future ports must add their entry in the same commit.
- **LICENSE.md** — an adapted + improved "Non-Commercial Educational Fan Project License" (the original by David Daumand is a custom, non-SPDX license). Improvements over the source text: explicitly separates what we CAN license (our original data/scripts) from what we CANNOT (Nintendo IP — explicitly not granted), preserves third-party fan-work terms + credits in forks, and adds a takedown clause.