### PR TITLE
feat(engine): support map background colour

### DIFF
--- a/games/oot2d-2014/maps/bombchu.json
+++ b/games/oot2d-2014/maps/bombchu.json
@@ -2,6 +2,7 @@
  "id": "bombchu",
  "name": "Bombchu",
  "version": "1.0.0",
+ "backgroundColor": "#303030",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 30,

--- a/games/oot2d-2014/maps/castle.json
+++ b/games/oot2d-2014/maps/castle.json
@@ -2,6 +2,7 @@
  "id": "castle",
  "name": "Castle",
  "version": "1.0.0",
+ "backgroundColor": "#409740",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 123,
@@ -58254,5 +58255,8 @@
   "source": "Maps/Castle.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 433,
+  "atlasY": 62
+ }
 }

--- a/games/oot2d-2014/maps/deku-0.json
+++ b/games/oot2d-2014/maps/deku-0.json
@@ -2,6 +2,7 @@
  "id": "deku-0",
  "name": "Deku 0",
  "version": "1.0.0",
+ "backgroundColor": "#544429",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 325,

--- a/games/oot2d-2014/maps/end.json
+++ b/games/oot2d-2014/maps/end.json
@@ -2,6 +2,7 @@
  "id": "end",
  "name": "End",
  "version": "1.0.0",
+ "backgroundColor": "#2C2C2C",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 33,
@@ -821,5 +822,8 @@
   "source": "Maps/End.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 214,
+  "atlasY": 163
+ }
 }

--- a/games/oot2d-2014/maps/field.json
+++ b/games/oot2d-2014/maps/field.json
@@ -2,6 +2,7 @@
  "id": "field",
  "name": "Field",
  "version": "1.0.0",
+ "backgroundColor": "#409740",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 372,
@@ -162354,5 +162355,8 @@
   "source": "Maps/Field.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 390,
+  "atlasY": 470
+ }
 }

--- a/games/oot2d-2014/maps/guards.json
+++ b/games/oot2d-2014/maps/guards.json
@@ -2,6 +2,7 @@
  "id": "guards",
  "name": "Guards",
  "version": "1.0.0",
+ "backgroundColor": "#409740",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 204,
@@ -39750,5 +39751,8 @@
   "source": "Maps/Guards.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 1060,
+  "atlasY": 331
+ }
 }

--- a/games/oot2d-2014/maps/houses-kokiri.json
+++ b/games/oot2d-2014/maps/houses-kokiri.json
@@ -2,6 +2,7 @@
  "id": "houses-kokiri",
  "name": "Houses Kokiri",
  "version": "1.0.0",
+ "backgroundColor": "#623E3B",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 194,
@@ -27732,5 +27733,8 @@
   "source": "Maps/Houses_Kokiri.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 1145,
+  "atlasY": 532
+ }
 }

--- a/games/oot2d-2014/maps/houses-ranch.json
+++ b/games/oot2d-2014/maps/houses-ranch.json
@@ -2,6 +2,7 @@
  "id": "houses-ranch",
  "name": "Houses Ranch",
  "version": "1.0.0",
+ "backgroundColor": "#382828",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 102,
@@ -25722,5 +25723,8 @@
   "source": "Maps/Houses_Ranch.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 1664,
+  "atlasY": 426
+ }
 }

--- a/games/oot2d-2014/maps/houses.json
+++ b/games/oot2d-2014/maps/houses.json
@@ -2,6 +2,7 @@
  "id": "houses",
  "name": "Houses",
  "version": "1.0.0",
+ "backgroundColor": "#382828",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 124,
@@ -15798,5 +15799,8 @@
   "source": "Maps/Houses.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 30,
+  "atlasY": 555
+ }
 }

--- a/games/oot2d-2014/maps/kakariko.json
+++ b/games/oot2d-2014/maps/kakariko.json
@@ -2,6 +2,7 @@
  "id": "kakariko",
  "name": "Kakariko",
  "version": "1.0.0",
+ "backgroundColor": "#489848",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 166,

--- a/games/oot2d-2014/maps/kokiri-forest.json
+++ b/games/oot2d-2014/maps/kokiri-forest.json
@@ -2,6 +2,7 @@
  "id": "kokiri-forest",
  "name": "Kokiri Forest",
  "version": "1.0.0",
+ "backgroundColor": "#768D2D",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 218,
@@ -127110,5 +127111,8 @@
   "source": "Maps/Kokiri_Forest.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 1827,
+  "atlasY": 715
+ }
 }

--- a/games/oot2d-2014/maps/lost-woods.json
+++ b/games/oot2d-2014/maps/lost-woods.json
@@ -2,6 +2,7 @@
  "id": "lost-woods",
  "name": "Lost Woods",
  "version": "1.0.0",
+ "backgroundColor": "#768D2D",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 296,
@@ -155760,5 +155761,8 @@
   "source": "Maps/Lost_Woods.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 1195,
+  "atlasY": 683
+ }
 }

