### PR TITLE
fix(gjs): MiniMap measure orientation + dialog preview timer lifecycle

### DIFF
--- a/packages/gjs/src/widgets/cast/add-animation-dialog.ts
+++ b/packages/gjs/src/widgets/cast/add-animation-dialog.ts
@@ -222,9 +222,21 @@ export class AddAnimationDialog extends Adw.Dialog {
     this._populatePalette()
   }
 
-  // Lifecycle hooks — stop the preview timer when the dialog goes
-  // away so the timeout source doesn't outlive the Picture it
-  // updates.
+  // Lifecycle hooks — keep the preview timer scoped to "mapped". A
+  // dialog can be unmapped without a full close (host flows), and the
+  // timeout would otherwise keep churning the hidden Picture's
+  // paintable. Stop on unmap, resume on (re)map — matches
+  // CharacterPreview. vfunc_closed stays the final teardown.
+  vfunc_map(): void {
+    super.vfunc_map?.()
+    this._restartPreviewTimer()
+  }
+
+  vfunc_unmap(): void {
+    this._stopPreviewTimer()
+    super.vfunc_unmap?.()
+  }
+
   vfunc_closed(): void {
     this._stopPreviewTimer()
     super.vfunc_closed?.()

--- a/packages/gjs/src/widgets/editor/mini-map.ts
+++ b/packages/gjs/src/widgets/editor/mini-map.ts
@@ -114,10 +114,11 @@ export class MiniMap extends Gtk.Widget {
     }
   }
 
-  vfunc_measure(_orientation: Gtk.Orientation, _forSize: number): [number, number, number, number] {
-    const w = this.cols * this._tilePx
-    const _h = this._rows.length * this._tilePx
-    return [w, w, -1, -1]
+  vfunc_measure(orientation: Gtk.Orientation, _forSize: number): [number, number, number, number] {
+    // Report the natural size for the requested orientation. Returning the
+    // width for both axes mis-sized a non-square mini-map vertically.
+    const size = orientation === Gtk.Orientation.HORIZONTAL ? this.cols * this._tilePx : this.rows * this._tilePx
+    return [size, size, -1, -1]
   }
 
   private _updateSize(): void {


### PR DESCRIPTION
## Summary

Two GTK widget fixes in `@pixelrpg/gjs` from the audit.

### `MiniMap.vfunc_measure` ignored orientation
It computed both width and height but returned `[w, w, -1, -1]` for **both** orientations (the height went into a dead `_h` local), so a non-square mini-map was mis-sized vertically. Now branches on the requested orientation, mirroring `CollisionPreview.vfunc_measure`.

### `AddAnimationDialog` preview timer outlived "mapped"
The preview `GLib.timeout` was stopped only in `vfunc_closed`. An `Adw.Dialog` can be unmapped without a full close, leaving the timer churning the hidden preview `Picture`'s paintable. Now stopped in `vfunc_unmap` and resumed in `vfunc_map` (matching `CharacterPreview`); `vfunc_closed` stays the final teardown.

## Verification
`@pixelrpg/gjs` has no unit-test harness yet, so verified via type-check + build + Biome (all green). Mechanical lifecycle/measure changes, no behavior change beyond the fixes.