### PR TITLE
feat(atlas): viewport scene-card previews + card redesign

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@ Conventions:
 
 ## Atlas / world
 
-- **Viewport scene-card previews — SHIPPED**; remaining polish: the per-map `editorData.preview.zoom` is honoured but has no UI (default 300%) — expose it in the scene inspector; touch devices have no card-move path besides the (small) corner handle; the welcome view still uses fit-whole-map previews by design. *owner: gjs (MapPreview) + maker*
+- **Viewport scene-card previews — SHIPPED** (uniform 200% default zoom, atlas-global zoom via the scene editor's FloatingZoom pill routed through `win.zoom-*`, per-card lock toggle: closed = drag moves the card, open = drag pans the section, persisted as `editorData.preview`). Remaining polish: the global atlas zoom is session-only (not persisted per project); the welcome view still uses fit-whole-map previews by design. *owner: gjs (MapPreview) + maker*
 - **Atlas load time for big projects** — opening `games/oot2d-2014` (19 maps, 18 MB) takes ~19 s to the atlas; the project now loads **twice** (`loadProjectAsAtlas` + the welcome/engine path each construct a `GameProjectResource`) and repeated loads in one session can OOM GJS. Deduplicate to one shared resource per open project (existing "GameProjectResource double copy" debt) and consider lazy map parsing. *owner: maker / engine*
 
 ## Welcome / project lifecycle

--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@ Conventions:
 
 ## Atlas / world
 
-- **Viewport scene-card previews** — show every map at a uniform pixel zoom (~300%) cropped to an adjustable section (persisted as `editorData.preview`) instead of fit-whole-map, so all cards share one resolution and content stays recognizable. Open design points: card geometry (uniform card size vs map-proportional) and the in-card pan gesture (must not collide with card dragging — candidates: Ctrl/middle-drag, or an edit-viewport toggle). Prereq shipped: `MapPreview` bakes off-frame through a queue + content-fingerprint LRU cache (so a re-bake per pan step is cheap and whole-map data stays available). *owner: gjs (MapPreview) + maker (persistence via the `scene-moved` → `map.editor-data` pattern)*
+- **Viewport scene-card previews — SHIPPED**; remaining polish: the per-map `editorData.preview.zoom` is honoured but has no UI (default 300%) — expose it in the scene inspector; touch devices have no card-move path besides the (small) corner handle; the welcome view still uses fit-whole-map previews by design. *owner: gjs (MapPreview) + maker*
 - **Atlas load time for big projects** — opening `games/oot2d-2014` (19 maps, 18 MB) takes ~19 s to the atlas; the project now loads **twice** (`loadProjectAsAtlas` + the welcome/engine path each construct a `GameProjectResource`) and repeated loads in one session can OOM GJS. Deduplicate to one shared resource per open project (existing "GameProjectResource double copy" debt) and consider lazy map parsing. *owner: maker / engine*
 
 ## Welcome / project lifecycle

--- a/apps/maker-gjs/src/services/project-loader.ts
+++ b/apps/maker-gjs/src/services/project-loader.ts
@@ -89,6 +89,9 @@ export async function loadProjectAsAtlas(projectPath: string): Promise<LoadedPro
       x,
       y,
       tilePx,
+      previewTileX: typeof editor.preview?.tileX === 'number' ? editor.preview.tileX : undefined,
+      previewTileY: typeof editor.preview?.tileY === 'number' ? editor.preview.tileY : undefined,
+      previewZoom: typeof editor.preview?.zoom === 'number' ? editor.preview.zoom : undefined,
       // Event count is the number of object placements on the map —
       // every kind counts (NPCs, items, teleports, …). Pre-migration
       // code counted the legacy `type: 'object'` layers; that field

--- a/apps/maker-gjs/src/services/project-loader.ts
+++ b/apps/maker-gjs/src/services/project-loader.ts
@@ -91,7 +91,6 @@ export async function loadProjectAsAtlas(projectPath: string): Promise<LoadedPro
       tilePx,
       previewTileX: typeof editor.preview?.tileX === 'number' ? editor.preview.tileX : undefined,
       previewTileY: typeof editor.preview?.tileY === 'number' ? editor.preview.tileY : undefined,
-      previewZoom: typeof editor.preview?.zoom === 'number' ? editor.preview.zoom : undefined,
       // Event count is the number of object placements on the map —
       // every kind counts (NPCs, items, teleports, …). Pre-migration
       // code counted the legacy `type: 'object'` layers; that field

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -384,6 +384,13 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     this.signals.connect(this._atlas_view, 'scene-moved', (_v: AtlasView, id: string, x: number, y: number) => {
       this._persistAtlasPosition(id, x, y)
     })
+    this.signals.connect(
+      this._atlas_view,
+      'preview-moved',
+      (_v: AtlasView, id: string, tileX: number, tileY: number) => {
+        this._persistPreviewViewport(id, tileX, tileY)
+      },
+    )
     // Every view's mode-rail forwards `mode-changed` at the view
     // level. Re-route all four through the central `win.mode` action
     // so navigation is consistent — the action's change-state handler
@@ -807,6 +814,29 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     this._persistMap(mapId, _('Could not save atlas position'))
     this._activeCollab()?.sendProjectOp(({ peerId, seq }) =>
       createMapEditorDataOp({ peerId, seq, mapId, editorData: { atlasX: x, atlasY: y } }),
+    )
+  }
+
+  /**
+   * Persist the preview-viewport centre the user just panned on an
+   * atlas card. Same flow as {@link _persistAtlasPosition}: in-memory
+   * update + disk write + `__project/map.editor-data` op for peers.
+   * The in-memory `SampleScene` mirror keeps the viewport stable when
+   * the atlas re-renders (e.g. after a card move).
+   */
+  private _persistPreviewViewport(mapId: string, tileX: number, tileY: number): void {
+    const mapResource = this._loadedProject?.resource.maps.get(mapId)
+    if (!mapResource?.mapData) return
+    const preview = { ...mapResource.mapData.editorData?.preview, tileX, tileY }
+    mapResource.mapData.editorData = { ...mapResource.mapData.editorData, preview }
+    const scene = this._scenesById.get(mapId)
+    if (scene) {
+      scene.previewTileX = tileX
+      scene.previewTileY = tileY
+    }
+    this._persistMap(mapId, _('Could not save preview section'))
+    this._activeCollab()?.sendProjectOp(({ peerId, seq }) =>
+      createMapEditorDataOp({ peerId, seq, mapId, editorData: { preview } }),
     )
   }
 

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -1226,16 +1226,27 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     })
     winActions.add_action(toggleInspectorAction)
 
+    // The zoom actions are view-contextual: on the atlas they drive
+    // the global card-preview zoom (the atlas reuses the scene
+    // editor's FloatingZoom pill), everywhere else the engine camera.
+    const zoomTargetsAtlas = () => this._stack.get_visible_child_name() === 'atlas'
+
     const zoomInAction = new Gio.SimpleAction({ name: 'zoom-in' })
-    zoomInAction.connect('activate', () => this._stepZoom(+0.2))
+    zoomInAction.connect('activate', () =>
+      zoomTargetsAtlas() ? this._atlas_view.stepPreviewZoom(+0.2) : this._stepZoom(+0.2),
+    )
     winActions.add_action(zoomInAction)
 
     const zoomOutAction = new Gio.SimpleAction({ name: 'zoom-out' })
-    zoomOutAction.connect('activate', () => this._stepZoom(-0.2))
+    zoomOutAction.connect('activate', () =>
+      zoomTargetsAtlas() ? this._atlas_view.stepPreviewZoom(-0.2) : this._stepZoom(-0.2),
+    )
     winActions.add_action(zoomOutAction)
 
     const zoomResetAction = new Gio.SimpleAction({ name: 'zoom-reset' })
-    zoomResetAction.connect('activate', () => this._applyZoom(1))
+    zoomResetAction.connect('activate', () =>
+      zoomTargetsAtlas() ? this._atlas_view.resetPreviewZoom() : void this._applyZoom(1),
+    )
     winActions.add_action(zoomResetAction)
 
     const newSceneAction = new Gio.SimpleAction({ name: 'new-scene' })

--- a/apps/maker-gjs/src/widgets/atlas-view.blp
+++ b/apps/maker-gjs/src/widgets/atlas-view.blp
@@ -80,6 +80,17 @@ template $AtlasView : $PixelRpgResponsiveEditorView {
             tooltip-text: _("Create a new scene");
           }
 