--- a/games/oot2d-2014/maps/market-central.json
+++ b/games/oot2d-2014/maps/market-central.json
@@ -2,6 +2,7 @@
  "id": "market-central",
  "name": "Market Central",
  "version": "1.0.0",
+ "backgroundColor": "#489848",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 102,
@@ -46800,5 +46801,8 @@
   "source": "Maps/Market_Central.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 46,
+  "atlasY": 1101
+ }
 }

--- a/games/oot2d-2014/maps/market-enter.json
+++ b/games/oot2d-2014/maps/market-enter.json
@@ -2,6 +2,7 @@
  "id": "market-enter",
  "name": "Market Enter",
  "version": "1.0.0",
+ "backgroundColor": "#489848",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 32,
@@ -4878,5 +4879,8 @@
   "source": "Maps/Market_Enter.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 1888,
+  "atlasY": 175
+ }
 }

--- a/games/oot2d-2014/maps/pots.json
+++ b/games/oot2d-2014/maps/pots.json
@@ -2,6 +2,7 @@
  "id": "pots",
  "name": "Pots",
  "version": "1.0.0",
+ "backgroundColor": "#2A2E28",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 24,
@@ -4506,5 +4507,8 @@
   "source": "Maps/Pots.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 1624,
+  "atlasY": 127
+ }
 }

--- a/games/oot2d-2014/maps/ranch.json
+++ b/games/oot2d-2014/maps/ranch.json
@@ -2,6 +2,7 @@
  "id": "ranch",
  "name": "Ranch",
  "version": "1.0.0",
+ "backgroundColor": "#4A9649",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 114,
@@ -55104,5 +55105,8 @@
   "source": "Maps/Ranch.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 109,
+  "atlasY": 1339
+ }
 }

--- a/games/oot2d-2014/maps/shooting-gallery.json
+++ b/games/oot2d-2014/maps/shooting-gallery.json
@@ -2,6 +2,7 @@
  "id": "shooting-gallery",
  "name": "Shooting Gallery",
  "version": "1.0.0",
+ "backgroundColor": "#303030",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 24,
@@ -4386,5 +4387,8 @@
   "source": "Maps/Shooting_Gallery.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 507,
+  "atlasY": 1486
+ }
 }

--- a/games/oot2d-2014/maps/smb.json
+++ b/games/oot2d-2014/maps/smb.json
@@ -2,6 +2,7 @@
  "id": "smb",
  "name": "SMB",
  "version": "1.0.0",
+ "backgroundColor": "#5C94FC",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 448,
@@ -19067,5 +19068,8 @@
   "source": "Maps/SMB.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 554,
+  "atlasY": 1296
+ }
 }

--- a/games/oot2d-2014/maps/windmill.json
+++ b/games/oot2d-2014/maps/windmill.json
@@ -2,6 +2,7 @@
  "id": "windmill",
  "name": "Windmill",
  "version": "1.0.0",
+ "backgroundColor": "#606060",
  "tileWidth": 8,
  "tileHeight": 8,
  "columns": 32,
@@ -4794,5 +4795,8 @@
   "source": "Maps/Windmill.zmap from 'The Legend of Zelda: Ocarina of Time 2D' v0.10.2 by CheerfulSage & GodsTurf (oot-2d.com, 2014) \u2014 archive the-legend-of-zelda-ocarina-of-time-2d-0-10-2-en-win.zip in the PixelRPG/oot-2d repo; converted by tools/export-pixelrpg-maps.py (zmap parser: fluxcompile/oot2d-map)"
  },
  "objectPlacements": [],
- "editorData": {}
+ "editorData": {
+  "atlasX": 81,
+  "atlasY": 1647
+ }
 }

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -296,6 +296,16 @@ export class Engine {
       newMapScene.camera.zoom = carryZoom
     }
 
+    // Map-declared room colour → GL clear colour. A colour *actor*
+    // would go through Excalibur's `Rectangle` Raster (2D-canvas
+    // rasterise), which the GJS canvas path doesn't survive — the
+    // clear colour is pure GL and also matches the original-game
+    // semantic (fill the screen, tiles on top). Reset to transparent
+    // for maps without one so the editor backdrop shows through.
+    this.excalibur.backgroundColor = mapResource.mapData.backgroundColor
+      ? Color.fromHex(mapResource.mapData.backgroundColor)
+      : Color.Transparent
+
     // Re-entry: drop the stale scene instance so addScene doesn't
     // collide and the room rebuilds fresh from data.
     if (this.excalibur.scenes[mapId]) this.excalibur.removeScene(mapId)

