### PR TITLE
fix(maker): tear down project + session on close-project

### DIFF
--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -566,6 +566,30 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
   }
 
   /**
+   * Tear down the active project + any live session before returning to the
+   * welcome view. `win.close-project` previously only switched the view,
+   * leaving the project, an active share/session and the engine all live —
+   * leaking those resources and layering any reopened project on stale state.
+   * The reverse of {@link _loadProjectFromPath}.
+   */
+  private async _closeProject(): Promise<void> {
+    // Close any host/join session first — also tears down its awareness,
+    // mDNS publisher and transport.
+    try {
+      await this._sessionSvc?.leaveSession('project-closed')
+    } catch (err) {
+      console.warn('[ApplicationWindow] leaveSession during close failed:', err)
+    }
+    // Detach the collab sink, free the engine (idempotent), drop the project
+    // (clears `_loadedProject`, which reads from the store), disable share.
+    this._projectStore.setCollabSession(null)
+    this._engineCtl.dispose()
+    this._projectStore.setProject(null)
+    this._shareAction?.set_enabled(false)
+    this._setView('welcome')
+  }
+
+  /**
    * Attach the active engine to the current `CollabSession` if (and
    * only if) the session is waiting for one. Called from
    * `_hydrateSceneEditor` immediately after `ensureForMap` resolves,
@@ -1189,7 +1213,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     winActions.add_action(backAction)
 
     const closeProjectAction = new Gio.SimpleAction({ name: 'close-project' })
-    closeProjectAction.connect('activate', () => this._setView('welcome'))
+    closeProjectAction.connect('activate', () => void this._closeProject())
     winActions.add_action(closeProjectAction)
 
     // Share-session — opens the Share dialog. Disabled until a


### PR DESCRIPTION
## Summary

`win.close-project` only did `_setView('welcome')`, leaving the loaded project, any active host/join **session**, and the **engine** all live. So every project close:
- leaked the engine (WebGL context + Excalibur loop),
- kept a share session running unseen,
- and let a reopened project layer onto stale state.

`_closeProject()` is now the reverse of `_loadProjectFromPath`: leave any session (which tears down its awareness / mDNS publisher / transport), detach the collab sink, dispose the engine (idempotent), clear the project (`setProject(null)` — which also clears `_loadedProject`, a store-backed getter), disable the share action, then switch to welcome.

## Verification
Type-check + build + lint green. Build-verified rather than unit-tested — `ApplicationWindow` subclasses `Adw.Window` and can't run headlessly — but every teardown primitive it calls (`SessionService.leaveSession`, `EngineController.dispose` [idempotent], `ProjectStore.setProject/setCollabSession`) is individually covered.