### PR TITLE
fix(engine): small resolver + awareness fixes

### DIFF
--- a/packages/engine/src/services/sprite-info.resolver.spec.ts
+++ b/packages/engine/src/services/sprite-info.resolver.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from '@gjsify/unit'
 
 import type { MapResource } from '../resource/MapResource.ts'
 import type { SpriteIndex } from '../types/SpriteIndex.ts'
-import { findSpriteInfoForTileId } from './sprite-info.resolver.ts'
+import { findSpriteInfoForTileId, getSpriteGidSpan } from './sprite-info.resolver.ts'
 
 function makeSpriteIndex(spriteIds: number[]): SpriteIndex {
   return {
@@ -92,6 +92,18 @@ export default async () => {
       })
       const result = await muteWarn(() => findSpriteInfoForTileId(mapResource, 1))
       expect(result).toBeNull()
+    })
+  })
+
+  await describe('getSpriteGidSpan', async () => {
+    await it('returns maxLocalId + 1 (a span, not a count) for a sparse set', async () => {
+      // Sparse ids: 5 sprites but the span reaches the largest id + 1.
+      expect(getSpriteGidSpan(makeSpriteIndex([0, 1, 2, 7, 9]))).toBe(10)
+      expect(getSpriteGidSpan(makeSpriteIndex([0, 1, 2, 3]))).toBe(4)
+    })
+
+    await it('returns 0 for an empty sprite set', async () => {
+      expect(getSpriteGidSpan(makeSpriteIndex([]))).toBe(0)
     })
   })
 }

--- a/packages/engine/src/services/sprite-info.resolver.ts
+++ b/packages/engine/src/services/sprite-info.resolver.ts
@@ -2,10 +2,16 @@ import type { MapResource } from '../resource/MapResource.ts'
 import type { SpriteIndex } from '../types/SpriteIndex.ts'
 import { isValidTileId } from './sprite.validator.ts'
 
-function getSpriteCount(spriteSetResource: SpriteIndex): number {
-  const sprites = spriteSetResource.sprites
-  const ids = Object.keys(sprites).map((id) => Number.parseInt(id, 10))
-  return ids.length > 0 ? Math.max(...ids) + 1 : 0
+/**
+ * The gid extent a sprite set occupies: `maxLocalId + 1`, NOT a count —
+ * sprite ids are sparse, so the span can exceed the number of sprites.
+ * Used to compute `lastGid = firstGid + span - 1`. Uses `reduce` rather
+ * than `Math.max(...ids)`, which would spread every id as a call arg and
+ * RangeError on a very large sprite set.
+ */
+export function getSpriteGidSpan(spriteSetResource: SpriteIndex): number {
+  const ids = Object.keys(spriteSetResource.sprites).map((id) => Number.parseInt(id, 10))
+  return ids.length > 0 ? ids.reduce((max, id) => (id > max ? id : max), 0) + 1 : 0
 }
 
 function spriteExists(spriteSetResource: SpriteIndex, spriteId: number): boolean {
@@ -45,8 +51,7 @@ export function findSpriteInfoForTileId(
     }
 
     const firstGid = spriteSetRef.firstGid
-    const spriteCount = getSpriteCount(spriteSetResource)
-    const lastGid = firstGid + spriteCount - 1
+    const lastGid = firstGid + getSpriteGidSpan(spriteSetResource) - 1
 
     if (tileId >= firstGid && tileId <= lastGid) {
       const localSpriteId = tileId - firstGid

--- a/packages/engine/src/sync/awareness.spec.ts
+++ b/packages/engine/src/sync/awareness.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from '@gjsify/unit'
 
-import { AwarenessManager, type AwarenessMessage, type AwarenessPeerState, isAwarenessMessage } from './awareness.ts'
+import {
+  AwarenessManager,
+  type AwarenessMessage,
+  type AwarenessPeerState,
+  DEFAULT_PEER_COLOR,
+  isAwarenessMessage,
+} from './awareness.ts'
 
 interface FakeClock {
   now: () => number
@@ -244,7 +250,7 @@ export default async () => {
       const bob = mgr.getPeer('peer-bob')
       expect(bob).not.toBeNull()
       expect(bob?.info.displayName).toBe('peer-bob')
-      expect(bob?.info.color).toBe('#888')
+      expect(bob?.info.color).toBe(DEFAULT_PEER_COLOR)
     })
   })
 }

