### PR TITLE
fix(engine): harden collab transport edge cases

### DIFF
--- a/packages/engine/src/sync/peer-session.spec.ts
+++ b/packages/engine/src/sync/peer-session.spec.ts
@@ -170,8 +170,8 @@ export default async () => {
       expect(answer).toBeDefined()
     })
 
-    await it('forwards ICE candidates over signalling and applies inbound ones', async () => {
-      const { hostTransport, joinerTransport } = pair()
+    await it('forwards local ICE candidates over signalling', async () => {
+      const { hostTransport } = pair()
       const fakePc = new FakeRTCPeerConnection()
       const session = new PeerSession({
         role: 'host',
@@ -186,10 +186,94 @@ export default async () => {
       if (last?.type === 'ice-candidate') {
         expect((last.payload as { candidate: string }).candidate).toBe('a=fake')
       }
+    })
 
-      joinerTransport.send({ type: 'ice-candidate', payload: { candidate: 'a=remote' } })
+    await it('buffers inbound ICE until the remote description is set, then drains in order', async () => {
+      const { hostTransport, joinerTransport } = pair()
+      const fakePc = new FakeRTCPeerConnection()
+      const session = new PeerSession({
+        role: 'host',
+        signalling: hostTransport,
+        rtcFactory: factoryFor(fakePc),
+      })
+      void session
+
+      // Two candidates arrive BEFORE the SDP answer — must be buffered,
+      // not applied (addIceCandidate before setRemoteDescription throws).
+      joinerTransport.send({ type: 'ice-candidate', payload: { candidate: 'a=remote-1' } })
+      joinerTransport.send({ type: 'ice-candidate', payload: { candidate: 'a=remote-2' } })
       await new Promise((r) => queueMicrotask(() => r(undefined)))
-      expect(fakePc.addedIce).toStrictEqual([{ candidate: 'a=remote' }])
+      await new Promise((r) => queueMicrotask(() => r(undefined)))
+      expect(fakePc.addedIce).toStrictEqual([])
+
+      // The SDP answer sets the remote description → buffered candidates drain in order.
+      joinerTransport.send({ type: 'sdp', payload: { type: 'answer', sdp: 'fake-answer' } })
+      await new Promise((r) => queueMicrotask(() => r(undefined)))
+      await new Promise((r) => queueMicrotask(() => r(undefined)))
+      expect(fakePc.remoteDescription?.type).toBe('answer')
+      expect(fakePc.addedIce).toStrictEqual([{ candidate: 'a=remote-1' }, { candidate: 'a=remote-2' }])
+
+      // A candidate that arrives AFTER the remote description is applied immediately.
+      joinerTransport.send({ type: 'ice-candidate', payload: { candidate: 'a=remote-3' } })
+      await new Promise((r) => queueMicrotask(() => r(undefined)))
+      expect(fakePc.addedIce).toStrictEqual([
+        { candidate: 'a=remote-1' },
+        { candidate: 'a=remote-2' },
+        { candidate: 'a=remote-3' },
+      ])
+    })
+
+    await it('a transient disconnected within the grace window does not close the session', async () => {
+      const { hostTransport } = pair()
+      const fakePc = new FakeRTCPeerConnection()
+      const session = new PeerSession({
+        role: 'host',
+        signalling: hostTransport,
+        rtcFactory: factoryFor(fakePc),
+        disconnectGraceMs: 10_000,
+      })
+
+      let closed = false
+      session.events.on('closed', () => {
+        closed = true
+      })
+
+      // ICE blip: disconnected → recovers to connected before the grace elapses.
+      fakePc.connectionState = 'disconnected'
+      fakePc.onconnectionstatechange?.()
+      expect(closed).toBe(false)
+      expect(session.getState()).not.toBe('closed')
+
+      fakePc.connectionState = 'connected'
+      fakePc.onconnectionstatechange?.()
+      // Give any (incorrectly scheduled) timer a chance to fire.
+      await new Promise((r) => setTimeout(r, 0))
+      expect(closed).toBe(false)
+      expect(session.getState()).not.toBe('closed')
+    })
+
+    await it('a disconnected state that persists past the grace window closes the session', async () => {
+      const { hostTransport } = pair()
+      const fakePc = new FakeRTCPeerConnection()
+      const session = new PeerSession({
+        role: 'host',
+        signalling: hostTransport,
+        rtcFactory: factoryFor(fakePc),
+        disconnectGraceMs: 0,
+      })
+
+      let reason: string | undefined
+      session.events.on('closed', ({ reason: r }) => {
+        reason = r
+      })
+
+      fakePc.connectionState = 'disconnected'
+      fakePc.onconnectionstatechange?.()
+      // Grace is 0 → close fires on the next macrotask.
+      await new Promise((r) => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
+      expect(session.getState()).toBe('closed')
+      expect(reason).toBe('peer-disconnected')
     })
 
     await it('emits state-changed → connected once both channels open', async () => {

--- a/packages/engine/src/sync/peer-session.ts
+++ b/packages/engine/src/sync/peer-session.ts
@@ -26,6 +26,15 @@ export interface PeerSessionOptions {
   rtcFactory?: RTCPeerConnectionFactory
   /** Override the default STUN-only ICE config. */
   iceServers?: readonly RTCIceServer[]
+  /**
+   * Grace period, in ms, before a transient `connectionState ===
+   * 'disconnected'` is treated as a hard close. WebRTC uses
+   * `disconnected` for a momentary ICE-consent blip (Wi-Fi hiccup,
+   * brief packet loss) that usually recovers to `connected` on its
+   * own — only `failed` is terminal. Defaults to 5 s. Tests pass `0`
+   * to exercise the elapse path on the next macrotask.
+   */
+  disconnectGraceMs?: number
 }
 
 /**
@@ -85,6 +94,9 @@ function plog(role: PeerRole, message: string): void {
   }
 }
 
+/** Default grace before a transient `disconnected` becomes a hard close. */
+const DEFAULT_DISCONNECT_GRACE_MS = 5_000
+
 export class PeerSession {
   public readonly events = new EventEmitter<PeerSessionEventMap>()
 
@@ -97,10 +109,21 @@ export class PeerSession {
   private closed = false
   private iceLocalCount = 0
   private iceRemoteCount = 0
+  // ICE candidates must not be added before the remote description is
+  // set — `addIceCandidate` throws / drops them otherwise. Inbound
+  // candidates that arrive first are buffered here and drained once
+  // `setRemoteDescription` completes (host glare, fast joiners).
+  private remoteDescriptionSet = false
+  private readonly pendingIce: RTCIceCandidateInit[] = []
+  // Running grace timer for a transient `disconnected` state (see
+  // `disconnectGraceMs`); cleared on recovery or close.
+  private disconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private readonly disconnectGraceMs: number
 
   constructor(opts: PeerSessionOptions) {
     this.role = opts.role
     this.signalling = opts.signalling
+    this.disconnectGraceMs = opts.disconnectGraceMs ?? DEFAULT_DISCONNECT_GRACE_MS
 
     const factory = opts.rtcFactory ?? resolveRTCPeerConnection()
     if (!factory) {
@@ -150,11 +173,19 @@ export class PeerSession {
     this.pc.onconnectionstatechange = () => {
       plog(this.role, `pc.connectionState → ${this.pc.connectionState}`)
       switch (this.pc.connectionState) {
+        case 'connected':
+          // Recovered (possibly from a transient `disconnected`) —
+          // cancel any pending grace close.
+          this.clearDisconnectTimer()
+          break
         case 'failed':
           this.fail(new Error('peer connection failed'))
           break
         case 'disconnected':
-          if (!this.closed) this.close('peer-disconnected')
+          // Transient by spec — wait out a grace window before closing,
+          // because the ICE agent often recovers to `connected` on its
+          // own. Only `failed` is terminal.
+          this.scheduleDisconnectClose()
           break
       }
     }
@@ -207,6 +238,7 @@ export class PeerSession {
   close(reason = 'closed'): void {
     if (this.closed) return
     this.closed = true
+    this.clearDisconnectTimer()
     try {
       this.signalling.send({ type: 'bye', payload: { reason } })
     } catch {
@@ -302,6 +334,10 @@ export class PeerSession {
           plog(this.role, `received SDP ${msg.payload.type} (sdp.length=${msg.payload.sdp?.length ?? 0})`)
           await this.pc.setRemoteDescription(msg.payload)
           plog(this.role, `setRemoteDescription(${msg.payload.type}) OK`)
+          this.remoteDescriptionSet = true
+          // Guard the await so the common no-buffered-candidate handshake
+          // keeps its original microtask timing (no extra tick).
+          if (this.pendingIce.length > 0) await this.drainPendingIce()
           if (this.role === 'joiner') {
             plog('joiner', 'createAnswer()…')
             const answer = await this.pc.createAnswer()
@@ -325,6 +361,13 @@ export class PeerSession {
           }
           this.iceRemoteCount++
           plog(this.role, `ICE remote #${this.iceRemoteCount}: ${msg.payload.candidate ?? '<no candidate string>'}`)
+          if (!this.remoteDescriptionSet) {
+            // Arrived before the SDP answer/offer — buffer until the
+            // remote description is in place, then drain (see drainPendingIce).
+            plog(this.role, `ICE remote #${this.iceRemoteCount}: buffered (no remote description yet)`)
+            this.pendingIce.push(msg.payload)
+            return
+          }
           await this.pc.addIceCandidate(msg.payload)
           break
         }
@@ -343,6 +386,54 @@ export class PeerSession {
     if (this.state === 'connected' || this.closed) return
     if (this.opChannel?.readyState === 'open' && this.awarenessChannel?.readyState === 'open') {
       this.transitionTo('connected')
+    }
+  }
+
+  /** Flush ICE candidates buffered before the remote description was set. */
+  private async drainPendingIce(): Promise<void> {
+    if (this.pendingIce.length === 0) return
+    const buffered = this.pendingIce.splice(0)
+    plog(this.role, `ICE: draining ${buffered.length} buffered candidate(s)`)
+    for (const candidate of buffered) {
+      try {
+        await this.pc.addIceCandidate(candidate)
+      } catch (err) {
+        // A single bad candidate must not fail the whole connection —
+        // the ICE agent tolerates losing one. Log and continue.
+        plog(this.role, `ICE: buffered candidate rejected: ${formatErrorMessage(err)}`)
+      }
+    }
+  }
+
+  /**
+   * Start the grace timer for a transient `disconnected` state. If a
+   * timer is already running, leave it — the window measures from the
+   * first `disconnected` transition. Closes only if still disconnected
+   * when the window elapses.
+   */
+  private scheduleDisconnectClose(): void {
+    if (this.closed || this.disconnectTimer !== null) return
+    if (this.disconnectGraceMs <= 0) {
+      this.disconnectTimer = setTimeout(() => this.onDisconnectGraceElapsed(), 0)
+      return
+    }
+    this.disconnectTimer = setTimeout(() => this.onDisconnectGraceElapsed(), this.disconnectGraceMs)
+  }
+
+  private onDisconnectGraceElapsed(): void {
+    this.disconnectTimer = null
+    if (this.closed) return
+    // Recovered to a non-disconnected state during the grace window?
+    // Then leave the connection alone.
+    if (this.pc.connectionState === 'disconnected') {
+      this.close('peer-disconnected')
+    }
+  }
+
+  private clearDisconnectTimer(): void {
+    if (this.disconnectTimer !== null) {
+      clearTimeout(this.disconnectTimer)
+      this.disconnectTimer = null
     }
   }
 

--- a/packages/engine/src/sync/snapshot-exchange.spec.ts
+++ b/packages/engine/src/sync/snapshot-exchange.spec.ts
@@ -363,6 +363,51 @@ export default async () => {
       }
     })
 
+    await it('a timed-out request clears partial chunks so a retry reassembles cleanly', async () => {
+      // Pre-fix: the timeout path nulled `pending` but left the
+      // partially-received chunks in the reassembler. A retry then
+      // mixed the stale chunk (totalChunks=3) with the new transfer
+      // and tripped "chunk batch size changed mid-stream".
+      const sessions = await createConnectedSessionPair()
+      try {
+        const joinerExchange = exchangeFor(sessions.joiner, 'joiner-retry', () => null)
+
+        // Request 1: receive a partial chunk (0 of 3), then time out.
+        const first = joinerExchange.request('room-partial', 50)
+        await flushMicrotasks()
+        sessions.host.sendOp({
+          kind: SNAPSHOT_CHUNK_KIND,
+          payload: { chunkIndex: 0, totalChunks: 3, data: '{"part' },
+          peerId: 'host-retry',
+          seq: 0,
+        })
+        let firstErr: Error | null = null
+        try {
+          await first
+        } catch (err) {
+          firstErr = err as Error
+        }
+        expect(firstErr?.message).toContain('timed out')
+
+        // Request 2: a fresh single-chunk transfer must reassemble
+        // cleanly — no leftover chunk from request 1.
+        const second = joinerExchange.request('room-retry', 2_000)
+        await flushMicrotasks()
+        sessions.host.sendOp({
+          kind: SNAPSHOT_CHUNK_KIND,
+          payload: { chunkIndex: 0, totalChunks: 1, data: JSON.stringify(FAKE_SNAPSHOT) },
+          peerId: 'host-retry',
+          seq: 1,
+        })
+        const received = await second
+        expect(received.project.id).toBe('shared')
+
+        joinerExchange.dispose()
+      } finally {
+        sessions.close()
+      }
+    })
+
     await it('rejects invalid chunk envelopes (negative index, totalChunks=0)', async () => {
       const sessions = await createConnectedSessionPair()
       try {

--- a/packages/engine/src/sync/snapshot-exchange.ts
+++ b/packages/engine/src/sync/snapshot-exchange.ts
@@ -131,7 +131,9 @@ export class SnapshotExchange {
   private readonly chunkSizeBytes: number
   private pending: PendingRequest | null = null
   // Shared validated reassembler (chunking.ts); one transfer at a time
-  // keyed by the fixed id — a new request resets it.
+  // keyed by the fixed id. Every settle path (resolve / fail / timeout /
+  // dispose) clears it, and `request()` clears it again defensively so a
+  // retry can never reassemble across a previous transfer's stale chunks.
   private readonly chunks = new ChunkReassembler<ProjectSnapshot>()
   private localSeq = 0
   private disposed = false
@@ -187,16 +189,20 @@ export class SnapshotExchange {
     if (this.pending) {
       return Promise.reject(new Error('SnapshotExchange: a snapshot request is already in flight — await it first'))
     }
+    // Defensive reset: guarantees the reassembler starts empty even if a
+    // previous transfer left partial chunks behind (see `chunks` above).
+    this.chunks.clear()
 
     return new Promise<ProjectSnapshot>((resolve, reject) => {
       const ms = timeoutMs ?? this.defaultTimeoutMs
       const timer =
         ms > 0
           ? setTimeout(() => {
+              // Route through failPending so the partial-chunk buffer is
+              // cleared alongside the pending request — a bare null-out
+              // would strand received chunks for the next retry.
               if (this.pending?.timer === timer) {
-                const p = this.pending
-                this.pending = null
-                p.reject(new Error(`SnapshotExchange: request timed out after ${ms} ms`))
+                this.failPending(new Error(`SnapshotExchange: request timed out after ${ms} ms`))
               }
             }, ms)
           : null


### PR DESCRIPTION
## Summary

Three independent robustness fixes in `packages/engine/src/sync`, surfaced by an audit of the collaboration transport layer. Each is small, self-contained, and unit-tested.

### 1. Buffer inbound ICE candidates until the remote description is set
`PeerSession.handleSignal` called `addIceCandidate` immediately for every inbound `ice-candidate`, with no gate on whether `setRemoteDescription` had completed. A candidate that arrives first is dropped/throws — a likely contributor to the known **~1-in-3 intermittent connect failures**. Inbound candidates that arrive early are now buffered and drained (in order) once the remote description lands. The common no-early-candidate handshake keeps its original microtask timing.

### 2. Treat `connectionState === 'disconnected'` as transient
WebRTC uses `disconnected` for a momentary ICE-consent blip that usually recovers on its own; only `failed` is terminal. The old code closed the session immediately on `disconnected`, killing recoverable connections on a brief Wi-Fi/packet hiccup. Now a grace window (default 5 s, injectable via `disconnectGraceMs`) is waited out — recovery to `connected` cancels the close; only a persistent disconnect closes.

### 3. Clear the partial-chunk buffer on snapshot request timeout
`SnapshotExchange`'s timeout path nulled the pending request but left partially-received chunks in the reassembler. A retry then mixed stale chunks (e.g. `totalChunks=3`) with the new transfer and tripped *"chunk batch size changed mid-stream"*. The timeout now routes through `failPending` (which clears the buffer), and `request()` clears defensively at the start.

## Tests
- ICE buffering + ordered drain + post-remote-description immediate-add
- disconnect grace: transient recovery (no close) and persistent disconnect (closes)
- snapshot retry after timeout reassembles cleanly

All `@pixelrpg/engine` suites green (gjs + node), lint + type-check clean.

## Collab-safety
All three are pure transport plumbing — no op-log/Command/registry, project-op, or awareness changes. Stable-key and idempotency invariants untouched.

🔎 Found via an audit of the sync layer; verified by independently reading the cited code paths.