### PR TITLE
refactor(maker): extract MapPersistenceController

### DIFF
--- a/apps/maker-gjs/src/services/map-editor-data.spec.ts
+++ b/apps/maker-gjs/src/services/map-editor-data.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure `MapEditorData` patch helpers behind the map-persistence path.
+ *
+ * The contract under test is field preservation: `editorData` holds atlas
+ * position, preview viewport, grid + camera and custom properties side by
+ * side, so an atlas-position write must not clobber the preview (and vice
+ * versa), and a preview write must MERGE into any existing preview rather
+ * than replace it. These are the exact spots a naive `editorData = {...}`
+ * write would silently drop sibling state.
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+
+import { withAtlasPosition, withPreviewViewport } from './map-editor-data.ts'
+
+export default async () => {
+  await describe('withAtlasPosition', async () => {
+    await it('sets atlas coordinates on empty editor-data', async () => {
+      expect(withAtlasPosition(undefined, 12, 34)).toStrictEqual({ atlasX: 12, atlasY: 34 })
+    })
+
+    await it('preserves grid, camera, preview and properties', async () => {
+      const existing = {
+        grid: { visible: true, size: 16 },
+        camera: { x: 1, y: 2, zoom: 2 },
+        preview: { tileX: 5, tileY: 6 },
+        properties: { foo: 'bar' },
+      }
+      expect(withAtlasPosition(existing, 99, 100)).toStrictEqual({
+        grid: { visible: true, size: 16 },
+        camera: { x: 1, y: 2, zoom: 2 },
+        preview: { tileX: 5, tileY: 6 },
+        properties: { foo: 'bar' },
+        atlasX: 99,
+        atlasY: 100,
+      })
+    })
+
+    await it('overwrites prior atlas coordinates', async () => {
+      expect(withAtlasPosition({ atlasX: 1, atlasY: 1 }, 7, 8)).toStrictEqual({ atlasX: 7, atlasY: 8 })
+    })
+
+    await it('does not mutate the input record', async () => {
+      const input = { atlasX: 1, atlasY: 1 }
+      withAtlasPosition(input, 7, 8)
+      expect(input).toStrictEqual({ atlasX: 1, atlasY: 1 })
+    })
+  })
+
+  await describe('withPreviewViewport', async () => {
+    await it('sets the viewport on empty editor-data', async () => {
+      expect(withPreviewViewport(undefined, 3, 4)).toStrictEqual({ preview: { tileX: 3, tileY: 4 } })
+    })
+
+    await it('preserves atlas position and grid while setting the viewport', async () => {
+      const existing = { atlasX: 10, atlasY: 20, grid: { visible: false } }
+      expect(withPreviewViewport(existing, 3, 4)).toStrictEqual({
+        atlasX: 10,
+        atlasY: 20,
+        grid: { visible: false },
+        preview: { tileX: 3, tileY: 4 },
+      })
+    })
+
+    await it('merges into an existing preview record (does not replace it)', async () => {
+      // A future preview key must survive a tileX/tileY-only update.
+      const existing = { preview: { tileX: 1, tileY: 1, zoom: 3 } as Record<string, number> }
+      expect(withPreviewViewport(existing, 9, 9)).toStrictEqual({ preview: { tileX: 9, tileY: 9, zoom: 3 } })
+    })
+
+    await it('does not mutate the input record', async () => {
+      const input = { preview: { tileX: 1, tileY: 1 } }
+      withPreviewViewport(input, 9, 9)
+      expect(input).toStrictEqual({ preview: { tileX: 1, tileY: 1 } })
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/map-editor-data.ts
+++ b/apps/maker-gjs/src/services/map-editor-data.ts
@@ -1,0 +1,35 @@
+import type { MapEditorData } from '@pixelrpg/engine'
+
+/**
+ * Pure `MapEditorData` patch helpers used by the map-persistence path.
+ * Kept gi-free (type-only import) so they unit-test under the node target.
+ *
+ * The point of having these as named functions is the field-preservation
+ * contract: a `MapData.editorData` carries atlas position, preview
+ * viewport, grid + camera settings and custom properties side by side, so
+ * a careless `editorData = { atlasX, atlasY }` write would silently drop
+ * the others (the same "fold drops sibling fields" trap that bit the
+ * shadow-sync path). These spread the existing record first.
+ */
+
+/** Set the atlas-card coordinates, preserving every other editor-data field. */
+export function withAtlasPosition(
+  editorData: MapEditorData | undefined,
+  atlasX: number,
+  atlasY: number,
+): MapEditorData {
+  return { ...editorData, atlasX, atlasY }
+}
+
+/**
+ * Set the atlas-card preview-viewport centre, preserving every other
+ * editor-data field AND any existing `preview` keys (the viewport is a
+ * nested record, so it is merged, not replaced).
+ */
+export function withPreviewViewport(
+  editorData: MapEditorData | undefined,
+  tileX: number,
+  tileY: number,
+): MapEditorData {
+  return { ...editorData, preview: { ...editorData?.preview, tileX, tileY } }
+}

--- a/apps/maker-gjs/src/services/map-persistence-controller.ts
+++ b/apps/maker-gjs/src/services/map-persistence-controller.ts
@@ -1,0 +1,101 @@
+import { type MapEditorData, type MapResource, MapFormat } from '@pixelrpg/engine'
+import type { SampleScene } from '@pixelrpg/gjs'
+import { gettext as _ } from 'gettext'
+
+import { writeTextFile } from './file-io.ts'
+import { withAtlasPosition, withPreviewViewport } from './map-editor-data.ts'
+
+/**
+ * What the controller needs from its host (the {@link ApplicationWindow}),
+ * injected as accessors so it always reads the window's live state and
+ * stays unit-constructible without a real window.
+ */
+export interface MapPersistenceHost {
+  /** Resolve a loaded map's resource by id, or `null` when not loaded. */
+  getMapResource(mapId: string): MapResource | null
+  /** The in-memory atlas/preview scene mirror for a map, or `null`. */
+  getScene(mapId: string): SampleScene | null
+  /** Id of the map currently open in the scene editor, or `null`. */
+  getCurrentSceneId(): string | null
+  /** Surface a best-effort-failure message to the user (a toast). */
+  showError(message: string): void
+  /**
+   * Broadcast a map's editor-data change to peers in a live session — the
+   * `__project/map.editor-data` project-op. No-op when editing solo. The
+   * op plumbing stays with the host (collab is its concern); the
+   * controller only signals what changed.
+   */
+  sendMapEditorDataChange(mapId: string, editorData: MapEditorData): void
+}
+
+/**
+ * Owns the maker's map-file persistence — serialising a `MapData` back to
+ * its source JSON and the editor-data (atlas position / preview viewport)
+ * writes that ride alongside. Extracted out of the `ApplicationWindow`
+ * god-object so the window stays a thin coordinator (ApplicationWindow
+ * split, step 2). All writes are best-effort: a failure toasts but the
+ * in-memory mutation stays, so the user keeps seeing their change.
+ */
+export class MapPersistenceController {
+  constructor(private readonly host: MapPersistenceHost) {}
+
+  /**
+   * Persist the currently-open map. Called after an in-place mutation the
+   * scene editor made (layer visibility/lock, object removal, …) and
+   * before entering play. No-op when no scene is open.
+   */
+  persistCurrentMap(): void {
+    const mapId = this.host.getCurrentSceneId()
+    if (!mapId) return
+    this.persistMap(mapId, _('Could not save layer changes'))
+  }
+
+  /**
+   * Write the atlas-card coordinates the user just dragged back into the
+   * map's source JSON. In-memory state always updates so the card position
+   * survives the session even if the disk write fails; in a live session
+   * the move also rides a `__project/map.editor-data` op (atlas drags
+   * happen with no live scene, so the Command/op-log path isn't available
+   * — see AGENTS.md transport rule 2's project-op exception).
+   */
+  persistAtlasPosition(mapId: string, atlasX: number, atlasY: number): void {
+    const mapResource = this.host.getMapResource(mapId)
+    if (!mapResource?.mapData) return
+    mapResource.mapData.editorData = withAtlasPosition(mapResource.mapData.editorData, atlasX, atlasY)
+    this.persistMap(mapId, _('Could not save atlas position'))
+    this.host.sendMapEditorDataChange(mapId, { atlasX, atlasY })
+  }
+
+  /**
+   * Persist the preview-viewport centre the user just panned on an atlas
+   * card. Same flow as {@link persistAtlasPosition} plus an update to the
+   * in-memory `SampleScene` mirror so the viewport stays stable when the
+   * atlas re-renders (e.g. after a card move).
+   */
+  persistPreviewViewport(mapId: string, tileX: number, tileY: number): void {
+    const mapResource = this.host.getMapResource(mapId)
+    if (!mapResource?.mapData) return
+    const editorData = withPreviewViewport(mapResource.mapData.editorData, tileX, tileY)
+    mapResource.mapData.editorData = editorData
+    const scene = this.host.getScene(mapId)
+    if (scene) {
+      scene.previewTileX = tileX
+      scene.previewTileY = tileY
+    }
+    this.persistMap(mapId, _('Could not save preview section'))
+    this.host.sendMapEditorDataChange(mapId, { preview: editorData.preview })
+  }
+
+  /**
+   * Write a map's `MapData` back to its source JSON. Best-effort — a
+   * failure toasts `errorMessage` but the in-memory mutation stays so the
+   * user still sees their change in the editor. No-op for an unknown /
+   * unloaded map id.
+   */
+  persistMap(mapId: string, errorMessage: string): void {
+    const mapResource = this.host.getMapResource(mapId)
+    if (!mapResource?.mapData) return
+    const ok = writeTextFile(mapResource.sourcePath, MapFormat.serialize(mapResource.mapData))
+    if (!ok) this.host.showError(errorMessage)
+  }
+}

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -13,6 +13,7 @@ import lanDiscoveryParseSuite from './services/lan-discovery-parse.spec.js'
 import lanSignallingSuite from './services/lan-signalling.spec.js'
 import lanSignallingIntegrationSuite from './services/lan-signalling-integration.spec.js'
 import lanSignallingTimeoutSuite from './services/lan-signalling-timeout.spec.js'
+import mapEditorDataSuite from './services/map-editor-data.spec.js'
 import orphanPublisherCleanupSuite from './services/orphan-publisher-cleanup.spec.js'
 import pixelrpgUrlSuite from './services/pixelrpg-url.spec.js'
 import projectLoaderSuite from './services/project-loader.spec.js'
@@ -38,6 +39,7 @@ run({
   lanSignallingIntegrationSuite,
   lanSignallingSuite,
   lanSignallingTimeoutSuite,
+  mapEditorDataSuite,
   orphanPublisherCleanupSuite,
   pixelrpgUrlSuite,
   projectLoaderSuite,

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -11,7 +11,6 @@ import {
   createMapEditorDataOp,
   type EditorTool,
   formatError,
-  MapFormat,
   type SpriteSetData,
   type SpriteSetKind,
 } from '@pixelrpg/engine'
@@ -32,9 +31,9 @@ import { DataController } from '../services/data-controller.ts'
 import { EngineController } from '../services/engine-controller.ts'
 import { buildVariant } from '../services/gvariant.ts'
 import { syncEngineState } from '../services/engine-state-sync.ts'
-import { writeTextFile } from '../services/file-io.ts'
 import type { DiscoveredService } from '../services/lan-discovery-parse.ts'
 import { LanSessionBackend } from '../services/lan-session-backend.ts'
+import { MapPersistenceController } from '../services/map-persistence-controller.ts'
 import { ObjectsController } from '../services/objects-controller.ts'
 import { buildPixelrpgJoinUrl } from '../services/pixelrpg-url.ts'
 import { type LoadedProject, loadProjectAsAtlas } from '../services/project-loader.ts'
@@ -249,6 +248,20 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     if (engine) this._scene_editor_view.setEngineWidget(engine, engine)
     else this._scene_editor_view.setEngineWidget(null)
   })
+  // Map-file persistence (serialise MapData → source JSON, atlas/preview
+  // editor-data writes). Injected accessors read this window's live state;
+  // the op plumbing for editor-data changes stays here (collab is the
+  // window's concern). See ApplicationWindow split, step 2.
+  private _mapPersistCtl = new MapPersistenceController({
+    getMapResource: (mapId) => this._loadedProject?.resource.maps.get(mapId) ?? null,
+    getScene: (mapId) => this._scenesById.get(mapId) ?? null,
+    getCurrentSceneId: () => this._currentSceneId,
+    showError: (message) => this._showToast(message),
+    sendMapEditorDataChange: (mapId, editorData) =>
+      this._activeCollab()?.sendProjectOp(({ peerId, seq }) =>
+        createMapEditorDataOp({ peerId, seq, mapId, editorData }),
+      ),
+  })
   /**
    * Per-mode controllers — own their view's data + mutation +
    * persistence path so this window stays a thin coordinator. Both
@@ -354,7 +367,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     // applied it in memory) — persist that map file here (this window
     // owns map IO) and reposition its atlas card.
     this._projectStore.on('map-editor-data-changed', ({ mapId }) => {
-      this._persistMap(mapId, _('Could not save atlas position'))
+      this._mapPersistCtl.persistMap(mapId, _('Could not save atlas position'))
       this._refreshAtlasScenePosition(mapId)
     })
   }
@@ -383,13 +396,13 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this._lastAtlasSelection = id
     })
     this.signals.connect(this._atlas_view, 'scene-moved', (_v: AtlasView, id: string, x: number, y: number) => {
-      this._persistAtlasPosition(id, x, y)
+      this._mapPersistCtl.persistAtlasPosition(id, x, y)
     })
     this.signals.connect(
       this._atlas_view,
       'preview-moved',
       (_v: AtlasView, id: string, tileX: number, tileY: number) => {
-        this._persistPreviewViewport(id, tileX, tileY)
+        this._mapPersistCtl.persistPreviewViewport(id, tileX, tileY)
       },
     )
     // Every view's mode-rail forwards `mode-changed` at the view
@@ -409,7 +422,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     // `setLayerLocked`, then asks the host to persist. Mirrors the
     // existing `scene-moved` → `_persistAtlasPosition` flow.
     this.signals.connect(this._scene_editor_view, 'persist-requested', () => {
-      this._persistCurrentMap()
+      this._mapPersistCtl.persistCurrentMap()
     })
 
     // A placement was removed via the Props tab — refresh the
@@ -419,7 +432,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       if (this._loadedProject && this._currentSceneId) {
         void this._scene_editor_view.populateFromProject(this._loadedProject, this._currentSceneId)
       }
-      this._persistCurrentMap()
+      this._mapPersistCtl.persistCurrentMap()
     })
 
     // Per-mode controllers — thin lenses over the shared ProjectStore.
@@ -813,59 +826,6 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
   }
 
   /**
-   * Serialise the currently-edited map's `MapData` back to disk.
-   * Called by the scene editor's `persist-requested` signal after
-   * an in-place mutation (layer visibility, layer lock — and any
-   * future inspector-driven map mutation).
-   */
-  private _persistCurrentMap(): void {
-    if (!this._currentSceneId) return
-    this._persistMap(this._currentSceneId, _('Could not save layer changes'))
-  }
-
-  /**
-   * Write the atlas coordinates the user just dragged back into the
-   * map's source JSON. In-memory state always updates so the card
-   * position survives the session even if the disk write fails. In a
-   * live session the move also rides a `__project/map.editor-data`
-   * project-op — atlas drags happen with NO live scene, so the
-   * Command/op-log path isn't available (see AGENTS.md, transport
-   * rule 2's project-op exception).
-   */
-  private _persistAtlasPosition(mapId: string, x: number, y: number): void {
-    const mapResource = this._loadedProject?.resource.maps.get(mapId)
-    if (!mapResource?.mapData) return
-    mapResource.mapData.editorData = { ...mapResource.mapData.editorData, atlasX: x, atlasY: y }
-    this._persistMap(mapId, _('Could not save atlas position'))
-    this._activeCollab()?.sendProjectOp(({ peerId, seq }) =>
-      createMapEditorDataOp({ peerId, seq, mapId, editorData: { atlasX: x, atlasY: y } }),
-    )
-  }
-
-  /**
-   * Persist the preview-viewport centre the user just panned on an
-   * atlas card. Same flow as {@link _persistAtlasPosition}: in-memory
-   * update + disk write + `__project/map.editor-data` op for peers.
-   * The in-memory `SampleScene` mirror keeps the viewport stable when
-   * the atlas re-renders (e.g. after a card move).
-   */
-  private _persistPreviewViewport(mapId: string, tileX: number, tileY: number): void {
-    const mapResource = this._loadedProject?.resource.maps.get(mapId)
-    if (!mapResource?.mapData) return
-    const preview = { ...mapResource.mapData.editorData?.preview, tileX, tileY }
-    mapResource.mapData.editorData = { ...mapResource.mapData.editorData, preview }
-    const scene = this._scenesById.get(mapId)
-    if (scene) {
-      scene.previewTileX = tileX
-      scene.previewTileY = tileY
-    }
-    this._persistMap(mapId, _('Could not save preview section'))
-    this._activeCollab()?.sendProjectOp(({ peerId, seq }) =>
-      createMapEditorDataOp({ peerId, seq, mapId, editorData: { preview } }),
-    )
-  }
-
-  /**
    * Re-read a map's persisted `editorData.atlasX/atlasY` into its atlas
    * card and re-render the atlas. Called after an inbound peer
    * `__project/map.editor-data` lands so the card moves live — the
@@ -881,19 +841,6 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     if (typeof editorData.atlasX === 'number') scene.x = editorData.atlasX
     if (typeof editorData.atlasY === 'number') scene.y = editorData.atlasY
     this._atlas_view.setWorld(project.scenes, project.teleports, project.resource)
-  }
-
-  /**
-   * Write a map's `MapData` back to its source JSON. Best-effort —
-   * a failure toasts but the in-memory mutation stays so the user
-   * sees their change in the editor even when persistence fails.
-   * Shared between `_persistCurrentMap` and `_persistAtlasPosition`.
-   */
-  private _persistMap(mapId: string, errorMessage: string): void {
-    const mapResource = this._loadedProject?.resource.maps.get(mapId)
-    if (!mapResource?.mapData) return
-    const ok = writeTextFile(mapResource.sourcePath, MapFormat.serialize(mapResource.mapData))
-    if (!ok) this._showToast(errorMessage)
   }
 
   vfunc_unmap(): void {
@@ -1155,7 +1102,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       // Save unsaved tile edits before entering runtime so a crash
       // mid-playtest can't lose work. Best-effort — failures surface
       // as a toast but the playtest still proceeds.
-      if (isPlaying) this._persistCurrentMap()
+      if (isPlaying) this._mapPersistCtl.persistCurrentMap()
       this._engineCtl.engine?.setRuntimeMode(isPlaying)
       // Visual feedback on the FloatingPlay pill: icon + label swap
       // to "pause" while in playtest mode so it's clear what the


### PR DESCRIPTION
## What

**ApplicationWindow split, step 2** (after #233's `gvariant` extraction). Move the map-file persistence cluster out of the 2114-LOC `ApplicationWindow` god-object into a focused `services/map-persistence-controller.ts`, and extract its tricky pure kernel for unit coverage.

## Why

The window is a god-object; persistence (serialise `MapData` → source JSON, plus the atlas-position / preview-viewport editor-data writes) is a cohesive responsibility that can live on its own. This is the documented next increment of the audit's lowest-risk-first split plan (step 1 = `gvariant`, #233).

## Changes

- **`services/map-persistence-controller.ts`** — `MapPersistenceController` owns `persistCurrentMap` / `persistAtlasPosition` / `persistPreviewViewport` / `persistMap`. It takes injected host accessors (`getMapResource` / `getScene` / `getCurrentSceneId` / `showError` / `sendMapEditorDataChange`) so it reads the window's live state and stays construction-light (the #228 AssistantPresenceController pattern). The collab-op plumbing for editor-data changes stays in the window — collab is the window's concern (step 3 territory).
- **`services/map-editor-data.ts`** (gi-free) — `withAtlasPosition` / `withPreviewViewport`, the `editorData` patch kernel, with a node spec pinning the **field-preservation contract**: an atlas write must not clobber the preview viewport (and vice versa), and a preview update must *merge* into any existing preview rather than replace it (the "fold drops sibling fields" trap).
- **`application-window.ts`** — constructs `_mapPersistCtl`, delegates all 6 call sites, drops the 4 moved methods (keeps `_refreshAtlasScenePosition`, the inbound atlas refresh). Net **−53 lines**; `MapFormat` / `writeTextFile` imports removed (now in the controller).

## Verification

- `gjsify test` (maker) green on both gjs + node targets (new `map-editor-data` suite, 8 cases).
- `tsc` clean, Biome clean, spec-registration guard passes, `gjsify build` (maker app) produces the bundle.
- Behavior-neutral: every moved method is byte-equivalent to its original; the window keeps the same call sites + collab-op emission.