### PR TITLE
perf(gjs): bake map previews off-frame through a queue

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,11 +47,12 @@ Conventions:
 
 ## Atlas / world
 
-- **Real scene-card thumbnails for very large maps** — `MapPreview` works but a 176×148 map renders ~26k snapshot ops. Acceptable today; if it becomes a bottleneck cap the max ops per preview (downsample, every Nth tile). *owner: gjs (MapPreview)*
+- **Viewport scene-card previews** — show every map at a uniform pixel zoom (~300%) cropped to an adjustable section (persisted as `editorData.preview`) instead of fit-whole-map, so all cards share one resolution and content stays recognizable. Open design points: card geometry (uniform card size vs map-proportional) and the in-card pan gesture (must not collide with card dragging — candidates: Ctrl/middle-drag, or an edit-viewport toggle). Prereq shipped: `MapPreview` bakes off-frame through a queue + content-fingerprint LRU cache (so a re-bake per pan step is cheap and whole-map data stays available). *owner: gjs (MapPreview) + maker (persistence via the `scene-moved` → `map.editor-data` pattern)*
+- **Atlas load time for big projects** — opening `games/oot2d-2014` (19 maps, 18 MB) takes ~19 s to the atlas; the project now loads **twice** (`loadProjectAsAtlas` + the welcome/engine path each construct a `GameProjectResource`) and repeated loads in one session can OOM GJS. Deduplicate to one shared resource per open project (existing "GameProjectResource double copy" debt) and consider lazy map parsing. *owner: maker / engine*
 
 ## Welcome / project lifecycle
 
-- **Template thumbnail caching** — every welcome show currently reloads each template's project + sprite-sets to render previews. Cache rendered previews in a `WeakMap<projectPath, Gdk.Texture>` once the first paint lands. *owner: maker / gjs*
+- **Template thumbnail caching** — partially shipped: `MapPreview` keeps baked textures in a fingerprint-keyed LRU, so welcome re-shows paint instantly (a per-path entry serves first, then refreshes in the background). Still open: the background refresh re-parses each template project on every welcome show — skip the reload when the project file's mtime is unchanged. *owner: maker / gjs*
 
 ## Cleanup / debt
 

--- a/packages/gjs/src/widgets/editor/map-preview.ts
+++ b/packages/gjs/src/widgets/editor/map-preview.ts
@@ -29,20 +29,44 @@ interface SheetRange {
   sheet: GdkSpriteSheet
 }
 
+/** A finished bake, kept so widget rebuilds don't re-render the map. */
+interface BakedPreview {
+  texture: Gdk.Texture
+  mapWidth: number
+  mapHeight: number
+}
+
 /**
- * Renders a static thumbnail of a project's first map by compositing
- * each tile sprite onto a `Gtk.Snapshot`. Used by the welcome view's
- * template cards and the recent-projects list.
+ * Renders a static thumbnail of a project map by compositing each
+ * tile sprite onto a `Gtk.Snapshot`. Used by the welcome view's
+ * template cards, the recent-projects list and the atlas scene cards.
  *
  * Why a custom widget instead of an `Engine`: each `Engine` would spin
  * up its own Excalibur runtime + GL context, which is wasteful for
  * tiny static previews. This widget loads the project, decodes the
- * sprite-sheets via the existing `GdkSpriteSetResource` pipeline, and
- * batches one `append_scaled_texture` call per tile. GTK caches the
- * resulting GSK tree, so the per-tile cost is paid exactly once.
+ * sprite-sheets via the existing `GdkSpriteSetResource` pipeline and
+ * rasterises the tiles ONCE into a small texture (the "bake").
+ *
+ * Rendering strategy (the ported worlds have 100k+ tiles, so the
+ * naive paint-every-tile path is too hot for the main loop):
+ *
+ * - The widget itself never paints individual tiles. Until its bake
+ *   is ready it shows the accent colour + the map's own
+ *   `backgroundColor`; then it paints the baked texture (O(1)).
+ * - Bakes run through a module-wide queue, ONE per main-loop idle at
+ *   idle priority — 19 atlas cards become 19 short steps between
+ *   frames instead of one multi-second stall.
+ * - Finished bakes land in a small LRU cache keyed by a content
+ *   fingerprint of the map, so re-entering the atlas (which rebuilds
+ *   the cards) reuses the textures instead of re-rendering. The
+ *   welcome view's per-path lookups serve the cached texture
+ *   instantly and then refresh it in the background.
  */
 /** Cap the baked preview texture's longest edge — these are small thumbnails. */
 const BAKE_MAX_EDGE = 512
