### PR TITLE
fix(engine): harden entity-definition validation

### DIFF
--- a/packages/engine/src/commands/types.ts
+++ b/packages/engine/src/commands/types.ts
@@ -73,10 +73,19 @@ export interface Command<P = unknown> {
  * peers without the field send).
  */
 export interface Operation<K extends string = string, P = unknown> {
-  kind: K
-  payload: P
-  peerId: string
-  seq: number
+  readonly kind: K
+  readonly payload: P
+  // `(peerId, seq)` is the op-log's dedupe/echo-suppression + snapshot
+  // watermark key — `readonly` so a relay/forward path can't rewrite the
+  // identity of an already-stamped op (mirrors Command's readonly payload).
+  readonly peerId: string
+  readonly seq: number
+  /**
+   * Correlation id of the local op this envelope echoes — set by the
+   * originating peer so its own broadcast is recognised and suppressed
+   * when it loops back through the transport. Absent on ops minted purely
+   * for remote application.
+   */
   localId?: string
   direction?: 'apply' | 'revert'
   origin?: string

--- a/packages/engine/src/entity/convert.spec.ts
+++ b/packages/engine/src/entity/convert.spec.ts
@@ -91,6 +91,19 @@ export default async () => {
       const already = { id: 'x', name: 'X', components: [{ type: 'collision' }] }
       expect(objectDefinitionToEntity(already)).toBe(already)
     })
+
+    await it('warns when a legacy kind drops its payload (teleport without targetMapId)', async () => {
+      const warnings: string[] = []
+      const entity = objectDefinitionToEntity(
+        { id: 'broken', kind: 'teleport', name: 'Broken', properties: { targetTileX: 1 } },
+        (m) => warnings.push(m),
+      )
+      // The teleport component is dropped (no targetMapId)…
+      expect(types(entity.components)).toStrictEqual([])
+      // …but the loss is surfaced rather than silent.
+      expect(warnings.length).toBe(1)
+      expect(warnings[0]).toContain('broken')
+    })
   })
 
   await describe('characterToEntity / entityToCharacter', async () => {

--- a/packages/engine/src/entity/convert.ts
+++ b/packages/engine/src/entity/convert.ts
@@ -43,8 +43,20 @@ function isAlreadyEntity(value: unknown): value is EntityDefinition {
   return value != null && typeof value === 'object' && Array.isArray((value as { components?: unknown }).components)
 }
 
-/** Convert one legacy object definition to an {@link EntityDefinition}. */
-export function objectDefinitionToEntity(def: LegacyObjectDefinition | EntityDefinition): EntityDefinition {
+/**
+ * Convert one legacy object definition to an {@link EntityDefinition}.
+ *
+ * `onWarn` (optional) is invoked when a legacy `kind` carries no usable
+ * payload — e.g. a `teleport` whose `targetMapId` is missing or not a
+ * string — so the one-shot, irreversible migration surfaces the silent
+ * data loss instead of producing an entity with a dropped component. The
+ * function stays pure (no `console`); the migration script passes
+ * `console.warn`.
+ */
+export function objectDefinitionToEntity(
+  def: LegacyObjectDefinition | EntityDefinition,
+  onWarn?: (message: string) => void,
+): EntityDefinition {
   if (isAlreadyEntity(def)) return def
   const legacy = def as LegacyObjectDefinition
   const components: ComponentData[] = []
@@ -79,6 +91,8 @@ export function objectDefinitionToEntity(def: LegacyObjectDefinition | EntityDef
           ...(props.facing ? { facing: props.facing as Facing } : {}),
           ...(props.label ? { label: props.label as string } : {}),
         })
+      } else {
+        onWarn?.(`teleport "${legacy.id}" dropped: missing/invalid targetMapId`)
       }
       break
     case 'item':
@@ -89,6 +103,8 @@ export function objectDefinitionToEntity(def: LegacyObjectDefinition | EntityDef
           ...(props.qty !== undefined ? { qty: Number(props.qty) } : {}),
           ...(props.pickupSound ? { pickupSound: props.pickupSound as string } : {}),
         })
+      } else {
+        onWarn?.(`item "${legacy.id}" dropped: missing/invalid itemId`)
       }
       break
     case 'npc':

--- a/packages/engine/src/entity/data-access.spec.ts
+++ b/packages/engine/src/entity/data-access.spec.ts
@@ -85,5 +85,28 @@ export default async () => {
         null,
       )
     })
