### PR TITLE
fix(maker): deterministic GTK signal teardown

### DIFF
--- a/apps/maker-gjs/src/services/engine-controller.ts
+++ b/apps/maker-gjs/src/services/engine-controller.ts
@@ -92,6 +92,16 @@ export class EngineController {
   private _layerFlagHookAttached = false
   private _pointerTileHookAttached = false
   private readonly _events = new TypedEmitter<EngineControllerEvents>()
+  /**
+   * Excalibur `events.on(...)` subscriptions opened on the current engine
+   * (TILE_PICKED / PLACEMENT_SELECTED / LAYER_FLAG_CHANGED). Closed in
+   * {@link dispose} so teardown is deterministic rather than relying on the
+   * engine emitter being GC'd — the closures capture `this`, so a pinned
+   * emitter would otherwise keep firing into a controller whose `_engine`
+   * is a newer instance. (The zoom/undo/pointer hooks return a boolean; the
+   * gjs `Engine` widget owns those subscriptions and drops them on dispose.)
+   */
+  private readonly _hookSubs: Array<{ close(): void }> = []
 
   constructor(private readonly slot: EngineSlot) {}
 
@@ -173,6 +183,10 @@ export class EngineController {
     // critical). Calling `Engine.dispose()` synchronously here keeps
     // teardown in a user-action context where JS callbacks run
     // freely.
+    // Close the excalibur subscriptions we own before tearing the engine
+    // down, so the capturing closures stop firing deterministically.
+    for (const sub of this._hookSubs) sub.close()
+    this._hookSubs.length = 0
     this._engine.dispose()
     this.slot(null)
     this._engine = null
@@ -232,28 +246,31 @@ export class EngineController {
 
   private _attachTilePickedHook(): void {
     if (this._tilePickedHookAttached || !this._engine) return
-    // The gjs Engine widget owns the EventEmitter; on dispose the
-    // widget is dropped and its emitter is GC'd along with this
-    // closure, so we don't track an explicit Subscription handle.
-    this._engine.events.on(EngineEvent.TILE_PICKED, (payload) => {
-      this._events.emit('tile-picked', payload)
-    })
+    this._hookSubs.push(
+      this._engine.events.on(EngineEvent.TILE_PICKED, (payload) => {
+        this._events.emit('tile-picked', payload)
+      }),
+    )
     this._tilePickedHookAttached = true
   }
 
   private _attachPlacementSelectedHook(): void {
     if (this._placementSelectedHookAttached || !this._engine) return
-    this._engine.events.on(EngineEvent.PLACEMENT_SELECTED, (payload) => {
-      this._events.emit('placement-selected', payload)
-    })
+    this._hookSubs.push(
+      this._engine.events.on(EngineEvent.PLACEMENT_SELECTED, (payload) => {
+        this._events.emit('placement-selected', payload)
+      }),
+    )
     this._placementSelectedHookAttached = true
   }
 
   private _attachLayerFlagHook(): void {
     if (this._layerFlagHookAttached || !this._engine) return
-    this._engine.events.on(EngineEvent.LAYER_FLAG_CHANGED, (payload) => {
-      this._events.emit('layer-flag-changed', payload)
-    })
+    this._hookSubs.push(
+      this._engine.events.on(EngineEvent.LAYER_FLAG_CHANGED, (payload) => {
+        this._events.emit('layer-flag-changed', payload)
+      }),
+    )
     this._layerFlagHookAttached = true
   }
 

--- a/apps/maker-gjs/src/widgets/data-view.ts
+++ b/apps/maker-gjs/src/widgets/data-view.ts
@@ -4,7 +4,7 @@ import Gio from '@girs/gio-2.0'
 import GObject from '@girs/gobject-2.0'
 import Gtk from '@girs/gtk-4.0'
 import type { SpriteSetKind } from '@pixelrpg/engine'
-import type { ModeRail } from '@pixelrpg/gjs'
+import { type ModeRail, SignalScope } from '@pixelrpg/gjs'
 import { gettext as _ } from 'gettext'
 
 import Template from './data-view.blp'
@@ -68,6 +68,7 @@ export class DataView extends ResponsiveEditorView {
   declare _import_sheet_button: Gtk.Button
   declare _import_tileset_button: Gtk.Button
 
+  private signals = new SignalScope()
   private _callbacks: DataViewCallbacks | null = null
   // True while `setData` writes the row texts, so the `notify`/`apply`
   // handlers don't fire the edit callbacks back during a refresh.
@@ -102,20 +103,32 @@ export class DataView extends ResponsiveEditorView {
     )
   }
 
-  constructor() {
-    super()
-    this._mode_rail.connect('mode-changed', (_r: ModeRail, mode: string) => this.emit('mode-changed', mode))
-    this._import_sheet_button.connect('clicked', () => this._callbacks?.importAsset('character'))
-    this._import_tileset_button.connect('clicked', () => this._callbacks?.importAsset('tileset'))
+  // Signals are connected in vfunc_map / released in vfunc_unmap via
+  // SignalScope (the workspace's GTK lifecycle rule) so a remapped view
+  // doesn't accumulate duplicate handlers and an unmapped one stops firing.
+  vfunc_map(): void {
+    super.vfunc_map()
+    this.signals.connect(this._mode_rail, 'mode-changed', (_r: ModeRail, mode: string) =>
+      this.emit('mode-changed', mode),
+    )
+    this.signals.connect(this._import_sheet_button, 'clicked', () => this._callbacks?.importAsset('character'))
+    this.signals.connect(this._import_tileset_button, 'clicked', () => this._callbacks?.importAsset('tileset'))
 
-    this._name_row.connect('apply', () => this._emitField('name', this._name_row.get_text()))
-    this._author_row.connect('apply', () => this._emitField('author', this._author_row.get_text()))
-    this._version_row.connect('apply', () => this._emitField('version', this._version_row.get_text()))
-    this._description_row.connect('apply', () => this._emitField('description', this._description_row.get_text()))
-    this._tilesize_row.connect('notify::value', () => {
+    this.signals.connect(this._name_row, 'apply', () => this._emitField('name', this._name_row.get_text()))
+    this.signals.connect(this._author_row, 'apply', () => this._emitField('author', this._author_row.get_text()))
+    this.signals.connect(this._version_row, 'apply', () => this._emitField('version', this._version_row.get_text()))
+    this.signals.connect(this._description_row, 'apply', () =>
+      this._emitField('description', this._description_row.get_text()),
+    )
+    this.signals.connect(this._tilesize_row, 'notify::value', () => {
       if (this._loading) return
       this._callbacks?.setProjectField('tileSize', String(Math.round(this._tilesize_row.get_value())))
     })
+  }
+
+  vfunc_unmap(): void {
+    this.signals.disconnectAll()
+    super.vfunc_unmap()
   }
 
   private _emitField(field: 'name' | 'author' | 'version' | 'description', value: string): void {


### PR DESCRIPTION
Re-verified lifecycle findings from the audit (`engine-controller-hooks-not-unsubscribed` + `data-view-constructor-signals`). Two widget/controller leaks where handlers outlived their target.

- **EngineController** subscribed to the engine's `events.on(TILE_PICKED / PLACEMENT_SELECTED / LAYER_FLAG_CHANGED)` and discarded the `Subscription` handles, relying on the emitter being GC'd. The closures capture the controller, which outlives the engine across `ensureForMap` recreations — a pinned emitter would keep firing into a stale `_engine`. Now the three handles are captured and `.close()`d in `dispose()`. (The zoom/undo/pointer hooks return a `boolean`; the gjs `Engine` widget owns those subscriptions and drops them with the engine.)
- **DataView** connected all seven of its signals (mode rail, two import buttons, four EntryRow `apply` + one SpinRow `notify::value`) in the constructor with no `SignalScope` and no `vfunc_unmap` — the one view skipping the workspace's connect-in-`vfunc_map` / disconnect-in-`vfunc_unmap` rule that all six sibling views follow. Moved to a `SignalScope` in `vfunc_map`/`vfunc_unmap`.

## Verification
gjs-only widgets (no headless unit path) — `gjsify run check` (all packages) exit 0; mirrors the exact `SignalScope` pattern of the sibling views; `format` / `lint` / `check:specs` clean.

Deferred (noted for a follow-up): `lens-controllers-no-dispose` — those controllers are created once per window and never recreated (the `if (!this._castCtl)` guards), so there's no active leak; adding `dispose()` wiring into the window lifecycle is defensive hygiene better done as its own change.