### PR TITLE
fix(engine): warn on object spawn integrity gaps

### DIFF
--- a/packages/engine/src/entity/spawn-placement.spec.ts
+++ b/packages/engine/src/entity/spawn-placement.spec.ts
@@ -10,8 +10,8 @@ import {
 } from '../components/index.ts'
 import { TIER_Z } from '../components/tilemap-tier.component.ts'
 import type { MapResource } from '../resource/MapResource.ts'
-import type { EntityDefinition, LayerData } from '../types/data/index.ts'
-import { buildPlacementEntity } from './spawn-placement.ts'
+import type { EntityDefinition, LayerData, ObjectPlacement } from '../types/data/index.ts'
+import { buildPlacementEntity, placementSpawnWarnings } from './spawn-placement.ts'
 
 const layer: LayerData = { id: 'l1', name: 'L', visible: true, sprites: [] }
 const fakeMapResource = {
@@ -85,6 +85,39 @@ export default async () => {
       ) as Actor
       expect(entity.graphics.current instanceof GraphicsGroup).toBe(true)
       expect((entity.graphics.current as GraphicsGroup).width).toBe(16)
+    })
+  })
+
+  // Pure (no DOM) — runs on both targets.
+  await describe('placementSpawnWarnings', async () => {
+    const placement: ObjectPlacement = { id: 'p1', layerId: 'l1', tileX: 0, tileY: 0, defId: 'ghost' }
+
+    await it('warns about an unresolved defId (deleted entity)', async () => {
+      const warnings = placementSpawnWarnings(placement, null)
+      expect(warnings.length).toBe(1)
+      expect(warnings[0]).toContain('defId "ghost"')
+    })
+
+    await it('is silent for a complete definition', async () => {
+      const def: EntityDefinition = {
+        id: 'cave',
+        name: 'Cave',
+        components: [{ type: 'teleport', targetMapId: 'm', targetTileX: 1, targetTileY: 2 }],
+      }
+      expect(placementSpawnWarnings({ ...placement, defId: undefined, inline: def }, def)).toStrictEqual([])
+    })
+
+    await it('warns about an incomplete required field (drafted teleport)', async () => {
+      // A teleport missing its required targetMapId — the save path allowed
+      // it, but spawn surfaces the gap (and still spawns best-effort).
+      const def: EntityDefinition = {
+        id: 'cave',
+        name: 'Cave',
+        components: [{ type: 'teleport', targetTileX: 1, targetTileY: 2 }],
+      }
+      const warnings = placementSpawnWarnings({ ...placement, defId: undefined, inline: def }, def)
+      expect(warnings.length).toBe(1)
+      expect(warnings[0]).toContain('incomplete definition')
     })
   })
 }

--- a/packages/engine/src/entity/spawn-placement.ts
+++ b/packages/engine/src/entity/spawn-placement.ts
@@ -9,6 +9,7 @@ import { EDITOR_CONSTANTS } from '../utils/constants.ts'
 import type { ComponentSpecRegistry } from './component-spec.ts'
 import { buildPlacementGraphic } from './placement-graphic.ts'
 import { BUILT_IN_COMPONENT_SPECS } from './registry.ts'
