### PR TITLE
feat(maker): list oot2d-2014 world as template

### DIFF
--- a/apps/maker-gjs/src/services/templates.ts
+++ b/apps/maker-gjs/src/services/templates.ts
@@ -57,6 +57,13 @@ export const STARTER_TEMPLATES: ProjectTemplate[] = [
     projectPath: `${TEMPLATES_ROOT}/zelda-like/game-project.json`,
     accentColor: '#3d6b3a',
   },
+  {
+    id: 'oot2d-2014',
+    name: 'OoT2D 2014 World',
+    caption: '19 converted reference maps · 8px tiles',
+    projectPath: `${TEMPLATES_ROOT}/oot2d-2014/game-project.json`,
+    accentColor: '#c4a24c',
+  },
 ]
 
 /** Convenience: look up the template used by the *New Project* flow. */

--- a/games/zelda-like/maps/tree-house-cozy.json
+++ b/games/zelda-like/maps/tree-house-cozy.json
@@ -711,7 +711,7 @@
     }
   ],
   "editorData": {
-    "atlasX": 80,
-    "atlasY": 130
+    "atlasX": 669,
+    "atlasY": 393
   }
 }


### PR DESCRIPTION
The welcome view's template list is hardcoded (`STARTER_TEMPLATES`), so the new `games/oot2d-2014` world from #212 wasn't discoverable — it only opened via the explicit file dialog. Adds its card ('OoT2D 2014 World — 19 converted reference maps · 8px tiles') so it shows up on the welcome screen and in `list_templates`/`ListTemplates`.