### PR TITLE
fix(maker): buffer project ops during the joiner attach window

### DIFF
--- a/apps/maker-gjs/src/services/collab-session.spec.ts
+++ b/apps/maker-gjs/src/services/collab-session.spec.ts
@@ -334,5 +334,35 @@ export default async () => {
       expect(threw).toBe(true)
       expect(applied).toHaveLength(0)
     })
+
+    await it('buffers project ops received before the sink is registered, then drains on set', async () => {
+      // Joiner window: ops arrive between start() and ProjectStore
+      // registering its sink (after the snapshot + sandbox project load).
+      // Pre-fix these were dropped → silent cast/library/sprite-set desync.
+      const session = makeJoinerSession()
+      const op = (id: string, seq: number): ProjectOp => ({
+        kind: '__project/entity.remove',
+        payload: { id },
+        peerId: 'host-peer',
+        seq,
+      })
+
+      // No onProjectOpReceived sink yet — these must be buffered.
+      session.peer.events.emit('op-received', { op: op('a', 0) })
+      session.peer.events.emit('op-received', { op: op('b', 1) })
+      // Own echo is still ignored, even while buffering.
+      session.peer.events.emit('op-received', { op: { ...op('self', 2), peerId: 'joiner-buffer' } })
+
+      const received: ProjectOp[] = []
+      session.onProjectOpReceived = (o) => received.push(o)
+
+      // Registering the sink drained the buffer, in arrival order.
+      expect(received.map((o) => (o.payload as { id: string }).id)).toStrictEqual(['a', 'b'])
+
+      // Live ops after registration flow straight through.
+      session.peer.events.emit('op-received', { op: op('c', 3) })
+      expect(received.map((o) => (o.payload as { id: string }).id)).toStrictEqual(['a', 'b', 'c'])
+      session.close('test')
+    })
   })
 }

--- a/apps/maker-gjs/src/services/collab-session.ts
+++ b/apps/maker-gjs/src/services/collab-session.ts
@@ -153,14 +153,26 @@ export class CollabSession {
    * editing has no live scene), so they're handled here rather than in
    * the engine-tied SessionController.
    */
-  public onProjectOpReceived: ((op: ProjectOp) => void) | null = null
+  get onProjectOpReceived(): ((op: ProjectOp) => void) | null {
+    return this._onProjectOpReceived
+  }
+  set onProjectOpReceived(fn: ((op: ProjectOp) => void) | null) {
+    this._onProjectOpReceived = fn
+    if (fn) for (const op of this.preSinkProjectOps.splice(0)) fn(op)
+  }
   /**
    * Sink for a completed sprite-set-import transfer. The maker's
    * `ProjectStore` registers itself here to write the image + descriptor
    * into the project and register the set. Fed by the chunk reassembler
    * once all chunks of one transfer arrive.
    */
-  public onSpriteSetAddReceived: ((payload: SpriteSetAddPayload) => void) | null = null
+  get onSpriteSetAddReceived(): ((payload: SpriteSetAddPayload) => void) | null {
+    return this._onSpriteSetAddReceived
+  }
+  set onSpriteSetAddReceived(fn: ((payload: SpriteSetAddPayload) => void) | null) {
+    this._onSpriteSetAddReceived = fn
+    if (fn) for (const p of this.preSinkSpriteSetAdds.splice(0)) fn(p)
+  }
   /**
    * Sink for a completed sprite-set DESCRIPTOR update (rename / animation
    * edit / tile-property change — no image bytes). The maker's
@@ -168,7 +180,29 @@ export class CollabSession {
    * set it already has. Fed by a dedicated reassembler once all chunks of
    * one transfer arrive.
    */
