### PR TITLE
refactor(maker): extract buildVariant into a testable gvariant module

### DIFF
--- a/apps/maker-gjs/src/services/gvariant.spec.ts
+++ b/apps/maker-gjs/src/services/gvariant.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@gjsify/unit'
+
+import { variantKindFor } from './gvariant.ts'
+
+export default async () => {
+  await describe('variantKindFor', async () => {
+    await it('honours a known declared scalar type over JS inference', async () => {
+      expect(variantKindFor('s', 42)).toBe('s')
+      expect(variantKindFor('b', 'true')).toBe('b')
+      expect(variantKindFor('i', 'x')).toBe('i')
+      expect(variantKindFor('u', 1)).toBe('u')
+      expect(variantKindFor('d', 7)).toBe('d') // whole-number value, declared double → stays double
+    })
+
+    await it('infers from the JS runtime type when no declared type is given', async () => {
+      expect(variantKindFor(null, 'hello')).toBe('s')
+      expect(variantKindFor(null, true)).toBe('b')
+      expect(variantKindFor(null, 3)).toBe('i') // integer → int32
+      expect(variantKindFor(null, 3.5)).toBe('d') // non-integer → double
+    })
+
+    await it('ignores a non-scalar declared type and falls back to inference', async () => {
+      // e.g. an array/tuple action type "(ii)" isn't a marshalled scalar.
+      expect(variantKindFor('(ii)', 'fallback')).toBe('s')
+    })
+
+    await it('throws for a value it cannot marshal', async () => {
+      expect(() => variantKindFor(null, { a: 1 })).toThrow(/Cannot build a GLib.Variant/)
+      expect(() => variantKindFor(null, undefined)).toThrow(/Cannot build a GLib.Variant/)
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/gvariant.ts
+++ b/apps/maker-gjs/src/services/gvariant.ts
@@ -1,0 +1,51 @@
+import GLib from '@girs/glib-2.0'
+
+/** The `GLib.Variant` scalar kinds the Control/action plane marshals to. */
+export type VariantKind = 's' | 'b' | 'i' | 'u' | 'd'
+
+/**
+ * Decide which `GLib.Variant` scalar kind to build for an action
+ * parameter/state: the action's declared variant type string when it's a
+ * known scalar, otherwise inferred from the JS runtime type (string → `s`,
+ * boolean → `b`, integer → `i`, non-integer number → `d`). Throws when
+ * neither a known declared type nor an inferable JS type applies.
+ *
+ * Pure (no GLib) so the marshalling decision — the bit with the
+ * whole-number-vs-double edge and the unsupported-type throw — is
+ * unit-testable on both the gjs and node targets. {@link buildVariant} is
+ * the thin GLib-constructing wrapper around it.
+ */
+export function variantKindFor(declaredType: string | null, value: unknown): VariantKind {
+  switch (declaredType) {
+    case 's':
+    case 'b':
+    case 'i':
+    case 'u':
+    case 'd':
+      return declaredType
+  }
+  if (typeof value === 'string') return 's'
+  if (typeof value === 'boolean') return 'b'
+  if (typeof value === 'number') return Number.isInteger(value) ? 'i' : 'd'
+  throw new Error(`Cannot build a GLib.Variant from ${typeof value}`)
+}
+
+/**
+ * Build a `GLib.Variant` for an action parameter/state from a plain JS
+ * value, using the action's declared type when known and otherwise
+ * inferring from the JS runtime type (see {@link variantKindFor}).
+ */
+export function buildVariant(type: GLib.VariantType | null, value: unknown): GLib.Variant {
+  switch (variantKindFor(type?.dup_string() ?? null, value)) {
+    case 's':
+      return GLib.Variant.new_string(String(value))
+    case 'b':
+      return GLib.Variant.new_boolean(Boolean(value))
+    case 'i':
+      return GLib.Variant.new_int32(Number(value))
+    case 'u':
+      return GLib.Variant.new_uint32(Number(value))
+    case 'd':
+      return GLib.Variant.new_double(Number(value))
+  }
+}

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -6,6 +6,7 @@ import collabLogSuite from './services/collab-log.spec.js'
 import collabSessionSuite from './services/collab-session.spec.js'
 import collabSessionE2eSuite from './services/collab-session-e2e.spec.js'
 import engineStateSyncSuite from './services/engine-state-sync.spec.js'
+import gvariantSuite from './services/gvariant.spec.js'
 import lanDiscoverySuite from './services/lan-discovery.spec.js'
 import lanDiscoveryIntegrationSuite from './services/lan-discovery-integration.gjs.spec.js'
 import lanDiscoveryParseSuite from './services/lan-discovery-parse.spec.js'
@@ -26,6 +27,7 @@ run({
   assistantStateServiceSuite,
   instanceIdSuite,
   engineStateSyncSuite,
+  gvariantSuite,
   collabLogSuite,
   collabSessionSuite,
   collabSessionE2eSuite,

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -30,6 +30,7 @@ import { AssistantStateService } from '../services/assistant-state.service.ts'
 import { CastController } from '../services/cast-controller.ts'
 import { DataController } from '../services/data-controller.ts'
 import { EngineController } from '../services/engine-controller.ts'
+import { buildVariant } from '../services/gvariant.ts'
 import { syncEngineState } from '../services/engine-state-sync.ts'
 import { writeTextFile } from '../services/file-io.ts'
 import type { DiscoveredService } from '../services/lan-discovery-parse.ts'
@@ -2108,32 +2109,6 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
         stateType: group.get_action_state_type(name)?.dup_string() ?? null,
       }))
   }
-}
-
-/**
- * Build a `GLib.Variant` for an action parameter/state from a plain JS
- * value, using the action's declared type when known and otherwise
- * inferring from the JS runtime type.
- */
-function buildVariant(type: GLib.VariantType | null, value: unknown): GLib.Variant {
-  switch (type?.dup_string() ?? null) {
-    case 's':
-      return GLib.Variant.new_string(String(value))
-    case 'b':
-      return GLib.Variant.new_boolean(Boolean(value))
-    case 'i':
-      return GLib.Variant.new_int32(Number(value))
-    case 'u':
-      return GLib.Variant.new_uint32(Number(value))
-    case 'd':
-      return GLib.Variant.new_double(Number(value))
-  }
-  if (typeof value === 'string') return GLib.Variant.new_string(value)
-  if (typeof value === 'boolean') return GLib.Variant.new_boolean(value)
-  if (typeof value === 'number') {
-    return Number.isInteger(value) ? GLib.Variant.new_int32(value) : GLib.Variant.new_double(value)
-  }
-  throw new Error(`Cannot build a GLib.Variant from ${typeof value}`)
 }
 
 GObject.type_ensure(ApplicationWindow.$gtype)


### PR DESCRIPTION
## Summary

First step of the **ApplicationWindow (2115 LOC) god-object split**, following the audit's lowest-risk-first plan: move the `GLib.Variant` marshalling helper out of the window into `services/gvariant.ts`.

It splits the **pure decision** from the GLib construction:
- `variantKindFor(declaredType, value)` — declared scalar type wins, else infer from the JS runtime type (string→`s`, boolean→`b`, integer→`i`, non-integer→`d`), throw when unmarshalable. **GTK-free.**
- `buildVariant(type, value)` — the thin wrapper that constructs the `GLib.Variant` from that kind.

Because the decision is GTK-free, its spec runs under **both** the gjs and node targets — covering the whole-number-vs-double edge, declared-type precedence, non-scalar-type fallback, and the unsupported-type throw. That's the *"untested marshalling boundary between the Control/MCP plane and every GAction, with a type hole"* the audit flagged.

## Verification
Behaviour preserved (call sites pass the same `GLib.VariantType | null`); the window imports `buildVariant` and shrinks ~25 lines. `@pixelrpg/maker-gjs` check + tests green (gjs + node), lint + spec-guard clean. `GLib` is still used 31× in the window, so no orphaned import.

Establishes the controller/helper-extraction pattern for the remaining ApplicationWindow split steps (map-persistence, collab-presence, session-coordinator).