--- a/packages/engine/src/sync/awareness.ts
+++ b/packages/engine/src/sync/awareness.ts
@@ -96,6 +96,14 @@ export interface AwarenessEventMap {
 const DEFAULT_CURSOR_THROTTLE_MS = 30
 
 /**
+ * Fallback colour for a peer (or the AI assistant) whose presence info is
+ * missing or carries a bogus colour token — mid-grey so it still renders.
+ * Shared by the roster fallback ({@link AwarenessManager}) and the cursor
+ * renderer's parse-failure path so the two can't drift.
+ */
+export const DEFAULT_PEER_COLOR = '#888888'
+
+/**
  * Validates a parsed inbound message before applying it. Defends
  * against the relay/transport handing us a buffer that happens to
  * parse as JSON but isn't a real awareness frame (third-party noise
@@ -336,7 +344,7 @@ export class AwarenessManager {
 
   private updatePeer(peerId: string, patch: Partial<Pick<AwarenessPeerState, 'info' | 'cursor' | 'selection'>>): void {
     const prev = this.peers.get(peerId)
-    const info = patch.info ?? prev?.info ?? { displayName: peerId, color: '#888' }
+    const info = patch.info ?? prev?.info ?? { displayName: peerId, color: DEFAULT_PEER_COLOR }
     const cursor = patch.cursor !== undefined ? patch.cursor : (prev?.cursor ?? null)
     const selection = patch.selection !== undefined ? patch.selection : (prev?.selection ?? null)
     const next: AwarenessPeerState = {

--- a/packages/engine/src/sync/remote-cursor-renderer.ts
+++ b/packages/engine/src/sync/remote-cursor-renderer.ts
@@ -3,7 +3,7 @@ import { Actor, Circle, Color, Font, GraphicsGroup, type Scene, Text, Vector } f
 import type { Engine } from '../engine.ts'
 import { createSelectionRing, findPlacementActor } from '../services/selection-highlight.ts'
 import { EDITOR_CONSTANTS } from '../utils/constants.ts'
-import type { AwarenessManager, AwarenessPeerState } from './awareness.ts'
+import { type AwarenessManager, type AwarenessPeerState, DEFAULT_PEER_COLOR } from './awareness.ts'
 
 /**
  * In-canvas renderer for remote peers' cursors.
@@ -225,6 +225,6 @@ export function parseAwarenessColour(token: string): Color {
   try {
     return Color.fromHex(token)
   } catch {
-    return Color.fromHex('#888888')
+    return Color.fromHex(DEFAULT_PEER_COLOR)
   }
 }


### PR DESCRIPTION
Re-verified low-bug findings from the audit (`getspritecount-span-not-count` + `two-fallback-peer-colours`).

- **`sprite-info.resolver`** — `getSpriteCount` actually returned `maxLocalId + 1` (a gid *span*; ids are sparse so it can exceed the sprite count), used as `lastGid = firstGid + span - 1`. Renamed to `getSpriteGidSpan` and exported so it's directly testable, and switched `Math.max(...ids)` → `reduce` (the spread would RangeError on a very large sprite set, the same arg-limit class the base64 chunker guards against).
- **`awareness`** — a single shared `DEFAULT_PEER_COLOR = '#888888'` replaces the two duplicated fallback literals (`'#888'` in the roster fallback, `'#888888'` in the cursor renderer's parse-failure path). They render identically but would drift the moment one was edited; the spec now asserts the constant.

## Verification
- `gjsify workspace @pixelrpg/engine` check + test green on gjs + node; new specs for `getSpriteGidSpan` (sparse span + empty) and the shared colour fallback.
- `format` / `lint` (pre-existing `agent-map-data` warning only) / `check:specs` clean.