### PR TITLE
fix(atlas): make the viewport lock clickable + inspector switch

### DIFF
--- a/apps/maker-gjs/src/widgets/atlas-view.ts
+++ b/apps/maker-gjs/src/widgets/atlas-view.ts
@@ -45,6 +45,7 @@ export class AtlasView extends ResponsiveEditorView {
   private _teleports: SampleTeleport[] = SAMPLE_TELEPORTS
   private _projectName = SAMPLE_SCENES.length ? "Aria's Quest" : 'New Project'
   private _projectResource: GameProjectResource | null = null
+  private _selectedSceneId: string | null = null
 
   static {
     GObject.registerClass(
@@ -144,8 +145,10 @@ export class AtlasView extends ResponsiveEditorView {
    * stays silent).
    */
   private _refreshSelectedScene(id: string): void {
+    this._selectedSceneId = id
     const scene = this._scenes.find((s) => s.id === id) ?? null
     this._inspector.setScene(scene, this._scenes, this._teleports, this._projectResource)
+    this._inspector.setPreviewLock(scene ? this._atlas.getPreviewLock(id) : null)
     this.emit('scene-selected', id)
   }
 
@@ -181,6 +184,16 @@ export class AtlasView extends ResponsiveEditorView {
     })
     this.signals.connect(this._atlas, 'preview-moved', (_a: AtlasCanvas, id: string, tileX: number, tileY: number) => {
       this.emit('preview-moved', id, tileX, tileY)
+    })
+    // Viewport lock, both directions: card toggle → inspector switch,
+    // inspector switch → card. Both ends guard against echo loops
+    // (the card setter no-ops on same value, the inspector suppresses
+    // programmatic updates).
+    this.signals.connect(this._atlas, 'preview-lock-changed', (_a: AtlasCanvas, id: string, unlocked: boolean) => {
+      if (id === this._selectedSceneId) this._inspector.setPreviewLock(unlocked)
+    })
+    this.signals.connect(this._inspector, 'preview-lock-changed', (_i: SceneInspector, unlocked: boolean) => {
+      if (this._selectedSceneId) this._atlas.setPreviewLock(this._selectedSceneId, unlocked)
     })
     this.signals.connect(this._mode_rail, 'mode-changed', (_r: ModeRail, mode: string) => {
       this.emit('mode-changed', mode as EditorMode)

--- a/packages/gjs/src/widgets/editor/atlas-canvas.ts
+++ b/packages/gjs/src/widgets/editor/atlas-canvas.ts
@@ -82,6 +82,11 @@ export class AtlasCanvas extends Adw.Bin {
           'preview-moved': {
             param_types: [GObject.TYPE_STRING, GObject.TYPE_DOUBLE, GObject.TYPE_DOUBLE],
           },
+          // A card's viewport lock flipped (`true` = open/pannable) —
+          // lets hosts mirror the state (e.g. the inspector's switch).
+          'preview-lock-changed': {
+            param_types: [GObject.TYPE_STRING, GObject.TYPE_BOOLEAN],
+          },
         },
       },
       AtlasCanvas,
@@ -240,6 +245,26 @@ export class AtlasCanvas extends Adw.Bin {
       const centre = preview.commitViewport()
       if (centre) this.emit('preview-moved', scene.id, centre.tileX, centre.tileY)
     })
+    card.connect('lock-changed', (_c: SceneCard, unlocked: boolean) => {
+      this.emit('preview-lock-changed', scene.id, unlocked)
+    })
+  }
+
+  /**
+   * Lock state of a card's preview viewport: `true` = open (drag pans
+   * the section), `false` = closed, `null` = the scene has no viewport
+   * preview (sample worlds / unknown id).
+   */
+  getPreviewLock(sceneId: string): boolean | null {
+    const card = this._cards.get(sceneId)
+    if (!card?.viewportLockable) return null
+    return card.previewUnlocked
+  }
+
+  /** Flip a card's viewport lock (the inspector's switch drives this). */
+  setPreviewLock(sceneId: string, unlocked: boolean): void {
+    const card = this._cards.get(sceneId)
+    if (card?.viewportLockable) card.previewUnlocked = unlocked
   }
 
   private _wireDrag(sceneId: string, card: SceneCard): void {

--- a/packages/gjs/src/widgets/editor/scene-card.ts
+++ b/packages/gjs/src/widgets/editor/scene-card.ts
@@ -48,6 +48,13 @@ export class SceneCard extends Gtk.Button {
   private _dragging = false
   private _viewportLockable = false
   /**
+   * Whether the current press began on the lock toggle. The card is a
+   * `Gtk.Button`, whose click gesture runs in the CAPTURE phase — the
+   * nested `Gtk.ToggleButton` never receives the press, so the card
+   * routes lock clicks manually in {@link _onClicked}.
+   */
+  private _pressOnLock = false
+  /**
    * When true (lock open), dragging the preview content pans the map
    * section inside the card (`preview-pan-*` signals). When false
    * (lock closed — the default — or no viewport preview at all), any
@@ -121,6 +128,9 @@ export class SceneCard extends Gtk.Button {
           // then one `preview-pan-end` for the host to persist.
           'preview-pan-update': { param_types: [GObject.TYPE_DOUBLE, GObject.TYPE_DOUBLE] },
           'preview-pan-end': {},
+          // Lock state flipped (via the card toggle or
+          // `previewUnlocked`). Payload: `true` = open/pannable.
+          'lock-changed': { param_types: [GObject.TYPE_BOOLEAN] },
         },
       },
       SceneCard,
@@ -138,9 +148,11 @@ export class SceneCard extends Gtk.Button {
     drag.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
     drag.connect('drag-begin', (_g, x, y) => {
       this._dragging = false
-      // Handle presses always MOVE the card; presses on the preview
-      // content PAN the map section when the host enabled it.
-      this._dragMode = !this._pannablePreview || this._isOnLock(x, y) ? 'move' : 'pan'
+      this._pressOnLock = this._isOnLock(x, y)
+      // Lock presses always MOVE the card (a click toggles instead —
+      // see `_onClicked`); presses on the preview content PAN the map
+      // section when the lock is open.
+      this._dragMode = !this._pannablePreview || this._pressOnLock ? 'move' : 'pan'
       this._lastPan = { dx: 0, dy: 0 }
       this._pressLocal = new Graphene.Point()
       this._pressLocal.init(x, y)
@@ -224,7 +236,18 @@ export class SceneCard extends Gtk.Button {
       this._lock_button.set_tooltip_text(
         this._lock_button.active ? _('Lock to move the card instead') : _('Unlock to pan the preview section'),
       )
+      this.emit('lock-changed', this._lock_button.active)
     })
+  }
+
+  /** Lock state — `true` = open (drag pans the preview section). */
+  get previewUnlocked(): boolean {
+    return this._lock_button?.active ?? false
+  }
+
+  set previewUnlocked(value: boolean) {
+    if (!this._lock_button || this._lock_button.active === value) return
+    this._lock_button.active = value
   }
 
   /**
@@ -345,6 +368,21 @@ export class SceneCard extends Gtk.Button {
 
   private _onClicked(): void {
     if (this._dragging) return
+    // Lock clicks: the card button claims every press in its CAPTURE
+    // phase, so the nested toggle never fires — toggle it here and
+    // suppress the host's `clicked` select handler through the same
+    // idle-reset window the drag suppression uses.
+    if (this._pressOnLock && this._viewportLockable) {
+      this._pressOnLock = false
+      this._lock_button.set_active(!this._lock_button.active)
+      this._lastClickMs = 0
+      this._dragging = true
+      GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+        this._dragging = false
+        return false
+      })
+      return
+    }
     const now = Date.now()
     if (now - this._lastClickMs < 350) {
       this.emit('scene-activated')

--- a/packages/gjs/src/widgets/editor/scene-inspector.blp
+++ b/packages/gjs/src/widgets/editor/scene-inspector.blp
@@ -84,6 +84,18 @@ template $PixelRpgSceneInspector : Adw.Bin {
         margin-top: 6;
       }
 
+      // Mirrors the card's viewport lock — only shown for viewport
+      // previews (real projects). Open = dragging the card pans its
+      // map section instead of moving the card.
+      Adw.PreferencesGroup lock_group {
+        visible: false;
+
+        Adw.SwitchRow lock_row {
+          title: _("Pan preview section");
+          subtitle: _("Dragging the card moves its map section");
+        }
+      }
+
       Adw.PreferencesGroup teleports_group {
         title: _("Teleports");
         visible: bind template.has-teleports;

--- a/packages/gjs/src/widgets/editor/scene-inspector.ts
+++ b/packages/gjs/src/widgets/editor/scene-inspector.ts
@@ -36,6 +36,8 @@ export class SceneInspector extends Adw.Bin {
   declare _subtitle_label: Gtk.Label
   declare _stats_grid: Gtk.Grid
   declare _teleports_group: Adw.PreferencesGroup
+  declare _lock_group: Adw.PreferencesGroup
+  declare _lock_row: Adw.SwitchRow
   declare _open_button: Gtk.Button
   declare _empty_state: Adw.StatusPage
   declare _body: Gtk.Box
@@ -46,6 +48,8 @@ export class SceneInspector extends Adw.Bin {
   private _statRows: Gtk.Widget[] = []
   private _teleportRows: Adw.ActionRow[] = []
   private _collapsed = false
+  /** Guards the lock switch against programmatic-update feedback. */
+  private _syncingLock = false
 
   static {
     GObject.registerClass(
@@ -58,10 +62,18 @@ export class SceneInspector extends Adw.Bin {
           'subtitle_label',
           'stats_grid',
           'teleports_group',
+          'lock_group',
+          'lock_row',
           'open_button',
           'empty_state',
           'body',
         ],
+        Signals: {
+          // The user flipped the viewport-lock switch — payload
+          // `true` = open/pannable. Programmatic `setPreviewLock`
+          // updates do NOT re-emit.
+          'preview-lock-changed': { param_types: [GObject.TYPE_BOOLEAN] },
+        },
         Properties: {
           'scene-name': GObject.ParamSpec.string(
             'scene-name',
@@ -160,6 +172,29 @@ export class SceneInspector extends Adw.Bin {
     if (this._collapsed === value) return
     this._collapsed = value
     this.notify('collapsed')
+  }
+
+  constructor() {
+    super()
+    this._lock_row.connect('notify::active', () => {
+      if (this._syncingLock) return
+      this.emit('preview-lock-changed', this._lock_row.active)
+    })
+  }
+
+  /**
+   * Mirror the selected card's viewport-lock state into the switch.
+   * `null` hides the row (scene without a viewport preview / no
+   * selection). Programmatic — does not re-emit `preview-lock-changed`.
+   */
+  setPreviewLock(unlocked: boolean | null): void {
+    this._syncingLock = true
+    try {
+      this._lock_group.set_visible(unlocked !== null && this._scene != null)
+      if (unlocked !== null) this._lock_row.set_active(unlocked)
+    } finally {
+      this._syncingLock = false
+    }
   }
 
   private _refreshPreview(): void {
@@ -291,6 +326,8 @@ export class SceneInspector extends Adw.Bin {
     this._stats_grid.set_visible(populated)
     this._open_button.set_visible(populated)
     this._empty_state.set_visible(!populated)
+    // Re-shown per selection via `setPreviewLock` — default hidden.
+    if (!populated) this._lock_group.set_visible(false)
   }
 }
 


### PR DESCRIPTION
The lock toggle never received clicks: the scene card is a
Gtk.Button whose click gesture runs in the CAPTURE phase, so the
nested ToggleButton's press was claimed by the card. The card now
detects lock presses itself (the drag gesture already picks the
press target) and toggles the lock from its own clicked handler,
suppressing the host's select via the existing idle-reset window.

The scene inspector additionally mirrors the lock as a switch row
('Pan preview section') for the selected map — synced both ways
with echo guards (card toggle -> switch, switch -> card).