-  public onSpriteSetUpdateReceived: ((payload: SpriteSetUpdatePayload) => void) | null = null
+  get onSpriteSetUpdateReceived(): ((payload: SpriteSetUpdatePayload) => void) | null {
+    return this._onSpriteSetUpdateReceived
+  }
+  set onSpriteSetUpdateReceived(fn: ((payload: SpriteSetUpdatePayload) => void) | null) {
+    this._onSpriteSetUpdateReceived = fn
+    if (fn) for (const p of this.preSinkSpriteSetUpdates.splice(0)) fn(p)
+  }
+  private _onProjectOpReceived: ((op: ProjectOp) => void) | null = null
+  private _onSpriteSetAddReceived: ((payload: SpriteSetAddPayload) => void) | null = null
+  private _onSpriteSetUpdateReceived: ((payload: SpriteSetUpdatePayload) => void) | null = null
+  /**
+   * Holding pens for project-level traffic that arrives before its sink is
+   * registered — the joiner's `start()` → `ProjectStore.setCollabSession`
+   * (after the snapshot + sandbox project load) window. Without these the
+   * op was dropped on the floor: a host editing the cast / entity-library /
+   * sprite-sets while a joiner connects silently desynced the joiner.
+   * Drained in arrival order when the matching sink is assigned. The plain
+   * project-op channel is idempotent upserts, so replaying one already
+   * folded into the snapshot is safe.
+   */
+  private readonly preSinkProjectOps: ProjectOp[] = []
+  private readonly preSinkSpriteSetAdds: SpriteSetAddPayload[] = []
+  private readonly preSinkSpriteSetUpdates: SpriteSetUpdatePayload[] = []
   private closed = false
   private engine: Engine | null = null
   private readonly peerId: string
@@ -276,15 +310,27 @@ export class CollabSession {
         // surfacing the (heavy, binary) payload to its own sink.
         if ((op as ProjectOp).kind === SPRITESET_ADD_CHUNK_KIND) {
           const payload = this.spriteSetReassembler.accept(op as SpriteSetAddChunkOp)
-          if (payload) this.onSpriteSetAddReceived?.(payload)
+          // Buffer the completed payload if the sink isn't registered yet
+          // (joiner pre-attach window) so it isn't dropped.
+          if (payload) {
+            if (this._onSpriteSetAddReceived) this._onSpriteSetAddReceived(payload)
+            else this.preSinkSpriteSetAdds.push(payload)
+          }
         } else if ((op as ProjectOp).kind === SPRITESET_UPDATE_CHUNK_KIND) {
           // Descriptor-only updates (rename / animation / tile-prop) are
           // also chunked — a fat tileset descriptor can exceed the SCTP
           // single-send ceiling.
           const payload = this.spriteSetUpdateReassembler.accept(op as SpriteSetUpdateChunkOp)
-          if (payload) this.onSpriteSetUpdateReceived?.(payload)
+          if (payload) {
+            if (this._onSpriteSetUpdateReceived) this._onSpriteSetUpdateReceived(payload)
+            else this.preSinkSpriteSetUpdates.push(payload)
+          }
+        } else if (this._onProjectOpReceived) {
+          this._onProjectOpReceived(op as ProjectOp)
         } else {
-          this.onProjectOpReceived?.(op as ProjectOp)
+          // No sink yet — buffer until ProjectStore registers itself
+          // (drained by the onProjectOpReceived setter).
+          this.preSinkProjectOps.push(op as ProjectOp)
         }
         return
       }
@@ -561,6 +607,9 @@ export class CollabSession {
     }
     this.subscriptions.length = 0
     this.preAttachBuffer.clear()
+    this.preSinkProjectOps.length = 0
+    this.preSinkSpriteSetAdds.length = 0
+    this.preSinkSpriteSetUpdates.length = 0
     this.spriteSetReassembler.clear()
     this.spriteSetUpdateReassembler.clear()
     this.cursorRenderer?.close()

--- a/apps/maker-gjs/src/services/project-store.spec.ts
+++ b/apps/maker-gjs/src/services/project-store.spec.ts
@@ -248,6 +248,26 @@ export default async () => {
       expect(data.entityLibrary).toHaveLength(1)
     })
 
