### PR TITLE
perf(engine): build TileMaps lazily on first scene use

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@ Conventions:
 ## Atlas / world
 
 - **Viewport scene-card previews — SHIPPED** (uniform 200% default zoom, atlas-global zoom via the scene editor's FloatingZoom pill routed through `win.zoom-*`, per-card lock toggle: closed = drag moves the card, open = drag pans the section, persisted as `editorData.preview`). Remaining polish: the global atlas zoom is session-only (not persisted per project); the welcome view still uses fit-whole-map previews by design. *owner: gjs (MapPreview) + maker*
-- **Atlas load time for big projects** — opening `games/oot2d-2014` (19 maps, 18 MB) takes ~19 s to the atlas; the project now loads **twice** (`loadProjectAsAtlas` + the welcome/engine path each construct a `GameProjectResource`) and repeated loads in one session can OOM GJS. Deduplicate to one shared resource per open project (existing "GameProjectResource double copy" debt) and consider lazy map parsing. *owner: maker / engine*
+- **Atlas load time for big projects — FIXED via lazy TileMap build**: `MapResource.load()` no longer constructs the per-tier Excalibur `TileMap`s (1.25M `Tile` objects across the 19 oot2d maps); they build on first scene use (`ensureTileMaps`). Opening `games/oot2d-2014` is now ~1.3 s to the atlas (was ~19 s), and the GJS OOM after repeated opens disappeared with the object churn. `GameProjectResource.load()` logs per-phase timings (data / sprite sets / maps) at info level. Still open: the project is parsed by several `GameProjectResource` instances per session (welcome template card, atlas, engine at scene open — each ~0.5 s now). Sharing ONE resource per open project (the "double copy" debt) remains the structural cleanup. *owner: maker / engine*
 
 ## Welcome / project lifecycle
 

--- a/packages/engine/src/resource/GameProjectResource.ts
+++ b/packages/engine/src/resource/GameProjectResource.ts
@@ -174,9 +174,11 @@ export class GameProjectResource {
    */
   async load(): Promise<GameProjectData> {
     try {
+      const t0 = Date.now()
       // Load the game project data
       const fullPath = joinPaths(this.baseDir, this.filename)
       this.data = await this.loadGameProjectData(fullPath)
+      const tData = Date.now()
 
       // Determine initial map ID
       const initialMapId = this.customInitialMapId || this.data.startup.initialMapId
@@ -185,6 +187,7 @@ export class GameProjectResource {
       if (this.preloadAllSpriteSets) {
         await this.loadSpriteSets()
       }
+      const tSheets = Date.now()
 
       // Load all maps if configured to preload
       if (this.preloadAllMaps) {
@@ -193,9 +196,13 @@ export class GameProjectResource {
 
       // Load the initial map
       await this.loadMap(initialMapId)
+      const tMaps = Date.now()
 
       this._isLoaded = true
-      this.logger.info(`Game project "${this.data.name}" loaded successfully`)
+      this.logger.info(
+        `Game project "${this.data.name}" loaded successfully ` +
+          `(data ${tData - t0}ms, sprite sets ${tSheets - tData}ms, maps ${tMaps - tSheets}ms)`,
+      )
 
       return this.data
     } catch (error) {

--- a/packages/engine/src/resource/MapResource.ts
+++ b/packages/engine/src/resource/MapResource.ts
@@ -116,7 +116,6 @@ export class MapResource implements Loadable<TileMap> {
    * checking "does this tier exist".
    */
   private createTileMaps(data: MapData): void {
-    MapFormat.validate(data)
     for (const tier of LAYER_TIERS) {
       const tilemap = this.buildSingleTileMap(data, tier)
       tilemap.addComponent(new TileMapTierComponent(tier))
@@ -215,35 +214,54 @@ export class MapResource implements Loadable<TileMap> {
     }
   }
 
+  /**
+   * Parse the map JSON + resolve its sprite sets. The Excalibur
+   * `TileMap`s (one `Tile` object per cell per tier — six figures for
+   * the big ported worlds) are NOT built here: projects preload every
+   * map for the atlas/previews/snapshots, which only read `mapData`.
+   * {@link ensureTileMaps} builds them on first scene use.
+   *
+   * `Loadable` consumers gate on {@link isLoaded}; the returned
+   * `TileMap` is only meaningful once the tilemaps exist.
+   */
   async load(): Promise<TileMap> {
     try {
       const mapDataPath = joinPaths(this.basePath, this.filename)
       const mapDataText = await loadTextFile(mapDataPath)
       this._mapData = MapFormat.deserialize(mapDataText)
-
-      this.createTileMaps(this._mapData)
-      // Loadable<TileMap> contract — point `data` at the ground
-      // tilemap. Callers that need a specific tier should walk the
-      // scene by `TileMapTierComponent` instead.
-      const groundTileMap = this.tileMapsByTier.get(DEFAULT_LAYER_TIER)
-      if (!groundTileMap) throw new Error('Failed to build ground tilemap')
-      this.data = groundTileMap
+      MapFormat.validate(this._mapData)
 
       await this.loadSpriteSets()
 
-      this.processLayers(this._mapData)
-
-      return groundTileMap
+      return this.data
     } catch (error) {
       this.logger.error(`Failed to load map: ${error}`)
       throw error
     }
   }
 
+  /**
+   * Build the per-tier `TileMap`s + the editor shadow state from the
+   * loaded map data. Idempotent — the first scene to use this map
+   * pays the (large) tile-allocation cost, later calls are no-ops.
+   */
+  ensureTileMaps(): void {
+    if (this.tileMapsByTier.size > 0) return
+    if (!this._mapData) throw new Error('Map resource not loaded')
+
+    this.createTileMaps(this._mapData)
+    // Loadable<TileMap> contract — point `data` at the ground
+    // tilemap. Callers that need a specific tier should walk the
+    // scene by `TileMapTierComponent` instead.
+    const groundTileMap = this.tileMapsByTier.get(DEFAULT_LAYER_TIER)
+    if (!groundTileMap) throw new Error('Failed to build ground tilemap')
+    this.data = groundTileMap
+
+    this.processLayers(this._mapData)
+  }
+
   addToScene(scene: Scene): void {
-    if (this.tileMapsByTier.size === 0) {
-      throw new Error('Map resource not loaded')
-    }
+    this.ensureTileMaps()
 
     for (const tier of LAYER_TIERS) {
       const tileMap = this.tileMapsByTier.get(tier)
@@ -497,6 +515,8 @@ export class MapResource implements Loadable<TileMap> {
   }
 
   isLoaded(): boolean {
-    return !!this.data
+    // Loaded = map data parsed. The TileMaps build lazily on first
+    // scene use (`ensureTileMaps`) — `data` stays unset until then.
+    return !!this._mapData
   }
 }


### PR DESCRIPTION
MapResource.load() eagerly built the per-tier Excalibur TileMaps —
one Tile object per cell per tier, ~1.25M objects across the 19
oot2d-2014 maps — although project preloading only needs the parsed
mapData (atlas previews, snapshots, agent projections). Opening that
project took ~19 s and repeated opens could OOM GJS.

- load() now parses + validates the JSON and resolves sprite sets;
  ensureTileMaps() builds the tilemaps + editor shadow on first
  addToScene (idempotent; the map cache makes re-entries free)
- isLoaded() gates on the parsed map data (Loadable contract)
- syncShadowToMapData() already guarded the never-built case
- GameProjectResource.load() logs per-phase timings at info level

Measured: oot2d-2014 open is now ~1.3 s to the atlas (worst case,
right after app start), scene open + engine render verified intact.