+
+    await it('deep-clones states on the override path so the library is never aliased', async () => {
+      const stateful: EntityDefinition = {
+        id: 'door',
+        name: 'Door',
+        components: [{ type: 'collision' }],
+        states: [{ id: 'open', components: [{ type: 'visual', spriteSetId: 's', spriteId: 1 }] }],
+      }
+      const placement = {
+        id: 'p',
+        layerId: 'l1',
+        tileX: 0,
+        tileY: 0,
+        defId: 'door',
+        overrides: { name: 'Side Door' },
+      }
+      const resolved = resolvePlacementDefinition(placement, [stateful])
+      expect(resolved?.states).toStrictEqual(stateful.states)
+      // …but the arrays + their components are fresh copies, not the library's.
+      expect(resolved?.states === stateful.states).toBe(false)
+      expect(resolved?.states?.[0] === stateful.states?.[0]).toBe(false)
+      expect(resolved?.states?.[0].components[0] === stateful.states?.[0].components[0]).toBe(false)
+    })
   })
 }

--- a/packages/engine/src/entity/data-access.ts
+++ b/packages/engine/src/entity/data-access.ts
@@ -65,5 +65,12 @@ export function resolvePlacementDefinition(
     ...base,
     name: placement.overrides.name ?? base.name,
     components: mergePlacementComponents(base.components, placement.overrides.components),
+    // `...base` would alias `base.states` by reference. Components are
+    // cloned by mergePlacementComponents; deep-clone states the same way
+    // so a resolved override never shares mutable state data with the
+    // library definition.
+    ...(base.states
+      ? { states: base.states.map((s) => ({ ...s, components: s.components.map((c) => ({ ...c })) })) }
+      : {}),
   }
 }

--- a/packages/engine/src/entity/registry.spec.ts
+++ b/packages/engine/src/entity/registry.spec.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from '@gjsify/unit'
+import type { NpcRouteComponent } from '../components/index.ts'
+import type { ComponentData } from '../types/data/index.ts'
 import { type ComponentSpec, isComponentSpec } from './component-spec.ts'
 import { BUILT_IN_COMPONENT_SPECS } from './registry.ts'
 import * as Specs from './specs/index.ts'
@@ -48,6 +50,26 @@ export default async () => {
       expect(teleport).not.toBeNull()
       // …while a data-only spec (movement) builds nothing (read off the def).
       expect(BUILT_IN_COMPONENT_SPECS.movement.build({ type: 'movement', tilesPerSec: 4 }, ctx)).toBeNull()
+    })
+
+    await it('npc-route build drops malformed waypoints (json-field escape hatch)', async () => {
+      const ctx = { placementId: 'p', tileX: 0, tileY: 0, tileWidth: 16, tileHeight: 16 }
+      // Mix of well-formed and malformed entries (strings, missing coord, NaN).
+      const data: ComponentData = {
+        type: 'npc-route',
+        waypoints: [
+          { tileX: 1, tileY: 2 },
+          { tileX: '3', tileY: 4 },
+          { tileX: 5 },
+          { tileX: Number.NaN, tileY: 6 },
+          { tileX: 7, tileY: 8 },
+        ],
+      }
+      const built = BUILT_IN_COMPONENT_SPECS['npc-route'].build(data, ctx) as NpcRouteComponent
+      expect(built.waypoints).toStrictEqual([
+        { tileX: 1, tileY: 2 },
+        { tileX: 7, tileY: 8 },
+      ])
     })
   })
 }

--- a/packages/engine/src/entity/specs/npc-route.ts
+++ b/packages/engine/src/entity/specs/npc-route.ts
@@ -20,6 +20,17 @@ export const npcRouteSpec: ComponentSpec = {
   ],
   build: (data) => {
     const d = data as NpcRouteData
-    return new NpcRouteComponent(d.waypoints ?? [], d.facing)
+    // `waypoints` is a free-form `json` field (and legacy migration pushes
+    // `props.route` verbatim), so guard each entry to a well-formed numeric
+    // tile coord before it reaches the runtime component.
+    const waypoints = (d.waypoints ?? []).filter(isWaypoint)
+    return new NpcRouteComponent(waypoints, d.facing)
   },