--- a/packages/engine/src/types/data/MapData.ts
+++ b/packages/engine/src/types/data/MapData.ts
@@ -59,6 +59,15 @@ export interface MapData {
   version: string
 
   /**
+   * Optional solid fill colour (`#rrggbb`) painted across the map
+   * bounds *below* every tile layer. Sparse maps (ported games often
+   * store only detail tiles over a flat room colour) rely on this to
+   * not render as void — the engine adds a background rect and the
+   * editor's previews fill with it. Absent = transparent.
+   */
+  backgroundColor?: string
+
+  /**
    * Array of layers that make up the map
    * Each layer's tiles will be converted to Excalibur Tiles
    * Multiple layers allow for:

--- a/packages/gjs/src/widgets/editor/map-preview.ts
+++ b/packages/gjs/src/widgets/editor/map-preview.ts
@@ -49,6 +49,8 @@ export class MapPreview extends Gtk.Widget {
   private _mapWidth = 0
   private _mapHeight = 0
   private _accentColor: Gdk.RGBA
+  /** Map-declared fill behind the tiles (`MapData.backgroundColor`). */
+  private _mapBackground: Gdk.RGBA | null = null
   private _loaded = false
   // The composited tiles, rasterised to ONE texture so repaints (atlas
   // pan, card hover) are O(1) instead of re-rendering N clipped tile nodes
@@ -141,6 +143,12 @@ export class MapPreview extends Gtk.Widget {
     this._mapWidth = mapData.columns * mapData.tileWidth
     this._mapHeight = mapData.rows * mapData.tileHeight
 
+    this._mapBackground = null
+    if (mapData.backgroundColor) {
+      const rgba = new Gdk.RGBA()
+      if (rgba.parse(mapData.backgroundColor)) this._mapBackground = rgba
+    }
+
     const ops: DrawOp[] = []
     for (const layer of mapData.layers ?? []) {
       if (!layer.visible || !layer.sprites) continue
@@ -175,13 +183,18 @@ export class MapPreview extends Gtk.Widget {
     background.init(0, 0, width, height)
     snapshot.append_color(this._accentColor, background)
 
-    if (!this._loaded || !this._ops.length || !this._mapWidth || !this._mapHeight) return
+    if (!this._loaded || !this._mapWidth || !this._mapHeight) return
 
     const scale = Math.min(width / this._mapWidth, height / this._mapHeight)
     const dw = this._mapWidth * scale
     const dh = this._mapHeight * scale
     const dest = new Graphene.Rect()
     dest.init((width - dw) / 2, (height - dh) / 2, dw, dh)
+
+    // The map's own room colour sits below the tiles (the bake also
+    // includes it; this covers the pre-bake paint + ops-free maps).
+    if (this._mapBackground && !this._baked) snapshot.append_color(this._mapBackground, dest)
+    if (!this._ops.length && !this._baked) return
 
     // Fast path: paint the pre-rasterised composite (one texture).
     if (this._baked) {
@@ -221,11 +234,12 @@ export class MapPreview extends Gtk.Widget {
     // thumbnail texture (it's only ever shown card-sized).
     const bakeScale = Math.min(1, BAKE_MAX_EDGE / Math.max(this._mapWidth, this._mapHeight))
     const sub = Gtk.Snapshot.new()
+    const region = new Graphene.Rect()
+    region.init(0, 0, this._mapWidth * bakeScale, this._mapHeight * bakeScale)
+    if (this._mapBackground) sub.append_color(this._mapBackground, region)
     for (const op of this._ops) this._paintTile(sub, op, bakeScale)
     const node = sub.to_node()
     if (!node) return null
-    const region = new Graphene.Rect()
-    region.init(0, 0, this._mapWidth * bakeScale, this._mapHeight * bakeScale)
     try {
       return renderer.render_texture(node, region)
     } catch (error) {


### PR DESCRIPTION
## Problem

The mass-ported OoT2D-2014 maps (#212) showed a hard render defect: large void areas and 'strange artifacts'. Root cause: the original `.zmap` format carries a per-room **background colour** in its header — the 2014 game fills the whole screen with it before painting tiles, so sparse maps (Field stores tiles for only ~19% of its 372×380 cells) rely on it for the grass/floor. Our converter dropped it.

## Changes

- **`MapData.backgroundColor`** — optional `#rrggbb`, documented as a fill below all tile layers.
- **Engine**: `loadMap` maps it onto the Excalibur **GL clear colour** (reset to transparent for maps without one). A colour `Actor` was tried first but goes through Excalibur's `Rectangle` Raster (2D-canvas rasterise + texture upload) — the clear colour is pure GL and matches the original game's fill-the-screen semantic.
- **`MapPreview`**: fills the map bounds with the colour in both the direct paint and the baked texture — atlas cards + welcome thumbnails now show the real room colours.
- **Data**: `backgroundColor` injected into all 19 `games/oot2d-2014` maps from their zmap headers (exporter updated in PixelRPG/oot-2d@e3ea382; values range from Field's grass `#409740` to SMB's classic sky `#5C94FC`).

## Verification

- Atlas previews verified visually (Field/Castle/Guards green, Deku brown, Lost Woods olive — matches the reference renders from `tools/export-maps.py`).
- `@pixelrpg/engine` check + 748 tests green, `@pixelrpg/gjs` check green.
- Engine-scene visual check pending a stable GL init — the intermittent engine-init segfault (pre-existing, see TODO) fired repeatedly during validation **before any map code ran** (`Loading map:` never logged), so it is unrelated to this change.