### PR TITLE
fix(engine): correct paint-target fallback + surface teleport failures

### DIFF
--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -154,7 +154,15 @@ export class Engine {
         keepRuntimeMode: true,
         keepZoom: true,
       }).catch((err) => {
-        console.warn(`[Engine] teleport to "${targetMapId}" failed:`, formatError(err))
+        // A failed teleport (e.g. missing target map) leaves the player
+        // mid-transition with no scene switch. Surface it as an engine
+        // ERROR so the host can react, instead of only console.warn-ing
+        // (mirrors the loader error path).
+        this.logger.error(`teleport to "${targetMapId}" failed:`, formatError(err))
+        this.events.emit(EngineEvent.ERROR, {
+          message: `Teleport to "${targetMapId}" failed`,
+          cause: err instanceof Error ? err : new Error(String(err)),
+        })
       })
     })
   }

--- a/packages/engine/src/resource/MapResource.ts
+++ b/packages/engine/src/resource/MapResource.ts
@@ -505,13 +505,24 @@ export class MapResource implements Loadable<TileMap> {
     return this.spriteSetResources
   }
 
+  /** Ids of the currently-visible layers (for layer-list / picker UI). */
   getAvailableLayerIds(): string[] {
     return this._mapData.layers.filter((layer) => layer.visible).map((layer) => layer.id)
   }
 
+  /**
+   * The first layer that can accept paint — the editor's fallback target
+   * when no active layer is set (pencil/object preview, TileEditorSystem).
+   *
+   * Deliberately NOT filtered by visibility: a hidden first layer must
+   * still be the fallback target (matching its on-disk order). Filtering
+   * by `visible` here meant hiding the first layer silently redirected
+   * paint to a different visible layer — or, with every layer hidden,
+   * returned null so paint landed nowhere.
+   */
   getFirstLayerId(): string | null {
-    const layerIds = this.getAvailableLayerIds()
-    return layerIds.length > 0 ? layerIds[0] : null
+    const first = this._mapData.layers[0]
+    return first ? first.id : null
   }
 
   isLoaded(): boolean {

--- a/packages/engine/src/resource/map-resource.spec.ts
+++ b/packages/engine/src/resource/map-resource.spec.ts
@@ -18,4 +18,30 @@ export default async () => {
       expect(resource.getSpriteSetResource('ghost')).toBe(undefined)
     })
   })
+
+  await describe('MapResource.getFirstLayerId', async () => {
+    await it('returns the first layer regardless of visibility (paint-target fallback)', async () => {
+      const resource = new MapResource('maps/main.json', { headless: true })
+      const withData = resource as unknown as { _mapData: unknown }
+      withData._mapData = {
+        layers: [
+          { id: 'background', visible: false },
+          { id: 'ground', visible: true },
+        ],
+      }
+      // The first layer is hidden — it must STILL be the fallback target,
+      // not silently redirected to the first *visible* layer (which would
+      // make paint land on the wrong layer, or nowhere if all are hidden).
+      expect(resource.getFirstLayerId()).toBe('background')
+      // The visible-only query is unchanged — UI uses it for the layer list.
+      expect(resource.getAvailableLayerIds()).toStrictEqual(['ground'])
+    })
+
+    await it('returns null when the map has no layers', async () => {
+      const resource = new MapResource('maps/empty.json', { headless: true })
+      const withData = resource as unknown as { _mapData: unknown }
+      withData._mapData = { layers: [] }
+      expect(resource.getFirstLayerId()).toBe(null)
+    })
+  })
 }


### PR DESCRIPTION
## Summary

Two engine "silent failure" fixes from the audit.

### 1. `getFirstLayerId()` must not filter by layer visibility
`getFirstLayerId()` is the **paint-target fallback** — `TileEditorSystem.resolveLayerId`, plus the pencil/object hover previews — used when no active layer is set. It was implemented on top of `getAvailableLayerIds()`, which filters to `layer.visible`. So:
- hide the first layer → paint silently lands on a *different* visible layer
- hide every layer → returns `null` → paint lands **nowhere**

It now returns the first layer by on-disk order regardless of visibility. The visible-only query stays as `getAvailableLayerIds()` for layer-list UI. (A non-deterministic fallback could also target a `layerId` a peer doesn't have → collab desync, so deterministic order matters here too.)

### 2. Surface teleport failures
A failed teleport (e.g. a missing target map id) left the player mid-transition with no scene switch and only a `console.warn`. It now also emits `EngineEvent.ERROR` (and logs at error level), mirroring the loader-error path, so the host can react.

## Tests
`MapResource.getFirstLayerId` returns the first layer even when it's hidden; returns `null` with no layers.

All `@pixelrpg/engine` suites green (gjs + node), lint + type-check + barrel-drift clean.

> Note: the related audit finding that `syncShadowToMapData` drops per-placement `properties`/`solid` on fold was **deferred** — the fix means extending the editor shadow + load path + `_isSolidRef`, and those per-placement overrides have no editor UI yet (only hand-edited JSON / the Tiled porter set them), so practical impact is low vs. the change's risk. Tracked for a focused pass.