+
+/** Baked textures kept across widget rebuilds (≤512px ≈ ≤1 MB each). */
+const BAKE_CACHE_MAX = 48
 
 export class MapPreview extends Gtk.Widget {
   private _ops: DrawOp[] = []
@@ -52,12 +76,60 @@ export class MapPreview extends Gtk.Widget {
   /** Map-declared fill behind the tiles (`MapData.backgroundColor`). */
   private _mapBackground: Gdk.RGBA | null = null
   private _loaded = false
-  // The composited tiles, rasterised to ONE texture so repaints (atlas
-  // pan, card hover) are O(1) instead of re-rendering N clipped tile nodes
-  // every frame. Invalidated whenever the tile ops change; rebuilt lazily
-  // off the first paint (when the widget has a renderer).
   private _baked: Gdk.Texture | null = null
-  private _bakeScheduled = false
+  /** Cache slot for this widget's current map (see `_cacheStore`). */
+  private _cacheKey: string | null = null
+
+  // ── module-wide bake machinery ────────────────────────────────────
+  private static _cache = new Map<string, BakedPreview>()
+  private static _queue: MapPreview[] = []
+  private static _pumpScheduled = false
+
+  private static _enqueue(preview: MapPreview): void {
+    if (!MapPreview._queue.includes(preview)) MapPreview._queue.push(preview)
+    MapPreview._pump()
+  }
+
+  /** One bake per idle tick so the frame clock breathes between bakes. */
+  private static _pump(): void {
+    if (MapPreview._pumpScheduled || !MapPreview._queue.length) return
+    MapPreview._pumpScheduled = true
+    GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+      MapPreview._pumpScheduled = false
+      MapPreview._queue.shift()?._runBake()
+      MapPreview._pump()
+      return GLib.SOURCE_REMOVE
+    })
+  }
+
+  private static _cacheStore(key: string, baked: BakedPreview): void {
+    // Refresh insertion order so eviction is least-recently-stored.
+    MapPreview._cache.delete(key)
+    MapPreview._cache.set(key, baked)
+    if (MapPreview._cache.size > BAKE_CACHE_MAX) {
+      const oldest = MapPreview._cache.keys().next().value
+      if (oldest !== undefined) MapPreview._cache.delete(oldest)
+    }
+  }
+
+  /**
+   * Cheap content stamp for cache keys: tile edits change the sum, so
+   * a re-entered atlas re-bakes exactly the maps that changed. Not
+   * cryptographic — a collision merely shows a stale thumbnail.
+   */
+  private static _fingerprint(mapData: MapData): number {
+    let hash = ((mapData.columns * 73856093) ^ (mapData.rows * 19349663)) | 0
+    for (const layer of mapData.layers ?? []) {
+      if (!layer.visible || !layer.sprites) continue
+      hash = (hash * 31 + layer.sprites.length) | 0
+      for (const tile of layer.sprites) {
+        hash = (hash + tile.x * 31 + tile.y * 131 + tile.spriteId * 7) | 0
+      }
+    }
+    const background = mapData.backgroundColor ?? ''
+    for (let i = 0; i < background.length; i++) hash = (hash * 33 + background.charCodeAt(i)) | 0
+    return hash >>> 0
+  }
 
   static {
     GObject.registerClass(
@@ -94,10 +166,16 @@ export class MapPreview extends Gtk.Widget {
    * the widget renders the accent placeholder).
    *
    * Used by the welcome view, where each template card owns its own
-   * fetch. Atlas/inspector previews reuse the already-loaded resource
-   * via {@link setFromResource}.
+   * fetch. A previously baked texture for the same project paints
+   * immediately; the load then continues in the background and swaps
+   * in a fresh bake (so an edited project heals its thumbnail).
+   * Atlas/inspector previews reuse the already-loaded resource via
+   * {@link setFromResource}.
    */
   async loadProject(projectPath: string): Promise<void> {
+    const pathKey = `path:${projectPath}`
+    const cached = MapPreview._cache.get(pathKey)
+    if (cached) this._showBaked(pathKey, cached)
     try {
       const resource = new GameProjectResource(projectPath, {
         preloadAllMaps: true,
@@ -109,7 +187,7 @@ export class MapPreview extends Gtk.Widget {
         this._loaded = true
         return
       }
-      await this._populateFromMap(firstMap, await this._collectSheets(resource, firstMap.spriteSets ?? []))
+      await this._populateFromMap(firstMap, await this._collectSheets(resource, firstMap.spriteSets ?? []), pathKey)
     } catch (error) {
       console.warn('[MapPreview] Failed to render preview:', error)
       this._loaded = true
@@ -122,7 +200,8 @@ export class MapPreview extends Gtk.Widget {
    * inspector) has already parsed the project file.
    *
    * Pass a specific `mapId` to render a non-default map; otherwise
-   * the project's first map is used.
+   * the project's first map is used. A cache hit (same map content)
+   * skips sprite-sheet collection and the bake entirely.
    */
   async setFromResource(resource: GameProjectResource, mapId?: string): Promise<void> {
     try {
@@ -132,16 +211,33 @@ export class MapPreview extends Gtk.Widget {
         this.queue_draw()
         return
       }
-      await this._populateFromMap(mapData, await this._collectSheets(resource, mapData.spriteSets ?? []))
+      const cacheKey = `map:${resource.path}:${mapData.id}:${MapPreview._fingerprint(mapData)}`
+      const cached = MapPreview._cache.get(cacheKey)
+      if (cached) {
+        this._showBaked(cacheKey, cached)
+        return
+      }
+      await this._populateFromMap(mapData, await this._collectSheets(resource, mapData.spriteSets ?? []), cacheKey)
     } catch (error) {
       console.warn('[MapPreview] Failed to render preview:', error)
       this._loaded = true
     }
   }
 
-  private async _populateFromMap(mapData: MapData, ranges: SheetRange[]): Promise<void> {
+  private _showBaked(cacheKey: string, baked: BakedPreview): void {
+    this._cacheKey = cacheKey
+    this._baked = baked.texture
+    this._mapWidth = baked.mapWidth
+    this._mapHeight = baked.mapHeight
+    this._ops = []
+    this._loaded = true
+    this.queue_draw()
+  }
+
+  private async _populateFromMap(mapData: MapData, ranges: SheetRange[], cacheKey: string | null): Promise<void> {
     this._mapWidth = mapData.columns * mapData.tileWidth
     this._mapHeight = mapData.rows * mapData.tileHeight
+    this._cacheKey = cacheKey
 
     this._mapBackground = null
     if (mapData.backgroundColor) {
@@ -170,7 +266,8 @@ export class MapPreview extends Gtk.Widget {
     }
     this._ops = ops
     this._loaded = true
-    this._baked = null // tiles changed → re-bake on next paint
+    this._baked = null // tiles changed → re-bake
+    if (ops.length) MapPreview._enqueue(this)
     this.queue_draw()
   }
 
@@ -191,40 +288,42 @@ export class MapPreview extends Gtk.Widget {
     const dest = new Graphene.Rect()
     dest.init((width - dw) / 2, (height - dh) / 2, dw, dh)
 
-    // The map's own room colour sits below the tiles (the bake also
-    // includes it; this covers the pre-bake paint + ops-free maps).
-    if (this._mapBackground && !this._baked) snapshot.append_color(this._mapBackground, dest)
-    if (!this._ops.length && !this._baked) return
-
-    // Fast path: paint the pre-rasterised composite (one texture).
     if (this._baked) {
       snapshot.append_scaled_texture(this._baked, Gsk.ScalingFilter.NEAREST, dest)
       return
     }
 
-    // First paint (or just after the tiles changed): draw the tiles
-    // directly this once, and bake them to a texture for every paint
-    // after. The bake runs off an idle so it isn't a re-entrant
-    // `render_texture` inside this snapshot.
-    snapshot.save()
-    snapshot.translate(new Graphene.Point({ x: dest.get_x(), y: dest.get_y() }))
-    for (const op of this._ops) this._paintTile(snapshot, op, scale)
-    snapshot.restore()
-    this._scheduleBake()
+    // Bake not ready: show the map's own room colour as a stand-in.
+    // Individual tiles are NEVER painted here — for the big ported
+    // worlds that node tree is millions of GI calls. The queued bake
+    // repaints us when its texture lands.
+    if (this._mapBackground) snapshot.append_color(this._mapBackground, dest)
+    if (this._ops.length) MapPreview._enqueue(this)
   }
 
-  /** Rasterise the tile composite to one texture (off-snapshot), then repaint. */
-  private _scheduleBake(): void {
-    if (this._bakeScheduled) return
-    this._bakeScheduled = true
-    GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
-      this._bakeScheduled = false
-      if (!this._baked && this._ops.length) {
-        this._baked = this._bakeTexture()
-        if (this._baked) this.queue_draw()
-      }
-      return GLib.SOURCE_REMOVE
-    })
+  /** Queue callback: rasterise once, publish to the cache, drop the ops. */
+  private _runBake(): void {
+    if (this._baked || !this._ops.length) return
+    try {
+      this._baked = this._bakeTexture()
+    } catch (error) {
+      // Disposed widget or renderer hiccup — leave unbaked; a later
+      // snapshot re-queues us if the widget is still alive.
+      console.warn('[MapPreview] Bake failed:', error)
+      return
+    }
+    if (!this._baked) return
+    if (this._cacheKey) {
+      MapPreview._cacheStore(this._cacheKey, {
+        texture: this._baked,
+        mapWidth: this._mapWidth,
+        mapHeight: this._mapHeight,
+      })
+    }
+    // The op list (one entry per tile — six figures for the ported
+    // worlds) is dead weight once the texture exists.
+    this._ops = []
+    this.queue_draw()
   }
 
   private _bakeTexture(): Gdk.Texture | null {
@@ -237,7 +336,10 @@ export class MapPreview extends Gtk.Widget {
     const region = new Graphene.Rect()
     region.init(0, 0, this._mapWidth * bakeScale, this._mapHeight * bakeScale)
     if (this._mapBackground) sub.append_color(this._mapBackground, region)
-    for (const op of this._ops) this._paintTile(sub, op, bakeScale)
+    const target = new Graphene.Rect()
+    const translatePoint = new Graphene.Point()
+    const fullRect = new Graphene.Rect()
+    for (const op of this._ops) this._paintTile(sub, op, bakeScale, target, translatePoint, fullRect)
     const node = sub.to_node()
     if (!node) return null
     try {
@@ -248,8 +350,19 @@ export class MapPreview extends Gtk.Widget {
     }
   }
 
-  private _paintTile(snapshot: Gtk.Snapshot, op: DrawOp, scale: number): void {
-    const target = new Graphene.Rect()
+  /**
+   * Append one tile to the bake snapshot. The three Graphene temps are
+   * caller-owned and reused across the whole loop — allocating them
+   * per tile triples the GI overhead of the hottest loop in here.
+   */
+  private _paintTile(
+    snapshot: Gtk.Snapshot,
+    op: DrawOp,
+    scale: number,
+    target: Graphene.Rect,
+    translatePoint: Graphene.Point,
+    fullRect: Graphene.Rect,
+  ): void {
     target.init(op.tx * scale, op.ty * scale, op.tw * scale, op.th * scale)
     snapshot.push_clip(target)
     snapshot.save()
@@ -258,13 +371,9 @@ export class MapPreview extends Gtk.Widget {
     // lines up with `target`, then paint the whole atlas at the same
     // scale. Push_clip keeps the rest invisible.
     const textureScale = (op.tw * scale) / op.sw
-    const translatePoint = new Graphene.Point({
-      x: op.tx * scale - op.sx * textureScale,
-      y: op.ty * scale - op.sy * textureScale,
-    })
+    translatePoint.init(op.tx * scale - op.sx * textureScale, op.ty * scale - op.sy * textureScale)
     snapshot.translate(translatePoint)
 
-    const fullRect = new Graphene.Rect()
     fullRect.init(0, 0, op.texture.get_width() * textureScale, op.texture.get_height() * textureScale)
     snapshot.append_scaled_texture(op.texture, Gsk.ScalingFilter.NEAREST, fullRect)
 


### PR DESCRIPTION
The ported worlds have 100k+ tiles; the old path painted every tile
as a clipped GSK node in the widget snapshot AND rebuilt the same
node tree for the bake — millions of GI calls on the main thread,
twice, for thumbnails whose tiles end up ~1.4px.

- never paint tiles in vfunc_snapshot: accent + room colour until
  the bake lands, then the texture (O(1))
- module-wide bake queue, one bake per idle at idle priority, so
  19 atlas cards become short steps between frames
- LRU cache (48 textures) keyed by a map-content fingerprint —
  atlas re-entry reuses textures, edits re-bake exactly the maps
  that changed; welcome thumbnails serve the cached texture
  instantly and refresh in the background
- reuse the Graphene temps in the per-tile loop and drop the op
  list once baked (six-figure object arrays per big map)