+    await it('defers sink registration until a project is present (joiner attach order)', async () => {
+      // Joiner: setCollabSession runs (state-changed) BEFORE the sandbox
+      // project finishes loading (setProject). Until a project is present
+      // the store must NOT register the sinks, so the session keeps
+      // buffering inbound ops instead of feeding a project-less applier.
+      const io = makeIo()
+      const store = new ProjectStore(io)
+      const session = makeSession()
+
+      store.setCollabSession(session)
+      expect(session.onProjectOpReceived).toBe(null)
+
+      // Project arrives → sinks register (which drains the session buffer).
+      store.setProject(makeProject(makeProjectData()))
+      expect(session.onProjectOpReceived).not.toBe(null)
+
+      session.onProjectOpReceived?.(remoteUpsert(npc))
+      expect(store.data?.entityLibrary).toHaveLength(1)
+    })
+
     await it('applies entity.upsert idempotently and never re-broadcasts', async () => {
       const { store, io, data } = makeStore()
       const session = makeSession()

--- a/apps/maker-gjs/src/services/project-store.ts
+++ b/apps/maker-gjs/src/services/project-store.ts
@@ -220,6 +220,11 @@ export class ProjectStore {
   setProject(project: LoadedProject | null): void {
     this._project = project
     this._events.emit('project-changed', project)
+    // (Re)evaluate sink registration: on the joiner the session attaches
+    // (setCollabSession) BEFORE the snapshot project finishes loading, so
+    // the sinks must be (re)registered here once a project is present —
+    // that drains any project ops the session buffered in the meantime.
+    this._refreshSessionSinks()
   }
 
   /**
@@ -230,10 +235,29 @@ export class ProjectStore {
    */
   setCollabSession(session: ProjectSyncSession | null): void {
     this._session = session
+    this._refreshSessionSinks()
+  }
+
+  /**
+   * Register (or clear) the inbound project-op sinks on the active
+   * session. Sinks are registered ONLY once a project is present so the
+   * single-applier (`applyRemote*`) always has a `GameProjectData` to
+   * mutate; until then inbound ops stay buffered in the session and drain
+   * the moment the sink is assigned. Symmetric: with no project (or no
+   * session) the sinks are cleared, returning the session to buffering.
+   */
+  private _refreshSessionSinks(): void {
+    const session = this._session
     if (!session) return
-    session.onProjectOpReceived = (op) => this.applyRemoteProjectOp(op)
-    session.onSpriteSetAddReceived = (payload) => this.applyRemoteSpriteSetAdd(payload)
-    session.onSpriteSetUpdateReceived = (payload) => this.applyRemoteSpriteSetUpdate(payload)
+    if (this._project) {
+      session.onProjectOpReceived = (op) => this.applyRemoteProjectOp(op)
+      session.onSpriteSetAddReceived = (payload) => this.applyRemoteSpriteSetAdd(payload)
+      session.onSpriteSetUpdateReceived = (payload) => this.applyRemoteSpriteSetUpdate(payload)
+    } else {
+      session.onProjectOpReceived = null
+      session.onSpriteSetAddReceived = null
+      session.onSpriteSetUpdateReceived = null
+    }
   }
 
   // ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes a **collab desync** (HIGH): a joiner silently lost the host's project-level edits made while it was connecting.

A joiner's WebRTC channel opens at `collab.start()`, but `ProjectStore` only registers its inbound project-op sinks *after* the snapshot transfers and the sandbox project loads — seconds later. During that window:
- **Scene Command ops** were already buffered (`PreAttachOpBuffer`) ✅
- **Project-level ops** (`__project/*` — cast / entity-library / `playerActorId` / sprite-set add + update) hit `this.onProjectOpReceived?.(op)` with a **null sink and were dropped** ❌

So a host editing the cast / entity library / sprite-sets while someone joined silently desynced the joiner — exactly the trap solo testing never catches.

## Fix (two layers)
1. **`CollabSession`** buffers project ops + completed sprite-set add/update payloads that arrive before their sink is registered, in arrival order, and **drains each pen the instant its sink is assigned** (the three sink fields are now getter/setter-backed). Pens cleared on `close()`.
2. **`ProjectStore`** registers the inbound sinks only once **both** a session **and** a project are present — re-evaluated from `setProject` as well as `setCollabSession`. On the joiner, `setCollabSession` fires (on `state-changed`) *before* the sandbox project finishes loading, so deferring registration to `setProject` is what makes the drain land on a store that can actually apply the ops (`applyRemoteProjectOp` no-ops without a project).

Replaying a project op already folded into the snapshot is safe: the `__project/*` channel is **idempotent upserts by id** (per the transport-ready-primitives contract).

## Tests
- `CollabSession` buffers-then-drains pre-sink project ops in arrival order; own-peer echoes still ignored; live ops after registration pass straight through.
- `ProjectStore` defers sink registration until a project is present (joiner attach order) — sinks stay null after `setCollabSession`, register on `setProject`.

All `@pixelrpg/maker-gjs` suites green (gjs + node), lint + type-check clean.

🔎 Found by the audit of the collab layer; re-verified by reading the join flow end-to-end (`session-service` → `application-window` event order → `ProjectStore`).