### PR TITLE
fix(engine): harden collab op intake

### DIFF
--- a/packages/engine/src/sync/chunking.spec.ts
+++ b/packages/engine/src/sync/chunking.spec.ts
@@ -7,7 +7,13 @@
 
 import { describe, expect, it } from '@gjsify/unit'
 
-import { buildChunkEnvelopes, CHUNK_SIZE_BYTES, ChunkReassembler } from './chunking.ts'
+import {
+  buildChunkEnvelopes,
+  CHUNK_SIZE_BYTES,
+  ChunkReassembler,
+  MAX_CONCURRENT_TRANSFERS,
+  MAX_TOTAL_CHUNKS,
+} from './chunking.ts'
 
 export default async () => {
   await describe('buildChunkEnvelopes', async () => {
@@ -98,6 +104,37 @@ export default async () => {
       const result = reassembler.accept({ transferId: 't', chunkIndex: 0, totalChunks: 1, data: 'not-json' })
       expect(result.status).toBe('error')
       if (result.status === 'error') expect(result.reason.includes('json.length=8')).toBe(true)
+    })
+
+    await it('rejects totalChunks above the cap (unbounded allocation guard)', async () => {
+      const reassembler = new ChunkReassembler<unknown>()
+      const result = reassembler.accept({
+        transferId: 't',
+        chunkIndex: 0,
+        totalChunks: MAX_TOTAL_CHUNKS + 1,
+        data: '',
+      })
+      expect(result.status).toBe('error')
+      // A within-cap transfer still starts normally.
+      expect(reassembler.accept({ transferId: 't2', chunkIndex: 0, totalChunks: 2, data: 'a' }).status).toBe('pending')
+    })
+
+    await it('rejects new transfers past the concurrency cap (partial-buffer leak guard)', async () => {
+      const reassembler = new ChunkReassembler<unknown>()
+      // Open MAX_CONCURRENT_TRANSFERS distinct, never-completed transfers.
+      // t0's two chunks join to valid JSON ('true') so it can complete below.
+      expect(reassembler.accept({ transferId: 't0', chunkIndex: 0, totalChunks: 2, data: 'tr' }).status).toBe('pending')
+      for (let i = 1; i < MAX_CONCURRENT_TRANSFERS; i++) {
+        expect(reassembler.accept({ transferId: `t${i}`, chunkIndex: 0, totalChunks: 2, data: 'a' }).status).toBe(
+          'pending',
+        )
+      }
+      // The next NEW transferId is refused…
+      expect(reassembler.accept({ transferId: 'overflow', chunkIndex: 0, totalChunks: 2, data: 'a' }).status).toBe(
+        'error',
+      )
+      // …but an already-open transfer still makes progress (and frees a slot).
+      expect(reassembler.accept({ transferId: 't0', chunkIndex: 1, totalChunks: 2, data: 'ue' }).status).toBe('done')
     })
 
     await it('clear() drops partial transfers', async () => {

--- a/packages/engine/src/sync/chunking.ts
+++ b/packages/engine/src/sync/chunking.ts
@@ -21,6 +21,23 @@ import { formatErrorMessage } from '../utils/format-error.ts'
 /** SCTP-safe chunk size: ~80 sends for a 1.2 MB snapshot. */
 export const CHUNK_SIZE_BYTES = 16 * 1024
 
+/**
+ * Upper bound on `totalChunks` the reassembler will accept — 64 MiB at
+ * {@link CHUNK_SIZE_BYTES}, far above any real snapshot (~80 chunks). A
+ * remote peer controls `totalChunks`, and `accept()` allocates an array
+ * of that length, so without a cap a single envelope claiming
+ * `totalChunks: 2_000_000_000` forces a 2-billion-slot allocation.
+ */
+export const MAX_TOTAL_CHUNKS = 4096
+
+/**
+ * Upper bound on concurrent in-flight transfers per reassembler. A peer
+ * can open many `transferId`s and never complete them, leaking partial
+ * buffers until session close — mirror {@link CHUNK_SIZE_BYTES}'s defensive
+ * posture (and the `PreAttachOpBuffer` cap) with a ceiling on live transfers.
+ */
+export const MAX_CONCURRENT_TRANSFERS = 64
+
 /** One slice of a chunked JSON payload, addressed by transfer + index. */
 export interface ChunkEnvelope {
   /** Groups the slices of one logical payload (multi-transfer reassembly). */
@@ -83,6 +100,7 @@ export class ChunkReassembler<T> {
     if (
       !Number.isInteger(totalChunks) ||
       totalChunks <= 0 ||
+      totalChunks > MAX_TOTAL_CHUNKS ||
       !Number.isInteger(chunkIndex) ||
       chunkIndex < 0 ||
       chunkIndex >= totalChunks
@@ -90,11 +108,19 @@ export class ChunkReassembler<T> {
       this.transfers.delete(transferId)
       return {
         status: 'error',
-        reason: `invalid chunk envelope (chunkIndex=${chunkIndex}, totalChunks=${totalChunks})`,
+        reason: `invalid chunk envelope (chunkIndex=${chunkIndex}, totalChunks=${totalChunks}, cap=${MAX_TOTAL_CHUNKS})`,
       }
     }
     let entry = this.transfers.get(transferId)
     if (!entry) {
+      // Cap concurrent transfers so a peer can't open unbounded partial
+      // buffers (each holds up to MAX_TOTAL_CHUNKS slices until completion).
+      if (this.transfers.size >= MAX_CONCURRENT_TRANSFERS) {
+        return {
+          status: 'error',
+          reason: `too many concurrent transfers (cap=${MAX_CONCURRENT_TRANSFERS})`,
+        }
+      }
       entry = { chunks: new Array<string | undefined>(totalChunks), total: totalChunks, received: 0 }
       this.transfers.set(transferId, entry)
     } else if (entry.total !== totalChunks) {

--- a/packages/engine/src/sync/session-controller.ts
+++ b/packages/engine/src/sync/session-controller.ts
@@ -117,22 +117,6 @@ export class SessionController {
   }
 
   /**
-   * Send a session-protocol message (e.g. snapshot-request /
-   * snapshot-response). Stamps `peerId` + `seq` so the receiver
-   * can deduplicate the same way it does for commands; the
-   * envelope rides the existing reliable op channel.
-   */
-  sendSessionProtocol(op: Omit<SessionProtocolOp, 'peerId' | 'seq'>): void {
-    if (this.closed) return
-    const stamped = {
-      ...op,
-      peerId: this.peerId,
-      seq: this.localSeq++,
-    } as SessionProtocolOp
-    this.session.sendOp(stamped)
-  }
-
-  /**
    * Detach from both engine + session. Idempotent. The peer
    * session itself is NOT closed — the controller can be replaced
    * mid-session (e.g. host migration in Phase 8) without


### PR DESCRIPTION
Re-verified backlog items from the audit (`chunk-reassembler-unbounded` + `session-protocol-localseq-footgun`), both still-real. Two defensive fixes to the sync wire layer.

## ChunkReassembler caps
`accept()` validated `totalChunks` only as a positive integer with no upper bound, then allocated `new Array(totalChunks)` — a remote peer (it controls `totalChunks`, and `transferId` is remote-controlled on the `__project/spriteset.*.chunk` path) can force a multi-billion-slot allocation with one envelope. There was also no cap on concurrent in-flight `transferId`s, so partial buffers leak until session close.

- `MAX_TOTAL_CHUNKS = 4096` (64 MiB at 16 KiB/chunk, far above the ~80-chunk real snapshot) — over-cap `totalChunks` → `error`.
- `MAX_CONCURRENT_TRANSFERS = 64` — a new `transferId` past the cap → `error`; existing transfers still progress.

Mirrors the `PreAttachOpBuffer` cap that exists for exactly this reason.

## Drop dead `sendSessionProtocol`
`SessionController.sendSessionProtocol` has **zero callers** (snapshot request/response/chunk ops are sent by `SnapshotExchange` with its own seq counter). It bumped the same `localSeq` that `peekNextSeq()` returns — and `peekNextSeq()` is now live as the `SnapshotOpWatermark.nextSeq`. A session-protocol op would have advanced the watermark past command seqs that don't exist, skewing the `(peerId, seq)` dedupe. Deleting it makes `localSeq` purely command-driven; the receive path (`isSessionProtocolOp` → `onSessionProtocol`) is untouched.

## Verification
- `gjsify workspace @pixelrpg/engine test` → green on gjs (892) + node (867), +2 cap cases.
- `format` / `lint` (pre-existing `agent-map-data` warning only) / `check:specs` clean.