### PR TITLE
fix(maker): collab lifecycle robustness (firstGid idempotency + host leak)

### DIFF
--- a/apps/maker-gjs/src/services/project-store.spec.ts
+++ b/apps/maker-gjs/src/services/project-store.spec.ts
@@ -1,3 +1,4 @@
+import GLib from '@girs/glib-2.0'
 import { describe, expect, it } from '@gjsify/unit'
 import {
   createEntityRemoveOp,
@@ -323,6 +324,44 @@ export default async () => {
       const store = new ProjectStore(io)
       store.applyRemoteProjectOp(remoteUpsert(npc))
       expect(io.writes).toHaveLength(0)
+    })
+  })
+
+  await describe('ProjectStore — applyRemoteSpriteSetAdd idempotency', async () => {
+    const makeSpriteSetData = (id: string, spriteCount: number) =>
+      ({
+        version: '1.0.0',
+        id,
+        name: id,
+        image: { id: 'main', path: `${id}.png`, type: 'image' },
+        spriteWidth: 16,
+        spriteHeight: 16,
+        columns: spriteCount,
+        rows: 1,
+        margin: 0,
+        spacing: 0,
+        sprites: Array.from({ length: spriteCount }, (_, i) => ({ id: i, col: i, row: 0 })),
+      }) as unknown as SpriteSetAddPayload['data']
+
+    await it('reuses an existing firstGid on re-apply (idempotent gid space)', async () => {
+      // applyRemoteSpriteSetAdd uses GLib path helpers — only real under the
+      // GJS target. Skip gracefully on node where gi:// is stubbed.
+      if (typeof (GLib as { path_get_dirname?: unknown }).path_get_dirname !== 'function') return
+      const { store, data } = makeStore()
+      const payload: SpriteSetAddPayload = { data: makeSpriteSetData('imported', 3), imageBase64: '' }
+
+      store.applyRemoteSpriteSetAdd(payload)
+      const firstGid1 = data.spriteSets.find((r) => r.id === 'imported')?.firstGid
+      expect(firstGid1).toBe(1)
+
+      // Simulate the async live-load completing: the set now reports 3 sprites,
+      // so a naive _nextFirstGid would count this set and shift its gid on the
+      // next apply.
+      store.resource?.spriteSets.set('imported', { data: { sprites: [{}, {}, {}] } } as never)
+
+      store.applyRemoteSpriteSetAdd(payload)
+      const firstGid2 = data.spriteSets.find((r) => r.id === 'imported')?.firstGid
+      expect(firstGid2).toBe(firstGid1) // unchanged — re-apply is idempotent
     })
   })
 }

--- a/apps/maker-gjs/src/services/project-store.ts
+++ b/apps/maker-gjs/src/services/project-store.ts
@@ -448,13 +448,17 @@ export class ProjectStore {
       return
     }
     this.io.writeText(jsonDest, SpriteSetFormat.serialize(safeData))
+    // gid space is per-peer; the sender's value may collide with ours, so we
+    // assign our own. On re-apply REUSE the existing firstGid — recomputing
+    // would shift it (once the set's sprites are loaded `_nextFirstGid` counts
+    // this set too), breaking the documented idempotency and the tile-id space.
+    const existingRef = resource.data.spriteSets.find((r) => r.id === id)
+    const firstGid = typeof existingRef?.firstGid === 'number' ? existingRef.firstGid : this._nextFirstGid()
     applySpriteSetReference(resource.data, {
       id,
       path: `./spritesets/${id}.json`,
       type: 'spriteset',
-      // Recompute on our side — gid space is per-peer; the sender's
-      // value may collide with ours.
-      firstGid: this._nextFirstGid(),
+      firstGid,
     })
     this._persistProject()
     void (async () => {

--- a/apps/maker-gjs/src/services/session-service.ts
+++ b/apps/maker-gjs/src/services/session-service.ts
@@ -397,7 +397,19 @@ export class SessionService {
         peerConnectTimeoutMs: this.peerConnectTimeoutMs,
         rtcFactory: this.rtcFactory,
       })
-      await collab.start()
+      try {
+        await collab.start()
+      } catch (err) {
+        // start() failed (peer-connect timeout, etc.) — tear the session
+        // down before rethrowing so its PeerSession + awareness channel
+        // don't leak. Mirrors the joiner path's close-on-failure.
+        try {
+          collab.close('host-start-failed')
+        } catch {
+          /* best-effort */
+        }
+        throw err
+      }
       this.wireCollabClose(collab)
       this.setState({ kind: 'connected', role, roomId, collab })
       return


### PR DESCRIPTION
## Summary

Two collab-robustness fixes from the audit.

### 1. `applyRemoteSpriteSetAdd` firstGid wasn't idempotent
The method documents "re-applying overwrites the same files + replaces the ref by id" but recomputed `firstGid` via `_nextFirstGid()` every time. Once the set's sprites load, `_nextFirstGid` counts the set *itself*, so a re-applied add **shifted the reference's firstGid** — moving the whole tile-id space. Now: reuse the existing reference's `firstGid` on re-apply; only compute a fresh one for a genuinely new id.

### 2. Host `openSession` leaked the CollabSession on `start()` failure
The host branch did `await collab.start()` with no guard. When `start()` threw (peer-connect timeout, etc.) the constructed `CollabSession` — its `PeerSession` + awareness channel — leaked. Now wrapped in try/catch that `collab.close()`s before rethrowing, mirroring the joiner branch three lines below.

## Tests
- `project-store` spec: re-applying a sprite-set add keeps the same `firstGid` (idempotent). GJS-only — `applyRemoteSpriteSetAdd` uses `GLib` path helpers that are stubbed on the node target, so it skips gracefully there (matches the repo's `.gjs.spec` convention).
- The host-leak fix ships test-light: it's a defensive teardown mirroring the already-covered joiner path, and a full host-`attachEngine` test needs a complete engine stub disproportionate to the one-line change.

`@pixelrpg/maker-gjs` check + tests green (gjs + node), lint + spec-guard clean.