### PR TITLE
fix(signalling): reap half-occupied rooms with a chatty lone peer

### DIFF
--- a/apps/signalling-server/src/room-manager.spec.ts
+++ b/apps/signalling-server/src/room-manager.spec.ts
@@ -108,6 +108,26 @@ export default async () => {
       expect(rm.size).toBe(1) // lastActivity bumped by the forward at t=800
     })
 
+    await it('reaps a half-occupied room even when the lone peer keeps sending', async () => {
+      let t = 0
+      const rm = new RoomManager({ idleMs: 1000, now: () => t })
+      const host = new FakePeer()
+      rm.join('a', 'host', host) // lastActivity = 0, no joiner
+
+      // Host keeps retrying SDP offers with no joiner present. These futile
+      // forwards must NOT refresh lastActivity — otherwise the half-occupied
+      // room would never hit the idle sweep.
+      t = 500
+      rm.forward('a', 'host', '{"type":"sdp"}', 'sdp')
+      t = 900
+      rm.forward('a', 'host', '{"type":"sdp"}', 'sdp')
+
+      t = 1500
+      rm.sweep()
+      expect(rm.size).toBe(0) // reaped — lastActivity stayed at the join (t=0)
+      expect(host.closed).toBe(true)
+    })
+
     await it('logs each high-level event with the room + role context', async () => {
       const log = spy((_event: RoomEvent): void => {})
       const rm = new RoomManager({ log })

--- a/apps/signalling-server/src/room-manager.ts
+++ b/apps/signalling-server/src/room-manager.ts
@@ -111,8 +111,13 @@ export class RoomManager {
     if (!room) return
     const toRole: PeerRole = fromRole === 'host' ? 'joiner' : 'host'
     const target = room[toRole]
-    room.lastActivity = this.now()
     if (!target) return
+    // Only count activity when a frame was actually relayed (both slots
+    // occupied). Bumping unconditionally let a lone peer that keeps
+    // sending (e.g. a host retrying SDP offers with no joiner) refresh
+    // lastActivity forever, so a half-occupied room never hit the idle
+    // sweep — defeating the documented reap.
+    room.lastActivity = this.now()
     target.send(frame)
     this.log({ kind: 'message', roomId, from: fromRole, to: toRole, type: messageType })
   }


### PR DESCRIPTION
## Summary

`RoomManager.forward` set `room.lastActivity = now()` **unconditionally**, before the "other side absent" guard. So a lone peer that keeps sending — e.g. a host retrying SDP offers while no joiner has arrived — refreshed `lastActivity` forever, and the half-occupied room **never hit the idle sweep**, defeating the documented reap.

The bump now happens only after confirming the target is present, so only a real relay (both slots occupied) counts as activity. A half-occupied room reaps on the idle window measured from its `join` timestamp.

## Tests
Added a spec: a lone host that keeps calling `forward` is still reaped after `idleMs`. Existing "does not reap a room receiving traffic" (both peers present) still passes.

All `@pixelrpg/signalling-server` suites green (gjs + node), lint + type-check clean.