+          // Same zoom pill as the scene editor (fires win.zoom-*);
+          // in the atlas the window routes those actions to the
+          // global card-preview zoom instead of the engine camera.
+          [overlay]
+          $PixelRpgFloatingZoom preview_zoom {
+            halign: start;
+            valign: end;
+            margin-start: 12;
+            margin-bottom: 12;
+          }
+
           child: $PixelRpgAtlasCanvas atlas {};
         };
       };

--- a/apps/maker-gjs/src/widgets/atlas-view.ts
+++ b/apps/maker-gjs/src/widgets/atlas-view.ts
@@ -66,6 +66,9 @@ export class AtlasView extends ResponsiveEditorView {
           'scene-moved': {
             param_types: [GObject.TYPE_STRING, GObject.TYPE_INT, GObject.TYPE_INT],
           },
+          'preview-moved': {
+            param_types: [GObject.TYPE_STRING, GObject.TYPE_DOUBLE, GObject.TYPE_DOUBLE],
+          },
           // mode-changed is inherited from ResponsiveEditorView.
         },
       },
@@ -152,6 +155,9 @@ export class AtlasView extends ResponsiveEditorView {
     })
     this.signals.connect(this._atlas, 'scene-moved', (_a: AtlasCanvas, id: string, x: number, y: number) => {
       this.emit('scene-moved', id, x, y)
+    })
+    this.signals.connect(this._atlas, 'preview-moved', (_a: AtlasCanvas, id: string, tileX: number, tileY: number) => {
+      this.emit('preview-moved', id, tileX, tileY)
     })
     this.signals.connect(this._mode_rail, 'mode-changed', (_r: ModeRail, mode: string) => {
       this.emit('mode-changed', mode as EditorMode)

--- a/apps/maker-gjs/src/widgets/atlas-view.ts
+++ b/apps/maker-gjs/src/widgets/atlas-view.ts
@@ -4,6 +4,7 @@ import {
   AtlasCanvas,
   type EditorMode,
   FloatingFab,
+  FloatingZoom,
   ModeRail,
   SAMPLE_SCENES,
   SAMPLE_TELEPORTS,
@@ -20,6 +21,7 @@ GObject.type_ensure(ModeRail.$gtype)
 GObject.type_ensure(AtlasCanvas.$gtype)
 GObject.type_ensure(SceneInspector.$gtype)
 GObject.type_ensure(FloatingFab.$gtype)
+GObject.type_ensure(FloatingZoom.$gtype)
 
 /**
  * Maker-app **Atlas** view — composes the mode rail, atlas canvas, and
@@ -36,6 +38,7 @@ GObject.type_ensure(FloatingFab.$gtype)
 export class AtlasView extends ResponsiveEditorView {
   declare _atlas: AtlasCanvas
   declare _inspector: SceneInspector
+  declare _preview_zoom: FloatingZoom
 
   private signals = new SignalScope()
   private _scenes: SampleScene[] = SAMPLE_SCENES
@@ -48,7 +51,7 @@ export class AtlasView extends ResponsiveEditorView {
       {
         GTypeName: 'AtlasView',
         Template,
-        InternalChildren: ['mode_rail', 'atlas', 'inspector'],
+        InternalChildren: ['mode_rail', 'atlas', 'inspector', 'preview_zoom'],
         Properties: {
           'project-name': GObject.ParamSpec.string(
             'project-name',
@@ -82,6 +85,26 @@ export class AtlasView extends ResponsiveEditorView {
     this._mode_rail.projectTagline = 'Atlas view'
     this._atlas.setWorld(this._scenes, this._teleports)
     this._inspector.setScene(null, this._scenes, this._teleports)
+    this._preview_zoom.setZoom(this._atlas.previewZoom)
+  }
+
+  /**
+   * Step the global card-preview zoom (the window routes `win.zoom-in/
+   * out` here while the atlas is the visible view).
+   */
+  stepPreviewZoom(delta: number): void {
+    this.setPreviewZoom(this._atlas.previewZoom + delta)
+  }
+
+  /** Absolute card-preview zoom; mirrors the value into the OSD pill. */
+  setPreviewZoom(zoom: number): void {
+    this._atlas.setPreviewZoom(zoom)
+    this._preview_zoom.setZoom(this._atlas.previewZoom)
+  }
+
+  /** Back to the 200% default (`win.zoom-reset` in the atlas). */
+  resetPreviewZoom(): void {
+    this.setPreviewZoom(AtlasCanvas.DEFAULT_PREVIEW_ZOOM)
   }
 
   get projectName(): string {

--- a/packages/engine/src/types/data/MapData.ts
+++ b/packages/engine/src/types/data/MapData.ts
@@ -143,17 +143,16 @@ export interface MapEditorData {
 
   /**
    * Viewport of the map's atlas-card preview. Cards render the map at
-   * a uniform native-pixel zoom (default 300%) cropped to the card, so
-   * only a section is visible — this records which one. Absent = map
-   * centre. Adjusted by panning the card's preview content.
+   * a uniform native-pixel zoom (atlas-global, default 200%) cropped
+   * to the card, so only a section is visible — this records which
+   * one. Absent = map centre. Adjusted by panning the card's preview
+   * content with its lock toggle open.
    */
   preview?: {
     /** Viewport centre, in tile coordinates. */
     tileX?: number
     /** See {@link tileX}. */
     tileY?: number
-    /** Native-pixel zoom of the preview (3 = 300%). */
-    zoom?: number
   }
 
   /**

--- a/packages/engine/src/types/data/MapData.ts
+++ b/packages/engine/src/types/data/MapData.ts
@@ -142,6 +142,21 @@ export interface MapEditorData {
   atlasY?: number
 
   /**
+   * Viewport of the map's atlas-card preview. Cards render the map at
+   * a uniform native-pixel zoom (default 300%) cropped to the card, so
+   * only a section is visible — this records which one. Absent = map
+   * centre. Adjusted by panning the card's preview content.
+   */
+  preview?: {
+    /** Viewport centre, in tile coordinates. */
+    tileX?: number
+    /** See {@link tileX}. */
+    tileY?: number
+    /** Native-pixel zoom of the preview (3 = 300%). */
+    zoom?: number
+  }
+
+  /**
    * Custom editor properties
    */
   properties?: Properties

--- a/packages/gjs/src/__demo__/world-sample.ts
+++ b/packages/gjs/src/__demo__/world-sample.ts
@@ -35,8 +35,6 @@ export interface SampleScene {
   previewTileX?: number
   /** See {@link previewTileX}. */
   previewTileY?: number
-  /** Persisted preview zoom (native-pixel factor, default 3). */
-  previewZoom?: number
   npcs?: { x: number; y: number; cast: number }[]
   hero?: { x: number; y: number }
   /** Total events placed in this scene (for the corner badge). */

--- a/packages/gjs/src/__demo__/world-sample.ts
+++ b/packages/gjs/src/__demo__/world-sample.ts
@@ -31,6 +31,12 @@ export interface SampleScene {
   y: number
   /** Mini-map tile size in CSS pixels. */
   tilePx: number
+  /** Persisted preview-viewport centre (tile coords), if any. */
+  previewTileX?: number
+  /** See {@link previewTileX}. */
+  previewTileY?: number
+  /** Persisted preview zoom (native-pixel factor, default 3). */
+  previewZoom?: number
   npcs?: { x: number; y: number; cast: number }[]
   hero?: { x: number; y: number }
   /** Total events placed in this scene (for the corner badge). */

--- a/packages/gjs/src/widgets/editor/atlas-canvas.ts
+++ b/packages/gjs/src/widgets/editor/atlas-canvas.ts
@@ -1,6 +1,7 @@
 import Adw from '@girs/adw-1'
 import GObject from '@girs/gobject-2.0'
-import type Gtk from '@girs/gtk-4.0'
+import Graphene from '@girs/graphene-1.0'
+import Gtk from '@girs/gtk-4.0'
 import type { GameProjectResource } from '@pixelrpg/engine'
 import type { SampleScene, SampleTeleport } from '../../__demo__/world-sample'
 import Template from './atlas-canvas.blp'
@@ -75,6 +76,12 @@ export class AtlasCanvas extends Adw.Bin {
           'scene-moved': {
             param_types: [GObject.TYPE_STRING, GObject.TYPE_INT, GObject.TYPE_INT],
           },
+          // Fires when a preview-viewport pan ends, with the new centre
+          // in tile coordinates — hosts persist it as
+          // `editorData.preview` (same flow as `scene-moved`).
+          'preview-moved': {
+            param_types: [GObject.TYPE_STRING, GObject.TYPE_DOUBLE, GObject.TYPE_DOUBLE],
+          },
         },
       },
       AtlasCanvas,
@@ -97,6 +104,43 @@ export class AtlasCanvas extends Adw.Bin {
     this._rebuildCards()
     this._teleports.setWorld(scenes, teleports, 1)
     this._sizeSurface()
+  }
+
+  constructor() {
+    super()
+    this._wireBackgroundPan()
+  }
+
+  /**
+   * Drag on the empty atlas backdrop pans the scrolled view (cards keep
+   * their own gestures: content drag pans the preview, the corner
+   * handle moves the card). The gesture lives on the SCROLLER — its
+   * coordinates are viewport-stable, so adjusting the scroll position
+   * doesn't shift the gesture's own reference frame (the same feedback
+   * loop the cards' parent-space drag math guards against). It denies
+   * itself when the press landed on a card, so it can't fight them.
+   */
+  private _wireBackgroundPan(): void {
+    const pan = new Gtk.GestureDrag()
+    let startH = 0
+    let startV = 0
+    pan.connect('drag-begin', (gesture: Gtk.GestureDrag, x: number, y: number) => {
+      const point = new Graphene.Point()
+      point.init(x, y)
+      const [ok, inSurface] = this._scroller.compute_point(this._surface, point)
+      const picked = ok ? this._surface.pick(inSurface.x, inSurface.y, Gtk.PickFlags.DEFAULT) : null
+      if (picked && picked !== (this._surface as Gtk.Widget)) {
+        gesture.set_state(Gtk.EventSequenceState.DENIED)
+        return
+      }
+      startH = this._scroller.hadjustment.value
+      startV = this._scroller.vadjustment.value
+    })
+    pan.connect('drag-update', (_g: Gtk.GestureDrag, dx: number, dy: number) => {
+      this._scroller.hadjustment.value = startH - dx
+      this._scroller.vadjustment.value = startV - dy
+    })
+    this._scroller.add_controller(pan)
   }
 
   get selectedId(): string {
@@ -136,15 +180,21 @@ export class AtlasCanvas extends Adw.Bin {
     }
   }
 
+  /** Default native-pixel zoom of card previews (the user's "300%"). */
+  private static readonly PREVIEW_ZOOM = 3
+
   /**
    * For real projects (where the host passed us a `GameProjectResource`),
    * swap the card's default mini-map placeholder for a `MapPreview`
-   * that paints the scene's actual tile data. Falls through to the
-   * default placeholder if the resource has no matching map.
+   * that paints the scene's actual tile data — a section of the map at
+   * a uniform native-pixel zoom, pannable by dragging the preview
+   * (persisted via `preview-moved`). Falls through to the default
+   * placeholder if the resource has no matching map.
    */
   private _injectPreviewIfAvailable(card: SceneCard, scene: SampleScene): void {
     if (!this._projectResource) return
-    if (!this._projectResource.maps.has(scene.id)) return
+    const mapData = this._projectResource.maps.get(scene.id)?.mapData
+    if (!mapData) return
 
     const cols = scene.cols ?? 0
     const previewRows = scene.previewRows ?? 0
@@ -153,7 +203,19 @@ export class AtlasCanvas extends Adw.Bin {
     const preview = new MapPreview()
     preview.set_size_request(cols * scene.tilePx, previewRows * scene.tilePx)
     card.setPreviewWidget(preview)
-    void preview.setFromResource(this._projectResource, scene.id)
+    card.pannablePreview = true
+    void preview.setFromResource(this._projectResource, scene.id, {
+      tileX: scene.previewTileX ?? mapData.columns / 2,
+      tileY: scene.previewTileY ?? mapData.rows / 2,
+      zoom: scene.previewZoom ?? AtlasCanvas.PREVIEW_ZOOM,
+    })
+    card.connect('preview-pan-update', (_c: SceneCard, dx: number, dy: number) => {
+      preview.panViewportBy(dx, dy)
+    })
+    card.connect('preview-pan-end', () => {
+      const centre = preview.commitViewport()
+      if (centre) this.emit('preview-moved', scene.id, centre.tileX, centre.tileY)
+    })
   }
 
   private _wireDrag(sceneId: string, card: SceneCard): void {
@@ -202,8 +264,12 @@ export class AtlasCanvas extends Adw.Bin {
     let maxX = 0
     let maxY = 0
     for (const s of this._scenes) {
-      const w = (s.rows[0]?.length ?? 0) * s.tilePx
-      const h = s.rows.length * s.tilePx
+      // Real-project scenes carry no terrain rows — fall back to the
+      // cols/previewRows card geometry so the surface still spans them.
+      const cols = s.rows[0]?.length || s.cols || 0
+      const rows = s.rows.length || s.previewRows || 0
+      const w = cols * s.tilePx
+      const h = rows * s.tilePx
       maxX = Math.max(maxX, s.x + w)
       maxY = Math.max(maxY, s.y + h)
     }

--- a/packages/gjs/src/widgets/editor/atlas-canvas.ts
+++ b/packages/gjs/src/widgets/editor/atlas-canvas.ts
@@ -161,6 +161,7 @@ export class AtlasCanvas extends Adw.Bin {
   private _rebuildCards(): void {
     for (const [, card] of this._cards) this._surface.remove(card)
     this._cards.clear()
+    this._previews.clear()
 
     for (const scene of this._scenes) {
       const card = new SceneCard()
@@ -180,16 +181,38 @@ export class AtlasCanvas extends Adw.Bin {
     }
   }
 
-  /** Default native-pixel zoom of card previews (the user's "300%"). */
-  private static readonly PREVIEW_ZOOM = 3
+  /** Default native-pixel zoom of card previews (200%). */
+  static readonly DEFAULT_PREVIEW_ZOOM = 2
+
+  /** Current global preview zoom — the atlas zoom control drives it. */
+  private _previewZoom = AtlasCanvas.DEFAULT_PREVIEW_ZOOM
+
+  /** Live `MapPreview`s by scene id, for global zoom changes. */
+  private _previews: Map<string, MapPreview> = new Map()
+
+  get previewZoom(): number {
+    return this._previewZoom
+  }
+
+  /**
+   * Apply a new global preview zoom to every card (and to cards built
+   * later). Clamped to a sane pixel-zoom range.
+   */
+  setPreviewZoom(zoom: number): void {
+    const clamped = Math.min(6, Math.max(0.5, zoom))
+    if (clamped === this._previewZoom) return
+    this._previewZoom = clamped
+    for (const preview of this._previews.values()) preview.setViewportZoom(clamped)
+  }
 
   /**
    * For real projects (where the host passed us a `GameProjectResource`),
    * swap the card's default mini-map placeholder for a `MapPreview`
    * that paints the scene's actual tile data — a section of the map at
-   * a uniform native-pixel zoom, pannable by dragging the preview
-   * (persisted via `preview-moved`). Falls through to the default
-   * placeholder if the resource has no matching map.
+   * a uniform native-pixel zoom. The card's lock toggle switches its
+   * drag between moving the card (locked, default) and panning the
+   * section (unlocked; persisted via `preview-moved`). Falls through
+   * to the default placeholder if the resource has no matching map.
    */
   private _injectPreviewIfAvailable(card: SceneCard, scene: SampleScene): void {
     if (!this._projectResource) return
@@ -203,11 +226,12 @@ export class AtlasCanvas extends Adw.Bin {
     const preview = new MapPreview()
     preview.set_size_request(cols * scene.tilePx, previewRows * scene.tilePx)
     card.setPreviewWidget(preview)
-    card.pannablePreview = true
+    card.viewportLockable = true
+    this._previews.set(scene.id, preview)
     void preview.setFromResource(this._projectResource, scene.id, {
       tileX: scene.previewTileX ?? mapData.columns / 2,
       tileY: scene.previewTileY ?? mapData.rows / 2,
-      zoom: scene.previewZoom ?? AtlasCanvas.PREVIEW_ZOOM,
+      zoom: this._previewZoom,
     })
     card.connect('preview-pan-update', (_c: SceneCard, dx: number, dy: number) => {
       preview.panViewportBy(dx, dy)

--- a/packages/gjs/src/widgets/editor/map-preview.ts
+++ b/packages/gjs/src/widgets/editor/map-preview.ts
@@ -305,6 +305,25 @@ export class MapPreview extends Gtk.Widget {
     }
   }
 
+  /**
+   * Change the viewport zoom in place (the atlas's global zoom
+   * control). The stale texture is dropped too — it would paint at
+   * the wrong scale — so the card shows its room colour until the
+   * queued re-bake lands.
+   */
+  setViewportZoom(zoom: number): void {
+    if (!this._viewport || !this._source || this._viewport.zoom === zoom) return
+    this._viewport.zoom = zoom
+    this._viewport.centerX = this._clampCenter(this._viewport.centerX, this._mapWidth, true)
+    this._viewport.centerY = this._clampCenter(this._viewport.centerY, this._mapHeight, false)
+    this._cacheWrite = true
+    if (this._cacheKeyBase) this._cacheKey = `map:${this._cacheKeyBase}${this._viewportKeySuffix()}`
+    this._baked = null
+    this._staleBake = null
+    MapPreview._enqueue(this)
+    this.queue_draw()
+  }
+
   /** `path`/`map` cache-key base without the viewport suffix. */
   private _cacheKeyBase: string | null = null
 

--- a/packages/gjs/src/widgets/editor/map-preview.ts
+++ b/packages/gjs/src/widgets/editor/map-preview.ts
@@ -36,6 +36,16 @@ interface BakedPreview {
   mapHeight: number
 }
 
+/** Card-preview viewport: a section of the map at a fixed pixel zoom. */
+export interface PreviewViewport {
+  /** Viewport centre, in tile coordinates. */
+  tileX: number
+  /** See {@link tileX}. */
+  tileY: number
+  /** Native-pixel zoom (3 = one map pixel covers 3 widget pixels). */
+  zoom: number
+}
+
 /**
  * Renders a static thumbnail of a project map by compositing each
  * tile sprite onto a `Gtk.Snapshot`. Used by the welcome view's
@@ -47,6 +57,17 @@ interface BakedPreview {
  * sprite-sheets via the existing `GdkSpriteSetResource` pipeline and
  * rasterises the tiles ONCE into a small texture (the "bake").
  *
+ * Two content modes:
+ *
+ * - **Fit** (welcome/template cards): the whole map scaled into the
+ *   widget, longest texture edge capped at {@link BAKE_MAX_EDGE}.
+ * - **Viewport** (atlas cards): a section of the map at a uniform
+ *   native-pixel zoom, centred on an adjustable focus point — pass a
+ *   {@link PreviewViewport} to `setFromResource` and pan live via
+ *   {@link panViewportBy}/{@link commitViewport}. While a pan's
+ *   re-bake is pending the stale texture paints shifted, so the
+ *   gesture feels immediate.
+ *
  * Rendering strategy (the ported worlds have 100k+ tiles, so the
  * naive paint-every-tile path is too hot for the main loop):
  *
@@ -56,20 +77,21 @@ interface BakedPreview {
  * - Bakes run through a module-wide queue, ONE per main-loop idle at
  *   idle priority — 19 atlas cards become 19 short steps between
  *   frames instead of one multi-second stall.
+ * - Draw ops are built per bake from the retained map data (filtered
+ *   to the viewport) and dropped right after — no six-figure op
+ *   arrays held per card.
  * - Finished bakes land in a small LRU cache keyed by a content
- *   fingerprint of the map, so re-entering the atlas (which rebuilds
- *   the cards) reuses the textures instead of re-rendering. The
- *   welcome view's per-path lookups serve the cached texture
- *   instantly and then refresh it in the background.
+ *   fingerprint of the map (+ viewport), so re-entering the atlas
+ *   reuses the textures instead of re-rendering. Live pan bakes skip
+ *   the cache; the drag-end commit writes it.
  */
-/** Cap the baked preview texture's longest edge — these are small thumbnails. */
+/** Cap the FIT-mode bake's longest edge — those are small thumbnails. */
 const BAKE_MAX_EDGE = 512
 
 /** Baked textures kept across widget rebuilds (≤512px ≈ ≤1 MB each). */
 const BAKE_CACHE_MAX = 48
 
 export class MapPreview extends Gtk.Widget {
-  private _ops: DrawOp[] = []
   private _mapWidth = 0
   private _mapHeight = 0
   private _accentColor: Gdk.RGBA
@@ -77,6 +99,14 @@ export class MapPreview extends Gtk.Widget {
   private _mapBackground: Gdk.RGBA | null = null
   private _loaded = false
   private _baked: Gdk.Texture | null = null
+  /** Retained source for (re-)bakes; ops are derived per bake. */
+  private _source: { mapData: MapData; ranges: SheetRange[] } | null = null
+  /** Viewport centre in MAP pixels (null = fit-whole-map mode). */
+  private _viewport: { centerX: number; centerY: number; zoom: number } | null = null
+  /** Centre the current `_baked` texture was rendered at (viewport mode). */
+  private _bakedCenter: { x: number; y: number } | null = null
+  /** Whether the next finished bake may be written to the LRU cache. */
+  private _cacheWrite = true
   /** Cache slot for this widget's current map (see `_cacheStore`). */
   private _cacheKey: string | null = null
 
@@ -200,10 +230,16 @@ export class MapPreview extends Gtk.Widget {
    * inspector) has already parsed the project file.
    *
    * Pass a specific `mapId` to render a non-default map; otherwise
-   * the project's first map is used. A cache hit (same map content)
-   * skips sprite-sheet collection and the bake entirely.
+   * the project's first map is used. With a {@link PreviewViewport}
+   * the card shows a zoomed section instead of the whole map. A cache
+   * hit (same map content + viewport) skips sprite-sheet collection
+   * and the bake entirely.
    */
-  async setFromResource(resource: GameProjectResource, mapId?: string): Promise<void> {
+  async setFromResource(
+    resource: GameProjectResource,
+    mapId?: string,
+    viewport: PreviewViewport | null = null,
+  ): Promise<void> {
     try {
       const mapData = mapId ? resource.maps.get(mapId)?.mapData : Array.from(resource.maps.values())[0]?.mapData
       if (!mapData) {
@@ -211,10 +247,23 @@ export class MapPreview extends Gtk.Widget {
         this.queue_draw()
         return
       }
-      const cacheKey = `map:${resource.path}:${mapData.id}:${MapPreview._fingerprint(mapData)}`
+      this._viewport = viewport
+        ? {
+            centerX: viewport.tileX * mapData.tileWidth,
+            centerY: viewport.tileY * mapData.tileHeight,
+            zoom: viewport.zoom,
+          }
+        : null
+      const cacheKey = `map:${resource.path}:${mapData.id}:${MapPreview._fingerprint(mapData)}${this._viewportKeySuffix()}`
       const cached = MapPreview._cache.get(cacheKey)
       if (cached) {
         this._showBaked(cacheKey, cached)
+        if (this._viewport) this._bakedCenter = { x: this._viewport.centerX, y: this._viewport.centerY }
+        // Viewport pans need the source even after a cache hit.
+        if (this._viewport && !this._source) {
+          this._source = { mapData, ranges: await this._collectSheets(resource, mapData.spriteSets ?? []) }
+          this._readBackground(mapData)
+        }
         return
       }
       await this._populateFromMap(mapData, await this._collectSheets(resource, mapData.spriteSets ?? []), cacheKey)
@@ -224,50 +273,84 @@ export class MapPreview extends Gtk.Widget {
     }
   }
 
+  /**
+   * Live viewport pan by a widget-pixel delta (positive = drag right/
+   * down → content follows the pointer). Cheap: shifts the stale
+   * texture immediately and queues a non-cached re-bake.
+   */
+  panViewportBy(dxWidget: number, dyWidget: number): void {
+    if (!this._viewport || !this._source) return
+    const { zoom } = this._viewport
+    this._viewport.centerX = this._clampCenter(this._viewport.centerX - dxWidget / zoom, this._mapWidth, true)
+    this._viewport.centerY = this._clampCenter(this._viewport.centerY - dyWidget / zoom, this._mapHeight, false)
+    this._cacheWrite = false
+    this._baked = null // stale for the new centre — `_bakedCenter` keeps the shifted paint alive
+    MapPreview._enqueue(this)
+    this.queue_draw()
+  }
+
+  /**
+   * Finish a pan: re-enable caching and return the viewport centre in
+   * tile coordinates for the host to persist (`editorData.preview`).
+   */
+  commitViewport(): { tileX: number; tileY: number } | null {
+    if (!this._viewport || !this._source) return null
+    const mapData = this._source.mapData
+    this._cacheWrite = true
+    if (this._cacheKeyBase) this._cacheKey = `map:${this._cacheKeyBase}${this._viewportKeySuffix()}`
+    MapPreview._enqueue(this)
+    return {
+      tileX: this._viewport.centerX / mapData.tileWidth,
+      tileY: this._viewport.centerY / mapData.tileHeight,
+    }
+  }
+
+  /** `path`/`map` cache-key base without the viewport suffix. */
+  private _cacheKeyBase: string | null = null
+
+  private _viewportKeySuffix(): string {
+    if (!this._viewport) return ''
+    return `:vp:${this._viewport.zoom}:${Math.round(this._viewport.centerX)}:${Math.round(this._viewport.centerY)}`
+  }
+
+  /** Keep the viewport centre inside the map (centre small maps). */
+  private _clampCenter(value: number, mapExtent: number, horizontal: boolean): number {
+    const widgetExtent = horizontal ? this.get_width() : this.get_height()
+    const zoom = this._viewport?.zoom ?? 1
+    const half = widgetExtent > 0 ? widgetExtent / zoom / 2 : 0
+    if (!half || mapExtent <= half * 2) return mapExtent / 2
+    return Math.min(Math.max(value, half), mapExtent - half)
+  }
+
   private _showBaked(cacheKey: string, baked: BakedPreview): void {
     this._cacheKey = cacheKey
     this._baked = baked.texture
     this._mapWidth = baked.mapWidth
     this._mapHeight = baked.mapHeight
-    this._ops = []
     this._loaded = true
     this.queue_draw()
+  }
+
+  private _readBackground(mapData: MapData): void {
+    this._mapBackground = null
+    if (mapData.backgroundColor) {
+      const rgba = new Gdk.RGBA()
+      if (rgba.parse(mapData.backgroundColor)) this._mapBackground = rgba
+    }
   }
 
   private async _populateFromMap(mapData: MapData, ranges: SheetRange[], cacheKey: string | null): Promise<void> {
     this._mapWidth = mapData.columns * mapData.tileWidth
     this._mapHeight = mapData.rows * mapData.tileHeight
     this._cacheKey = cacheKey
-
-    this._mapBackground = null
-    if (mapData.backgroundColor) {
-      const rgba = new Gdk.RGBA()
-      if (rgba.parse(mapData.backgroundColor)) this._mapBackground = rgba
-    }
-
-    const ops: DrawOp[] = []
-    for (const layer of mapData.layers ?? []) {
-      if (!layer.visible || !layer.sprites) continue
-      for (const tile of layer.sprites) {
-        const resolved = this._resolveSpriteByLocalId(ranges, tile.spriteSetId, tile.spriteId)
-        if (!resolved) continue
-        ops.push({
-          texture: resolved.texture,
-          sx: resolved.x,
-          sy: resolved.y,
-          sw: resolved.width,
-          sh: resolved.height,
-          tx: tile.x * mapData.tileWidth,
-          ty: tile.y * mapData.tileHeight,
-          tw: mapData.tileWidth,
-          th: mapData.tileHeight,
-        })
-      }
-    }
-    this._ops = ops
+    this._cacheKeyBase = cacheKey?.startsWith('map:') ? (cacheKey.slice(4).split(':vp:')[0] ?? null) : null
+    this._readBackground(mapData)
+    this._source = { mapData, ranges }
     this._loaded = true
-    this._baked = null // tiles changed → re-bake
-    if (ops.length) MapPreview._enqueue(this)
+    this._baked = null // content changed → re-bake
+    this._bakedCenter = null
+    this._cacheWrite = true
+    MapPreview._enqueue(this)
     this.queue_draw()
   }
 
@@ -281,6 +364,11 @@ export class MapPreview extends Gtk.Widget {
     snapshot.append_color(this._accentColor, background)
 
     if (!this._loaded || !this._mapWidth || !this._mapHeight) return
+
+    if (this._viewport) {
+      this._snapshotViewport(snapshot, width, height)
+      return
+    }
 
     const scale = Math.min(width / this._mapWidth, height / this._mapHeight)
     const dw = this._mapWidth * scale
@@ -298,48 +386,173 @@ export class MapPreview extends Gtk.Widget {
     // worlds that node tree is millions of GI calls. The queued bake
     // repaints us when its texture lands.
     if (this._mapBackground) snapshot.append_color(this._mapBackground, dest)
-    if (this._ops.length) MapPreview._enqueue(this)
+    if (this._source) MapPreview._enqueue(this)
   }
+
+  /**
+   * Viewport mode: the baked texture covers the widget 1:1. While a
+   * pan's re-bake is pending, the previous texture paints shifted by
+   * the centre delta so the drag tracks the pointer immediately.
+   */
+  private _snapshotViewport(snapshot: Gtk.Snapshot, width: number, height: number): void {
+    const viewport = this._viewport
+    if (!viewport) return
+    if (this._mapBackground) {
+      const fill = new Graphene.Rect()
+      fill.init(0, 0, width, height)
+      snapshot.append_color(this._mapBackground, fill)
+    }
+    const texture = this._baked ?? this._staleBake?.texture ?? null
+    const bakedAt = this._baked ? this._bakedCenter : this._staleBake?.center
+    if (texture && bakedAt) {
+      const dest = new Graphene.Rect()
+      dest.init(
+        (bakedAt.x - viewport.centerX) * viewport.zoom,
+        (bakedAt.y - viewport.centerY) * viewport.zoom,
+        texture.get_width(),
+        texture.get_height(),
+      )
+      const clip = new Graphene.Rect()
+      clip.init(0, 0, width, height)
+      snapshot.push_clip(clip)
+      snapshot.append_scaled_texture(texture, Gsk.ScalingFilter.NEAREST, dest)
+      snapshot.pop()
+    }
+    if (!this._baked && this._source) MapPreview._enqueue(this)
+  }
+
+  /** Last completed viewport bake, kept for shifted stale painting. */
+  private _staleBake: { texture: Gdk.Texture; center: { x: number; y: number } } | null = null
 
   /** Queue callback: rasterise once, publish to the cache, drop the ops. */
   private _runBake(): void {
-    if (this._baked || !this._ops.length) return
+    if (this._baked || !this._source) return
+    let texture: Gdk.Texture | null = null
     try {
-      this._baked = this._bakeTexture()
+      texture = this._viewport ? this._bakeViewportTexture() : this._bakeFitTexture()
     } catch (error) {
       // Disposed widget or renderer hiccup — leave unbaked; a later
       // snapshot re-queues us if the widget is still alive.
       console.warn('[MapPreview] Bake failed:', error)
       return
     }
-    if (!this._baked) return
-    if (this._cacheKey) {
+    if (!texture) return
+    this._baked = texture
+    if (this._viewport) {
+      this._bakedCenter = { x: this._viewport.centerX, y: this._viewport.centerY }
+      this._staleBake = { texture, center: this._bakedCenter }
+    }
+    if (this._cacheKey && this._cacheWrite) {
       MapPreview._cacheStore(this._cacheKey, {
-        texture: this._baked,
+        texture,
         mapWidth: this._mapWidth,
         mapHeight: this._mapHeight,
       })
     }
-    // The op list (one entry per tile — six figures for the ported
-    // worlds) is dead weight once the texture exists.
-    this._ops = []
     this.queue_draw()
   }
 
-  private _bakeTexture(): Gdk.Texture | null {
+  /** Build the per-tile draw ops, optionally clipped to a map-px rect. */
+  private _buildOps(clip: { x: number; y: number; w: number; h: number } | null): DrawOp[] {
+    const source = this._source
+    if (!source) return []
+    const { mapData, ranges } = source
+    const ops: DrawOp[] = []
+    for (const layer of mapData.layers ?? []) {
+      if (!layer.visible || !layer.sprites) continue
+      for (const tile of layer.sprites) {
+        const tx = tile.x * mapData.tileWidth
+        const ty = tile.y * mapData.tileHeight
+        if (
+          clip &&
+          (tx + mapData.tileWidth <= clip.x ||
+            tx >= clip.x + clip.w ||
+            ty + mapData.tileHeight <= clip.y ||
+            ty >= clip.y + clip.h)
+        ) {
+          continue
+        }
+        const resolved = this._resolveSpriteByLocalId(ranges, tile.spriteSetId, tile.spriteId)
+        if (!resolved) continue
+        ops.push({
+          texture: resolved.texture,
+          sx: resolved.x,
+          sy: resolved.y,
+          sw: resolved.width,
+          sh: resolved.height,
+          tx,
+          ty,
+          tw: mapData.tileWidth,
+          th: mapData.tileHeight,
+        })
+      }
+    }
+    return ops
+  }
+
+  /** Fit mode: whole map, longest texture edge capped. */
+  private _bakeFitTexture(): Gdk.Texture | null {
     const renderer = this.get_native()?.get_renderer()
     if (!renderer || !this._mapWidth || !this._mapHeight) return null
-    // Bake at native map resolution, capped so a large map stays a small
-    // thumbnail texture (it's only ever shown card-sized).
     const bakeScale = Math.min(1, BAKE_MAX_EDGE / Math.max(this._mapWidth, this._mapHeight))
-    const sub = Gtk.Snapshot.new()
     const region = new Graphene.Rect()
     region.init(0, 0, this._mapWidth * bakeScale, this._mapHeight * bakeScale)
-    if (this._mapBackground) sub.append_color(this._mapBackground, region)
+    return this._renderOps(renderer, this._buildOps(null), bakeScale, 0, 0, region)
+  }
+
+  /** Viewport mode: the visible section at native-pixel zoom. */
+  private _bakeViewportTexture(): Gdk.Texture | null {
+    const viewport = this._viewport
+    const renderer = this.get_native()?.get_renderer()
+    const width = this.get_width()
+    const height = this.get_height()
+    if (!viewport || !renderer || width <= 0 || height <= 0) return null
+    // Re-clamp against the now-known widget size (initial centres are
+    // set before the first allocation).
+    viewport.centerX = this._clampCenter(viewport.centerX, this._mapWidth, true)
+    viewport.centerY = this._clampCenter(viewport.centerY, this._mapHeight, false)
+    const viewW = width / viewport.zoom
+    const viewH = height / viewport.zoom
+    // Whole-map-pixel origin: a fractional origin would land every
+    // tile's clip edge between device pixels, and the NEAREST-sampled
+    // atlas bleeds a hairline of the neighbouring sheet cell through —
+    // visible as faint seams across the preview.
+    const originX = Math.round(viewport.centerX - viewW / 2)
+    const originY = Math.round(viewport.centerY - viewH / 2)
+    const region = new Graphene.Rect()
+    region.init(0, 0, width, height)
+    const ops = this._buildOps({ x: originX, y: originY, w: viewW, h: viewH })
+    return this._renderOps(renderer, ops, viewport.zoom, -originX, -originY, region)
+  }
+
+  /** Rasterise ops (scaled + translated in map px) into `region`. */
+  private _renderOps(
+    renderer: Gsk.Renderer,
+    ops: DrawOp[],
+    scale: number,
+    offsetXMapPx: number,
+    offsetYMapPx: number,
+    region: Graphene.Rect,
+  ): Gdk.Texture | null {
+    const sub = Gtk.Snapshot.new()
+    if (this._mapBackground) {
+      const fill = new Graphene.Rect()
+      // Background covers the map bounds only (fit mode shows the
+      // accent outside them; viewport clamps inside the map anyway).
+      fill.init(
+        Math.max(0, offsetXMapPx * scale),
+        Math.max(0, offsetYMapPx * scale),
+        Math.min(region.get_width(), this._mapWidth * scale),
+        Math.min(region.get_height(), this._mapHeight * scale),
+      )
+      sub.append_color(this._mapBackground, fill)
+    }
     const target = new Graphene.Rect()
     const translatePoint = new Graphene.Point()
     const fullRect = new Graphene.Rect()
-    for (const op of this._ops) this._paintTile(sub, op, bakeScale, target, translatePoint, fullRect)
+    for (const op of ops) {
+      this._paintTile(sub, op, scale, offsetXMapPx, offsetYMapPx, target, translatePoint, fullRect)
+    }
     const node = sub.to_node()
     if (!node) return null
     try {
@@ -359,11 +572,15 @@ export class MapPreview extends Gtk.Widget {
     snapshot: Gtk.Snapshot,
     op: DrawOp,
     scale: number,
+    offsetXMapPx: number,
+    offsetYMapPx: number,
     target: Graphene.Rect,
     translatePoint: Graphene.Point,
     fullRect: Graphene.Rect,
   ): void {
-    target.init(op.tx * scale, op.ty * scale, op.tw * scale, op.th * scale)
+    const tx = (op.tx + offsetXMapPx) * scale
+    const ty = (op.ty + offsetYMapPx) * scale
+    target.init(tx, ty, op.tw * scale, op.th * scale)
     snapshot.push_clip(target)
     snapshot.save()
 
@@ -371,7 +588,7 @@ export class MapPreview extends Gtk.Widget {
     // lines up with `target`, then paint the whole atlas at the same
     // scale. Push_clip keeps the rest invisible.
     const textureScale = (op.tw * scale) / op.sw
-    translatePoint.init(op.tx * scale - op.sx * textureScale, op.ty * scale - op.sy * textureScale)
+    translatePoint.init(tx - op.sx * textureScale, ty - op.sy * textureScale)
     snapshot.translate(translatePoint)
 
     fullRect.init(0, 0, op.texture.get_width() * textureScale, op.texture.get_height() * textureScale)

--- a/packages/gjs/src/widgets/editor/scene-card.blp
+++ b/packages/gjs/src/widgets/editor/scene-card.blp
@@ -42,17 +42,19 @@ template $PixelRpgSceneCard : Gtk.Button {
         }
       };
 
-      // Dragging the handle moves the card on the atlas; dragging the
-      // preview content pans the map section inside it (viewport mode).
+      // Viewport lock: closed = dragging moves the card on the atlas
+      // (default); open = dragging pans the map section inside it.
+      // Only shown for viewport previews (real projects).
       [overlay]
-      Gtk.Image drag_handle {
-        icon-name: "list-drag-handle-symbolic";
-        pixel-size: 14;
+      Gtk.ToggleButton lock_button {
+        icon-name: "changes-prevent-symbolic";
         halign: end;
         valign: start;
         margin-top: 4;
         margin-end: 4;
-        styles ["scene-card-handle", "osd"]
+        visible: bind template.viewport-lockable;
+        tooltip-text: _("Unlock to pan the preview section");
+        styles ["scene-card-lock", "osd", "flat"]
       }
 
       [overlay]

--- a/packages/gjs/src/widgets/editor/scene-card.blp
+++ b/packages/gjs/src/widgets/editor/scene-card.blp
@@ -4,63 +4,76 @@ using Adw 1;
 template $PixelRpgSceneCard : Gtk.Button {
   styles ["scene-card", "flat"]
 
-  child: Gtk.Overlay overlay {
-    child: Gtk.Box body {
-      orientation: vertical;
-      spacing: 0;
-      overflow: hidden;
-      styles ["card"]
+  child: Gtk.Box root {
+    orientation: vertical;
+    spacing: 4;
 
-      Gtk.Box title_bar {
-        orientation: horizontal;
-        spacing: 6;
-        margin-top: 5;
-        margin-bottom: 5;
-        margin-start: 10;
-        margin-end: 9;
+    // Free-floating title row — no header bar, no background. The
+    // teleport overlay compensates for its height via
+    // `TITLE_BAR_HEIGHT` (teleport-overlay.ts).
+    Gtk.Box title_row {
+      orientation: horizontal;
+      spacing: 6;
+      styles ["scene-card-title"]
 
-        Gtk.Label name_label {
-          label: bind template.scene-name;
-          halign: start;
-          hexpand: true;
-          ellipsize: end;
-          styles ["caption-heading"]
+      Gtk.Label name_label {
+        label: bind template.scene-name;
+        halign: start;
+        hexpand: true;
+        ellipsize: end;
+        styles ["caption-heading"]
+      }
+
+      Gtk.Label size_label {
+        label: bind template.size-text;
+        halign: end;
+        styles ["caption", "dim-label", "numeric"]
+      }
+    }
+
+    Gtk.Overlay overlay {
+      child: Gtk.Box body {
+        orientation: vertical;
+        overflow: hidden;
+        styles ["scene-card-frame"]
+
+        Adw.Bin preview_slot {
+          child: $PixelRpgMiniMap map {};
+        }
+      };
+
+      // Dragging the handle moves the card on the atlas; dragging the
+      // preview content pans the map section inside it (viewport mode).
+      [overlay]
+      Gtk.Image drag_handle {
+        icon-name: "list-drag-handle-symbolic";
+        pixel-size: 14;
+        halign: end;
+        valign: start;
+        margin-top: 4;
+        margin-end: 4;
+        styles ["scene-card-handle", "osd"]
+      }
+
+      [overlay]
+      Gtk.Box event_badge {
+        halign: end;
+        valign: end;
+        margin-bottom: 4;
+        margin-end: 4;
+        spacing: 4;
+        visible: bind template.has-events;
+        styles ["scene-card-badge", "osd"]
+
+        Gtk.Image {
+          icon-name: "starred-symbolic";
+          pixel-size: 10;
         }
 
-        Gtk.Label size_label {
-          label: bind template.size-text;
-          halign: end;
-          styles ["caption", "dim-label", "numeric"]
+        Gtk.Label {
+          label: bind template.events-text;
+          styles ["caption-heading", "numeric"]
         }
-      }
-
-      Gtk.Separator {
-        orientation: horizontal;
-      }
-
-      Adw.Bin preview_slot {
-        child: $PixelRpgMiniMap map {};
-      }
-    };
-
-    [overlay]
-    Gtk.Box event_badge {
-      halign: end;
-      valign: start;
-      margin-top: 4;
-      margin-end: 4;
-      spacing: 4;
-      visible: bind template.has-events;
-      styles ["scene-card-badge", "osd"]
-
-      Gtk.Image {
-        icon-name: "starred-symbolic";
-        pixel-size: 10;
-      }
-
-      Gtk.Label {
-        label: bind template.events-text;
-        styles ["caption-heading", "numeric"]
       }
     }
   };

--- a/packages/gjs/src/widgets/editor/scene-card.css
+++ b/packages/gjs/src/widgets/editor/scene-card.css
@@ -21,15 +21,18 @@
   box-shadow: 0 0 0 2px @accent_bg_color;
 }
 
-.scene-card-handle {
+.scene-card-lock {
   border-radius: 6px;
-  padding: 3px;
+  padding: 2px;
+  min-width: 0;
+  min-height: 0;
   opacity: 0;
   transition: opacity 150ms ease;
 }
 
-.scene-card:hover .scene-card-handle,
-.scene-card.selected .scene-card-handle {
+.scene-card:hover .scene-card-lock,
+.scene-card.selected .scene-card-lock,
+.scene-card-lock:checked {
   opacity: 1;
 }
 

--- a/packages/gjs/src/widgets/editor/scene-card.css
+++ b/packages/gjs/src/widgets/editor/scene-card.css
@@ -1,17 +1,36 @@
 .scene-card {
   padding: 0;
-  border-radius: 12px;
+  border-radius: 10px;
   min-width: 0;
   min-height: 0;
+  background: none;
 }
 
-.scene-card > .card {
-  border-radius: 12px;
-  background-color: @card_bg_color;
+.scene-card .scene-card-title {
+  padding: 0 2px;
 }
 
-.scene-card.selected > .card {
+/* Subtle frame around the preview only — no filled header bar. */
+.scene-card .scene-card-frame {
+  border-radius: 10px;
+  border: 1px solid alpha(currentColor, 0.15);
+  background-color: alpha(@card_bg_color, 0.4);
+}
+
+.scene-card.selected .scene-card-frame {
   box-shadow: 0 0 0 2px @accent_bg_color;
+}
+
+.scene-card-handle {
+  border-radius: 6px;
+  padding: 3px;
+  opacity: 0;
+  transition: opacity 150ms ease;
+}
+
+.scene-card:hover .scene-card-handle,
+.scene-card.selected .scene-card-handle {
+  opacity: 1;
 }
 
 .scene-card-badge {

--- a/packages/gjs/src/widgets/editor/scene-card.ts
+++ b/packages/gjs/src/widgets/editor/scene-card.ts
@@ -18,8 +18,15 @@ GObject.type_ensure(MiniMap.$gtype)
  * card via `Gtk.Fixed.put(card, x, y)` and toggles the `selected`
  * style class on selection — that drives the accent ring.
  *
- * Layout: title bar (name + dimensions) on top, mini-map below; the
- * event-count badge floats in the top-right overlay corner.
+ * Layout: a free-floating title row (name + dimensions, no header
+ * bar) above the subtly-framed preview; the drag handle sits in the
+ * preview's top-right overlay corner, the event-count badge in the
+ * bottom-right.
+ *
+ * Drag semantics: the corner handle always MOVES the card on the
+ * atlas; dragging the preview content PANS the map section inside it
+ * when the host enabled `pannablePreview` (viewport previews), and
+ * falls back to moving the card otherwise (sample worlds).
  *
  * The card emits the underlying `Gtk.Button::clicked` signal on single
  * click; double-clicks are detected by listening to `clicked` and
@@ -28,6 +35,7 @@ GObject.type_ensure(MiniMap.$gtype)
 export class SceneCard extends Gtk.Button {
   declare _map: MiniMap
   declare _preview_slot: Adw.Bin
+  declare _drag_handle: Gtk.Image
 
   private _sceneName = ''
   private _cols = 0
@@ -36,6 +44,17 @@ export class SceneCard extends Gtk.Button {
   private _lastClickMs = 0
   private _selected = false
   private _dragging = false
+  /**
+   * When true, dragging the preview content pans the map section
+   * inside the card (`preview-pan-*` signals) and only the corner
+   * handle moves the card. When false (sample worlds, no viewport),
+   * any drag moves the card — the pre-viewport behaviour.
+   */
+  private _pannablePreview = false
+  /** Current drag interpretation, decided at gesture-begin. */
+  private _dragMode: 'move' | 'pan' = 'move'
+  /** Last emitted pan offset, for incremental `preview-pan-update`s. */
+  private _lastPan = { dx: 0, dy: 0 }
   // Press point in widget-local coords (captured at drag-begin) and the
   // same point translated into the parent (atlas Fixed) coordinate
   // space. We compute deltas in *parent* space so that moving the card
@@ -51,7 +70,7 @@ export class SceneCard extends Gtk.Button {
       {
         GTypeName: 'PixelRpgSceneCard',
         Template,
-        InternalChildren: ['map', 'preview_slot'],
+        InternalChildren: ['map', 'preview_slot', 'drag_handle'],
         Properties: {
           'scene-name': GObject.ParamSpec.string(
             'scene-name',
@@ -87,6 +106,11 @@ export class SceneCard extends Gtk.Button {
           'scene-drag-begin': {},
           'scene-drag-update': { param_types: [GObject.TYPE_DOUBLE, GObject.TYPE_DOUBLE] },
           'scene-drag-end': { param_types: [GObject.TYPE_DOUBLE, GObject.TYPE_DOUBLE] },
+          // Viewport panning (pannable-preview mode): incremental
+          // widget-pixel deltas while dragging the preview content,
+          // then one `preview-pan-end` for the host to persist.
+          'preview-pan-update': { param_types: [GObject.TYPE_DOUBLE, GObject.TYPE_DOUBLE] },
+          'preview-pan-end': {},
         },
       },
       SceneCard,
@@ -104,6 +128,10 @@ export class SceneCard extends Gtk.Button {
     drag.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
     drag.connect('drag-begin', (_g, x, y) => {
       this._dragging = false
+      // Handle presses always MOVE the card; presses on the preview
+      // content PAN the map section when the host enabled it.
+      this._dragMode = !this._pannablePreview || this._isOnHandle(x, y) ? 'move' : 'pan'
+      this._lastPan = { dx: 0, dy: 0 }
       this._pressLocal = new Graphene.Point()
       this._pressLocal.init(x, y)
       this._pressInParent = this._toParent(this._pressLocal)
@@ -112,9 +140,15 @@ export class SceneCard extends Gtk.Button {
       const dist = Math.hypot(dx, dy)
       if (!this._dragging && dist > 4) {
         this._dragging = true
-        this.emit('scene-drag-begin')
+        if (this._dragMode === 'move') this.emit('scene-drag-begin')
       }
-      if (!this._dragging || !this._pressLocal || !this._pressInParent) return
+      if (!this._dragging) return
+      if (this._dragMode === 'pan') {
+        this.emit('preview-pan-update', dx - this._lastPan.dx, dy - this._lastPan.dy)
+        this._lastPan = { dx, dy }
+        return
+      }
+      if (!this._pressLocal || !this._pressInParent) return
       // Resolve the current cursor position in PARENT space:
       //   current_widget_local = press_local + drag_offset (gesture-provided)
       //   current_in_parent     = compute_point(current_widget_local → parent)
@@ -132,7 +166,10 @@ export class SceneCard extends Gtk.Button {
     })
     drag.connect('drag-end', (_g, dx, dy) => {
       const wasRealDrag = this._dragging
-      if (wasRealDrag && this._pressLocal && this._pressInParent) {
+      if (wasRealDrag && this._dragMode === 'pan') {
+        this.emit('preview-pan-end')
+        this._lastClickMs = 0
+      } else if (wasRealDrag && this._pressLocal && this._pressInParent) {
         const currentLocal = new Graphene.Point()
         currentLocal.init(this._pressLocal.x + dx, this._pressLocal.y + dy)
         const currentInParent = this._toParent(currentLocal)
@@ -168,6 +205,30 @@ export class SceneCard extends Gtk.Button {
       }
     })
     this.add_controller(drag)
+    this._drag_handle?.set_cursor_from_name('grab')
+  }
+
+  /**
+   * Whether the pointer press at card-local `(x, y)` landed on the
+   * corner drag handle (which always moves the card, never pans).
+   */
+  private _isOnHandle(x: number, y: number): boolean {
+    const picked = this.pick(x, y, Gtk.PickFlags.DEFAULT)
+    let widget: Gtk.Widget | null = picked
+    while (widget && widget !== (this as Gtk.Widget)) {
+      if (widget === this._drag_handle) return true
+      widget = widget.get_parent()
+    }
+    return false
+  }
+
+  /** See {@link _pannablePreview}. Set by the atlas for viewport cards. */
+  set pannablePreview(value: boolean) {
+    this._pannablePreview = value
+  }
+
+  get pannablePreview(): boolean {
+    return this._pannablePreview ?? false
   }
 
   /**

--- a/packages/gjs/src/widgets/editor/scene-card.ts
+++ b/packages/gjs/src/widgets/editor/scene-card.ts
@@ -1,5 +1,6 @@
 import type Adw from '@girs/adw-1'
 import GLib from '@girs/glib-2.0'
+import { gettext as _ } from 'gettext'
 import GObject from '@girs/gobject-2.0'
 import Graphene from '@girs/graphene-1.0'
 import Gtk from '@girs/gtk-4.0'
@@ -19,14 +20,15 @@ GObject.type_ensure(MiniMap.$gtype)
  * style class on selection — that drives the accent ring.
  *
  * Layout: a free-floating title row (name + dimensions, no header
- * bar) above the subtly-framed preview; the drag handle sits in the
+ * bar) above the subtly-framed preview; the viewport lock sits in the
  * preview's top-right overlay corner, the event-count badge in the
  * bottom-right.
  *
- * Drag semantics: the corner handle always MOVES the card on the
- * atlas; dragging the preview content PANS the map section inside it
- * when the host enabled `pannablePreview` (viewport previews), and
- * falls back to moving the card otherwise (sample worlds).
+ * Drag semantics: with the lock CLOSED (default) a drag moves the
+ * card on the atlas; with the lock OPEN it pans the map section
+ * inside the preview (`preview-pan-*` signals). The lock is only
+ * shown for viewport previews (`viewportLockable`) — sample worlds
+ * keep plain drag-to-move.
  *
  * The card emits the underlying `Gtk.Button::clicked` signal on single
  * click; double-clicks are detected by listening to `clicked` and
@@ -35,7 +37,7 @@ GObject.type_ensure(MiniMap.$gtype)
 export class SceneCard extends Gtk.Button {
   declare _map: MiniMap
   declare _preview_slot: Adw.Bin
-  declare _drag_handle: Gtk.Image
+  declare _lock_button: Gtk.ToggleButton
 
   private _sceneName = ''
   private _cols = 0
@@ -44,11 +46,12 @@ export class SceneCard extends Gtk.Button {
   private _lastClickMs = 0
   private _selected = false
   private _dragging = false
+  private _viewportLockable = false
   /**
-   * When true, dragging the preview content pans the map section
-   * inside the card (`preview-pan-*` signals) and only the corner
-   * handle moves the card. When false (sample worlds, no viewport),
-   * any drag moves the card — the pre-viewport behaviour.
+   * When true (lock open), dragging the preview content pans the map
+   * section inside the card (`preview-pan-*` signals). When false
+   * (lock closed — the default — or no viewport preview at all), any
+   * drag moves the card. Driven by the lock toggle.
    */
   private _pannablePreview = false
   /** Current drag interpretation, decided at gesture-begin. */
@@ -70,7 +73,7 @@ export class SceneCard extends Gtk.Button {
       {
         GTypeName: 'PixelRpgSceneCard',
         Template,
-        InternalChildren: ['map', 'preview_slot', 'drag_handle'],
+        InternalChildren: ['map', 'preview_slot', 'lock_button'],
         Properties: {
           'scene-name': GObject.ParamSpec.string(
             'scene-name',
@@ -98,6 +101,13 @@ export class SceneCard extends Gtk.Button {
             'Has events',
             'Whether the events badge should be visible',
             GObject.ParamFlags.READABLE,
+            false,
+          ),
+          'viewport-lockable': GObject.ParamSpec.boolean(
+            'viewport-lockable',
+            'Viewport lockable',
+            'Whether the preview-viewport lock toggle is shown (viewport previews only)',
+            GObject.ParamFlags.READWRITE,
             false,
           ),
         },
@@ -130,7 +140,7 @@ export class SceneCard extends Gtk.Button {
       this._dragging = false
       // Handle presses always MOVE the card; presses on the preview
       // content PAN the map section when the host enabled it.
-      this._dragMode = !this._pannablePreview || this._isOnHandle(x, y) ? 'move' : 'pan'
+      this._dragMode = !this._pannablePreview || this._isOnLock(x, y) ? 'move' : 'pan'
       this._lastPan = { dx: 0, dy: 0 }
       this._pressLocal = new Graphene.Point()
       this._pressLocal.init(x, y)
@@ -205,28 +215,44 @@ export class SceneCard extends Gtk.Button {
       }
     })
     this.add_controller(drag)
-    this._drag_handle?.set_cursor_from_name('grab')
+
+    // The lock toggle drives the drag interpretation: closed (default)
+    // = drags move the card, open = drags pan the preview section.
+    this._lock_button?.connect('toggled', () => {
+      this._pannablePreview = this._lock_button.active
+      this._lock_button.set_icon_name(this._lock_button.active ? 'changes-allow-symbolic' : 'changes-prevent-symbolic')
+      this._lock_button.set_tooltip_text(
+        this._lock_button.active ? _('Lock to move the card instead') : _('Unlock to pan the preview section'),
+      )
+    })
   }
 
   /**
    * Whether the pointer press at card-local `(x, y)` landed on the
-   * corner drag handle (which always moves the card, never pans).
+   * lock toggle (whose drags should never pan the preview).
    */
-  private _isOnHandle(x: number, y: number): boolean {
+  private _isOnLock(x: number, y: number): boolean {
     const picked = this.pick(x, y, Gtk.PickFlags.DEFAULT)
     let widget: Gtk.Widget | null = picked
     while (widget && widget !== (this as Gtk.Widget)) {
-      if (widget === this._drag_handle) return true
+      if (widget === this._lock_button) return true
       widget = widget.get_parent()
     }
     return false
   }
 
-  /** See {@link _pannablePreview}. Set by the atlas for viewport cards. */
-  set pannablePreview(value: boolean) {
-    this._pannablePreview = value
+  /** Show the viewport lock — set by the atlas for viewport previews. */
+  set viewportLockable(value: boolean) {
+    if (this._viewportLockable === value) return
+    this._viewportLockable = value
+    this.notify('viewport-lockable')
   }
 
+  get viewportLockable(): boolean {
+    return this._viewportLockable ?? false
+  }
+
+  /** See {@link _pannablePreview}. Driven by the lock toggle. */
   get pannablePreview(): boolean {
     return this._pannablePreview ?? false
   }


### PR DESCRIPTION
## Viewport scene-card previews + card redesign

Implements the agreed atlas-preview concept:

- **Uniform pixel zoom, cropped section**: cards render their map at a global native-pixel zoom (default **200%**) cropped to the card instead of squeezing the whole map in — every preview shares one resolution and content is actually recognizable. Card size stays map-proportional.
- **Global zoom control**: the scene editor's `FloatingZoom` pill also sits in the atlas (bottom-left). `win.zoom-in/out/reset` route to the global card-preview zoom while the atlas is visible, to the engine camera elsewhere.
- **Per-card viewport lock** (top-right, on hover/selection): closed (default) = dragging moves the card on the atlas; open = dragging pans the map section inside the preview. Pan ends persist `editorData.preview {tileX,tileY}` to disk + as a `__project/map.editor-data` op (same flow as atlas positions).
- **Background pan**: dragging the empty atlas backdrop scrolls the atlas (denies itself over cards).
- **Card redesign**: free-floating title row (name + dimensions, no header bar), subtle frame, events badge bottom-right.

### Rendering
`MapPreview` gains a viewport mode: region bakes at the zoom factor through the existing bake queue, whole-map-pixel bake origin (fractional origins caused NEAREST clip-edge seams), stale-texture shifting while a pan's re-bake is pending, ops built per bake from retained source data (no persistent six-figure op arrays).

### Verification
Visual: atlas shows crisp 2× sections with correct room colours, zoom pill reads 200%, no seams (window screenshot). Checks + 748 engine tests green; biome clean. Pointer gestures (lock toggle, pan, background scroll) need a quick manual pass — they can't be driven over the MCP bridge yet.