+}
+
+/** True when a value is a `{ tileX, tileY }` pair of finite numbers. */
+function isWaypoint(w: unknown): w is NpcWaypoint {
+  if (w == null || typeof w !== 'object') return false
+  const { tileX, tileY } = w as Record<string, unknown>
+  return typeof tileX === 'number' && Number.isFinite(tileX) && typeof tileY === 'number' && Number.isFinite(tileY)
 }

--- a/packages/engine/src/entity/validate.spec.ts
+++ b/packages/engine/src/entity/validate.spec.ts
@@ -20,6 +20,22 @@ const selectSpec: ComponentSpec = {
   build: () => null,
 }
 
+// A mis-declared select: closed ComboRow in the UI, but no options to
+// validate against — must be rejected rather than accept any string.
+const brokenSelectSpec: ComponentSpec = {
+  type: 'state',
+  editor: { label: 'State', icon: 'x' },
+  fields: [{ key: 'value', label: 'Value', input: 'select' }],
+  build: () => null,
+}
+
+const jsonSpec: ComponentSpec = {
+  type: 'custom-data',
+  editor: { label: 'Custom', icon: 'x' },
+  fields: [{ key: 'data', label: 'Data', input: 'json' }],
+  build: () => null,
+}
+
 export default async () => {
   await describe('validateComponentData', async () => {
     await it('accepts valid data', async () => {
@@ -40,6 +56,20 @@ export default async () => {
       expect(validateComponentData(selectSpec, { type: 'trigger', on: 'nope' }).length).toBe(1)
       expect(validateComponentData(selectSpec, { type: 'trigger', on: 'auto', facing: 'sideways' }).length).toBe(1)
       expect(validateComponentData(selectSpec, { type: 'trigger', on: 'auto', facing: 'up' })).toStrictEqual([])
+    })
+    await it('rejects a select field declared without options', async () => {
+      const errors = validateComponentData(brokenSelectSpec, { type: 'state', value: 'whatever' })
+      expect(errors.some((e) => e.includes('select field has no options'))).toBe(true)
+    })
+    await it('accepts JSON-serialisable data but rejects non-serialisable shapes', async () => {
+      expect(validateComponentData(jsonSpec, { type: 'custom-data', data: { a: 1, b: [2, 3] } })).toStrictEqual([])
+      // Circular reference — JSON.stringify throws.
+      const circular: Record<string, unknown> = {}
+      circular.self = circular
+      expect(validateComponentData(jsonSpec, { type: 'custom-data', data: circular }).length).toBe(1)
+      // BigInt + Map are not JSON-serialisable.
+      expect(validateComponentData(jsonSpec, { type: 'custom-data', data: 10n as unknown }).length).toBe(1)
+      expect(validateComponentData(jsonSpec, { type: 'custom-data', data: new Map() }).length).toBe(1)
     })
   })
 

--- a/packages/engine/src/entity/validate.ts
+++ b/packages/engine/src/entity/validate.ts
@@ -36,16 +36,42 @@ function validateField(field: FieldDescriptor, value: unknown, requireComplete: 
       break
     case 'select':
       if (typeof value !== 'string') return `"${field.key}" must be a string`
-      if (field.options && !field.options.some((o) => o.value === value)) return `"${field.key}" has an invalid option`
+      // A `select` with no options is a mis-declared spec: the inspector
+      // renders a closed ComboRow but validation would accept any string.
+      // Reject it as a spec error rather than let it behave as free text.
+      if (!field.options || field.options.length === 0) return `"${field.key}" select field has no options`
+      if (!field.options.some((o) => o.value === value)) return `"${field.key}" has an invalid option`
       break
     case 'facing':
       if (typeof value !== 'string' || !FACINGS.has(value)) return `"${field.key}" must be a facing direction`
       break
     case 'json':
-      // Any JSON-serialisable value is accepted; objects/arrays/primitives all pass.
+      // Accept any JSON-serialisable value, but reject the shapes that
+      // violate transport rule 4 (no functions / BigInt / Map/Set, no
+      // circular references — AGENTS.md): this boundary is where the
+      // op-log's serialisability contract is enforced.
+      if (!isJsonSerialisable(value)) return `"${field.key}" must be JSON-serialisable`
       break
   }
   return null
+}
+
+/**
+ * Cheap structural guard for the `json` field input: rejects functions,
+ * symbols, BigInt and `Map`/`Set` (which `JSON.stringify` silently drops
+ * or mangles) and circular references (which throw). Plain
+ * objects/arrays/primitives pass.
+ */
+function isJsonSerialisable(value: unknown): boolean {
+  const t = typeof value
+  if (t === 'function' || t === 'symbol' || t === 'bigint') return false
+  if (value instanceof Map || value instanceof Set) return false
+  try {
+    JSON.stringify(value)
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/scripts/migrate-to-entity-components.mjs
+++ b/scripts/migrate-to-entity-components.mjs
@@ -40,7 +40,7 @@ function writeJson(path, value) {
 }
 
 /** Mirror of `objectDefinitionToEntity` in entity/convert.ts. */
-function objectDefinitionToEntity(def) {
+function objectDefinitionToEntity(def, onWarn) {
   if (def && Array.isArray(def.components)) return def // already migrated
   const components = []
   const props = def.properties ?? {}
@@ -74,6 +74,8 @@ function objectDefinitionToEntity(def) {
           ...(props.facing ? { facing: props.facing } : {}),
           ...(props.label ? { label: props.label } : {}),
         })
+      } else {
+        onWarn?.(`teleport "${def.id}" dropped: missing/invalid targetMapId`)
       }
       break
     case 'item':
@@ -84,6 +86,8 @@ function objectDefinitionToEntity(def) {
           ...(props.qty !== undefined ? { qty: Number(props.qty) } : {}),
           ...(props.pickupSound ? { pickupSound: props.pickupSound } : {}),
         })
+      } else {
+        onWarn?.(`item "${def.id}" dropped: missing/invalid itemId`)
       }
       break
     case 'npc':
@@ -158,7 +162,9 @@ function migrateProject(projectPath) {
   let dirty = false
   // Object library → entity library (objects).
   if (Array.isArray(data.objectLibrary)) {
-    data.entityLibrary = (data.entityLibrary ?? []).concat(data.objectLibrary.map(objectDefinitionToEntity))
+    data.entityLibrary = (data.entityLibrary ?? []).concat(
+      data.objectLibrary.map((d) => objectDefinitionToEntity(d, console.warn)),
+    )
     delete data.objectLibrary
     dirty = true
   }
@@ -181,7 +187,7 @@ function migrateMap(mapPath) {
   let dirty = false
   for (const placement of data.objectPlacements) {
     if (placement.inline && !Array.isArray(placement.inline.components)) {
-      placement.inline = objectDefinitionToEntity(placement.inline)
+      placement.inline = objectDefinitionToEntity(placement.inline, console.warn)
       dirty = true
     }
     if (placement.overrides) {


### PR DESCRIPTION
Re-verified backlog item from the map-editor audit (still-real against current HEAD). Five related data-integrity holes in the entity-definition pipeline, each with a colocated spec.

## Changes
- **`validate.ts`** — a `select` field declared without `options` is now a spec error (it renders a closed ComboRow but previously accepted any string), and `json` fields enforce JSON-serialisability (reject functions/BigInt/`Map`/`Set` and circular refs) — that boundary is exactly where AGENTS.md transport rule 4 should be enforced.
- **`specs/npc-route.ts`** — `build` filters malformed waypoints to well-formed `{tileX, tileY}` numeric pairs (the `json` escape-hatch field and legacy `props.route` could inject non-numeric coords straight into the runtime component).
- **`data-access.ts`** — `resolvePlacementDefinition` deep-clones `states` on the override path. Components were already cloned by `mergePlacementComponents`; `states` rode the `...base` spread by reference, so a resolved placement aliased the library definition's mutable state data.
- **`convert.ts`** — `objectDefinitionToEntity` gains an optional `onWarn` callback and reports dropped legacy payloads (a `teleport`/`item` whose required prop is missing/mistyped) instead of silently producing an entity with the component dropped. Function stays pure; the `migrate-to-entity-components.mjs` mirror is kept in sync and wired to `console.warn`.
- **`commands/types.ts`** — the `Operation` wire envelope marks `kind`/`payload`/`peerId`/`seq` `readonly` (they were mutable). `(peerId, seq)` is the op-log's dedupe / echo-suppression / snapshot-watermark key — a relay path must not be able to rewrite an already-stamped op's identity. Verified no consumer reassigns these.

## Verification
- `gjsify workspace @pixelrpg/engine test` → **812 pass** (gjs + node), +5 new cases.
- Full-workspace `gjsify run check` clean; `format`, `lint` (only the pre-existing `agent-map-data` warning), `check:specs` all clean.