### PR TITLE
refactor(maker): extract camera-zoom math

### DIFF
--- a/apps/maker-gjs/src/services/engine-controller.ts
+++ b/apps/maker-gjs/src/services/engine-controller.ts
@@ -1,6 +1,7 @@
 import { EngineEvent, type EngineEventMap } from '@pixelrpg/engine'
 import { Engine } from '@pixelrpg/gjs'
 import { TypedEmitter } from './typed-emitter.ts'
+import { calculateNextZoom, shouldReportZoomChange } from './zoom-math.ts'
 
 type TilePickedPayload = EngineEventMap[EngineEvent.TILE_PICKED]
 type PlacementSelectedPayload = EngineEventMap[EngineEvent.PLACEMENT_SELECTED]
@@ -224,14 +225,13 @@ export class EngineController {
   stepZoom(delta: number): void {
     const current = this.getCameraZoom()
     if (current == null) return
-    const next = Math.max(0.1, Math.min(4, Math.round((current + delta) * 10) / 10))
-    this.applyZoom(next)
+    this.applyZoom(calculateNextZoom(current, delta))
   }
 
   private _attachZoomHook(): void {
     if (this._zoomHookAttached || !this._engine) return
     this._zoomHookAttached = this._engine.onCameraZoomChanged((zoom) => {
-      if (Math.abs(zoom - this._lastReportedZoom) < 0.01) return
+      if (!shouldReportZoomChange(zoom, this._lastReportedZoom)) return
       this._lastReportedZoom = zoom
       this._events.emit('zoom-changed', zoom)
     })

--- a/apps/maker-gjs/src/services/zoom-math.spec.ts
+++ b/apps/maker-gjs/src/services/zoom-math.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure camera-zoom math used by `EngineController.stepZoom` (button/key
+ * zoom) and its `onCameraZoomChanged` dead-band (OSD-label de-spam).
+ *
+ * Pinned independently of the gi-bound engine widget. Every expected
+ * value here is the actual output of the original inline expressions, so
+ * the spec is a behavior-preservation guard for the extraction — including
+ * the deliberately-lossy step quantisation and the `>= deadBand` boundary
+ * (the negation of the source's `< 0.01` suppress condition).
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+
+import { ZOOM_MAX, ZOOM_MIN, calculateNextZoom, shouldReportZoomChange } from './zoom-math.ts'
+
+export default async () => {
+  await describe('calculateNextZoom', async () => {
+    await it('steps up by delta, rounded to one decimal', async () => {
+      expect(calculateNextZoom(1, 0.2)).toBe(1.2)
+      expect(calculateNextZoom(2, 0.2)).toBe(2.2)
+    })
+
+    await it('quantises to tenths (rounds independently each step)', async () => {
+      expect(calculateNextZoom(1.05, 0.001)).toBe(1.1)
+      expect(calculateNextZoom(1.234, 0.567)).toBe(1.8)
+      // 0.05 + 0.1 rounds to 0.2 — repeated steps != initial + Σdeltas.
+      expect(calculateNextZoom(0.05, 0.1)).toBe(0.2)
+    })
+
+    await it('clamps to the max bound', async () => {
+      expect(calculateNextZoom(3.9, 0.2)).toBe(ZOOM_MAX)
+      expect(calculateNextZoom(3.95, 0.1)).toBe(ZOOM_MAX)
+      expect(calculateNextZoom(10, 0)).toBe(ZOOM_MAX)
+    })
+
+    await it('clamps to the min bound', async () => {
+      expect(calculateNextZoom(0.1, -0.05)).toBe(ZOOM_MIN)
+      expect(calculateNextZoom(0.2, -1)).toBe(ZOOM_MIN)
+      expect(calculateNextZoom(0, 0)).toBe(ZOOM_MIN)
+    })
+
+    await it('is a no-op for a zero delta on an in-range value', async () => {
+      expect(calculateNextZoom(1, 0)).toBe(1)
+    })
+  })
+
+  await describe('shouldReportZoomChange', async () => {
+    await it('suppresses changes below the dead-band', async () => {
+      expect(shouldReportZoomChange(1.005, 1.0)).toBe(false)
+      expect(shouldReportZoomChange(1.009, 1.0)).toBe(false)
+      expect(shouldReportZoomChange(0.995, 1.0)).toBe(false)
+    })
+
+    await it('reports changes at or above the dead-band', async () => {
+      expect(shouldReportZoomChange(1.015, 1.0)).toBe(true)
+      expect(shouldReportZoomChange(1.011, 1.0)).toBe(true)
+      expect(shouldReportZoomChange(2.0, 1.0)).toBe(true)
+    })
+
+    await it('reports a change of exactly the dead-band edge', async () => {
+      // Mirrors the source `< 0.01` suppress condition negated: exactly
+      // 0.01 is NOT suppressed, so it must report.
+      expect(shouldReportZoomChange(1.01, 1.0)).toBe(true)
+    })
+
+    await it('suppresses an unchanged value', async () => {
+      expect(shouldReportZoomChange(1.0, 1.0)).toBe(false)
+    })
+
+    await it('honours a custom dead-band', async () => {
+      expect(shouldReportZoomChange(1.04, 1.0, 0.05)).toBe(false)
+      expect(shouldReportZoomChange(1.06, 1.0, 0.05)).toBe(true)
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/zoom-math.ts
+++ b/apps/maker-gjs/src/services/zoom-math.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure camera-zoom math shared by {@link EngineController}. Kept free of
+ * any `@pixelrpg/gjs` / `gi://` import so it can be unit-tested under the
+ * node target (the controller itself wraps the gi-bound engine widget and
+ * can't run headlessly).
+ */
+
+/** Camera zoom is clamped to this range (1 = 100%). */
+export const ZOOM_MIN = 0.1
+export const ZOOM_MAX = 4
+
+/** Default zoom-report dead-band — see {@link shouldReportZoomChange}. */
+export const ZOOM_REPORT_DEAD_BAND = 0.01
+
+/**
+ * Bump `currentZoom` by `delta` and snap the result to the engine's
+ * scroll-wheel-zoom granularity: rounded to one decimal and clamped to
+ * `[ZOOM_MIN, ZOOM_MAX]`.
+ *
+ * The rounding is lossy by design — stepping is quantised so the OSD reads
+ * clean tenths, which means repeated `calculateNextZoom` calls do NOT equal
+ * `initial + Σdeltas`; each step rounds independently.
+ */
+export function calculateNextZoom(currentZoom: number, delta: number): number {
+  return Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, Math.round((currentZoom + delta) * 10) / 10))
+}
+
+/**
+ * Whether a new camera zoom is far enough from the last reported value to
+ * be worth re-emitting — a dead-band that stops sub-`deadBand` floating
+ * point drift from spamming the OSD label. Reports when the absolute
+ * change is `>= deadBand` (so a change of exactly the band edge reports).
+ */
+export function shouldReportZoomChange(
+  newZoom: number,
+  lastReportedZoom: number,
+  deadBand = ZOOM_REPORT_DEAD_BAND,
+): boolean {
+  return Math.abs(newZoom - lastReportedZoom) >= deadBand
+}

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -21,6 +21,7 @@ import relaySignallingSuite from './services/relay-signalling.spec.js'
 import sandboxPathSuite from './services/sandbox-path.spec.js'
 import sessionServiceSuite from './services/session-service.spec.js'
 import sessionServiceE2eSuite from './services/session-service-e2e.spec.js'
+import zoomMathSuite from './services/zoom-math.spec.js'
 
 run({
   assistantPausePolicySuite,
@@ -45,4 +46,5 @@ run({
   sandboxPathSuite,
   sessionServiceSuite,
   sessionServiceE2eSuite,
+  zoomMathSuite,
 })


### PR DESCRIPTION
## What

Lift the two inline camera-zoom expressions out of `EngineController` into a new gi-free `apps/maker-gjs/src/services/zoom-math.ts` and add a unit spec.

## Why

`EngineController` wraps the `gi://`-bound `Engine` widget and can't run headlessly, so this math could only be exercised through a live engine. As pure functions with zero imports, both are node-testable:

- **`calculateNextZoom(current, delta)`** — the step + clamp(`[0.1, 4]`) + round-to-tenths used by `stepZoom` (button/key zoom). The rounding is lossy by design, so the spec pins that repeated steps ≠ `initial + Σdeltas`.
- **`shouldReportZoomChange(new, last, deadBand = 0.01)`** — the OSD-label de-spam dead-band from the `onCameraZoomChanged` hook. The extracted `>= deadBand` is the exact negation of the source's `< 0.01` suppress condition; the exactly-at-band boundary is pinned.

## Changes

- New `services/zoom-math.ts` (`calculateNextZoom`, `shouldReportZoomChange`, `ZOOM_MIN`/`ZOOM_MAX`/`ZOOM_REPORT_DEAD_BAND`).
- `EngineController.stepZoom` / `_attachZoomHook` now delegate (behavior-neutral).
- New `services/zoom-math.spec.ts` — every expected value is the **actual** output of the original inline expressions (behavior-preservation guard), registered in `test.mts`.

## Verification

- `gjsify test` (maker) green on both gjs + node targets.
- `tsc` clean, Biome clean, spec-registration guard passes.