### PR TITLE
fix(engine): reject duplicate component types in entity definitions

### DIFF
--- a/packages/engine/src/entity/validate.spec.ts
+++ b/packages/engine/src/entity/validate.spec.ts
@@ -54,6 +54,21 @@ export default async () => {
       const errors = validateEntityDefinition(def, registry)
       expect(errors.some((e) => e.includes('unregistered component type "teleport"'))).toBe(true)
     })
+    await it('rejects a duplicate component type within one list', async () => {
+      // getComponentData returns the FIRST match, so a second component of
+      // the same type is silently ignored at spawn — validation must catch it.
+      const def: EntityDefinition = {
+        id: 'hero',
+        name: 'Hero',
+        components: [
+          { type: 'movement', tilesPerSec: 4 },
+          { type: 'movement', tilesPerSec: 8 },
+        ],
+      }
+      expect(
+        validateEntityDefinition(def, registry).some((e) => e.includes('duplicate component type "movement"')),
+      ).toBe(true)
+    })
     await it('flags wrong field types always, but required only when requireComplete', async () => {
       // Wrong TYPE is always rejected (even on the lenient save path).
       const wrongType: EntityDefinition = {

--- a/packages/engine/src/entity/validate.ts
+++ b/packages/engine/src/entity/validate.ts
@@ -83,12 +83,21 @@ export function validateEntityDefinition(
     return errors
   }
   const validateList = (components: ComponentData[], where: string) => {
+    // A component `type` must appear at most once per list: getComponentData
+    // (data-access.ts) returns the FIRST match and the spawn pipeline builds
+    // from it, so a second component of the same type is silently ignored at
+    // runtime. Reject it here rather than let that drift go unnoticed.
+    const seenTypes = new Set<string>()
     for (const comp of components) {
       const spec = registry[comp.type]
       if (!spec) {
         errors.push(`Entity "${def.id}" ${where} references unregistered component type "${comp.type}"`)
         continue
       }
+      if (seenTypes.has(comp.type)) {
+        errors.push(`Entity "${def.id}" ${where} has a duplicate component type "${comp.type}"`)
+      }
+      seenTypes.add(comp.type)
       errors.push(...validateComponentData(spec, comp, requireComplete))
     }
   }


### PR DESCRIPTION
## Summary

`validateEntityDefinition` checked component **shape** and **registration**, but never that a component `type` appears at most once per list. `getComponentData` (`entity/data-access.ts`) returns the **first** match and the spawn pipeline builds from it — so a second component of the same type was silently ignored at runtime. The validator now rejects duplicates, for both the base `components` list and per-state overlays.

## Tests
Added a `validate.spec` case for a duplicate component type. Verified no `games/*` template carries a duplicate type (so nothing regresses on load).

All `@pixelrpg/engine` suites green (gjs + node), lint + type-check clean.