+import { validateEntityDefinition } from './validate.ts'
 
 /**
  * Build one Excalibur entity from a placement + its resolved definition,
@@ -57,4 +58,31 @@ export function buildPlacementEntity(
   if (!isLayerVisible(mapResource, placement.layerId)) actor.graphics.visible = false
 
   return actor
+}
+
+/**
+ * Diagnostic warnings for a placement about to spawn, evaluated against
+ * its resolved definition (`null` when the `defId` didn't resolve against
+ * the entity library, or an inline def was absent). Pure + node-testable;
+ * {@link ObjectSpawnSystem} logs the result.
+ *
+ * Warn-only by design: a leniently-saved draft (a placement whose required
+ * fields aren't filled in yet — the save path allows it, see
+ * {@link validateEntityDefinition}'s `requireComplete`) still spawns
+ * best-effort rather than vanishing from a shipped map, but the integrity
+ * gap is surfaced instead of staying silent. An unresolved `defId` (the
+ * entity it pointed at was deleted) is the only case that can't spawn.
+ */
+export function placementSpawnWarnings(
+  placement: ObjectPlacement,
+  def: EntityDefinition | null,
+  registry: ComponentSpecRegistry = BUILT_IN_COMPONENT_SPECS,
+): string[] {
+  if (!def) {
+    const ref = placement.defId ? `defId "${placement.defId}"` : 'an inline definition'
+    return [`placement "${placement.id}" references ${ref} that did not resolve — not spawned`]
+  }
+  const errors = validateEntityDefinition(def, registry, true)
+  if (errors.length === 0) return []
+  return [`placement "${placement.id}" ("${def.id}") has an incomplete definition: ${errors.join('; ')}`]
 }

--- a/packages/engine/src/systems/object-spawn.system.ts
+++ b/packages/engine/src/systems/object-spawn.system.ts
@@ -1,6 +1,6 @@
-import { Actor, type Scene, System, SystemType, type World } from 'excalibur'
+import { Actor, Logger, type Scene, System, SystemType, type World } from 'excalibur'
 import { resolvePlacementDefinition } from '../entity/data-access.ts'
-import { buildPlacementEntity } from '../entity/spawn-placement.ts'
+import { buildPlacementEntity, placementSpawnWarnings } from '../entity/spawn-placement.ts'
 import type { MapResource } from '../resource/MapResource.ts'
 import { areObjectsVisible } from '../services/editor-view.ts'
 import type { EntityDefinition } from '../types/data/index.ts'
@@ -18,6 +18,7 @@ import type { EntityDefinition } from '../types/data/index.ts'
  */
 export class ObjectSpawnSystem extends System {
   public readonly systemType = SystemType.Update
+  private readonly logger = Logger.getInstance()
 
   constructor(
     private readonly mapResource: MapResource,
@@ -45,6 +46,9 @@ export class ObjectSpawnSystem extends System {
     const objectsVisible = areObjectsVisible(scene)
     for (const placement of mapData.objectPlacements) {
       const def = resolvePlacementDefinition(placement, this.entityLibrary)
+      // Surface integrity gaps (dangling defId, incomplete required fields)
+      // instead of silently skipping — these used to vanish without a trace.
+      for (const warning of placementSpawnWarnings(placement, def)) this.logger.warn(`[ObjectSpawnSystem] ${warning}`)
       if (!def) continue
       const entity = buildPlacementEntity(placement, def, this.mapResource, layersById)
       // Respect the global objects toggle (Layers tab "Objects" row).


### PR DESCRIPTION
Re-verified backlog item (audit `engine-placement-integrity` + the diagnostic half of `spawn-skips-requirecomplete-gate`), still-real against current HEAD.

## Problem
`ObjectSpawnSystem.spawnAll` silently `continue`d past any placement whose `defId` failed to resolve (its entity was deleted from the library) — the object vanished with no trace. It also built definitions with empty required fields straight from undefined data.

## Fix
A pure, node-testable `placementSpawnWarnings(placement, def, registry)` in `entity/spawn-placement.ts`, logged by `ObjectSpawnSystem`:
- **unresolved `defId`** → warned (this case genuinely can't spawn)
- **incomplete required fields** → warned, but still spawned best-effort

**Warn-only by design.** Hard-skipping incomplete placements (what a strict `requireComplete` spawn gate would do) would make authored-but-unfinished objects disappear from shipped maps — and the games carry no migration shims. Surfacing the gap as a warning lets the author fix it without silently losing content. A future *publish/export* gate can enforce strictly; runtime spawn stays lenient.

## Verification
- `gjsify workspace @pixelrpg/engine test` → green on **gjs + node**, +3 new cases for `placementSpawnWarnings`.
- `format` / `lint` (only the pre-existing `agent-map-data` warning) / `check:specs` clean.