### PR TITLE
refactor(maker): extract CollabPresenceController

### DIFF
--- a/apps/maker-gjs/src/services/collab-presence-controller.ts
+++ b/apps/maker-gjs/src/services/collab-presence-controller.ts
@@ -1,0 +1,210 @@
+import { ASSISTANT_PEER_ID, type AwarenessPeerState } from '@pixelrpg/engine'
+import type { CollaboratorEntry } from '@pixelrpg/gjs'
+import { gettext as _ } from 'gettext'
+
+import type { AssistantStateService } from './assistant-state.service.ts'
+import type { CollabSession } from './collab-session.ts'
+import { buildParticipantRoster } from './participant-roster.ts'
+
+/** The slice of the live engine (`engine.excalibur`) the controller drives. */
+export interface CollabPresenceEngine {
+  setAssistantCursor(tileX: number, tileY: number): boolean
+  setAssistantInfo(displayName: string, color: string): void
+  hideAssistant(): void
+  setFollowAssistant(follow: boolean): void
+  panCameraTo(worldX: number, worldY: number): void
+  stopCameraFollow(): void
+}
+
+/** What the controller needs from its host (the {@link ApplicationWindow}). */
+export interface CollabPresenceHost {
+  /** The live engine assistant/camera surface, or `null` without a live scene. */
+  getEngine(): CollabPresenceEngine | null
+  /** The active `CollabSession` (host or joiner), or `null` when solo. */
+  getActiveCollab(): CollabSession | null
+  /** The shared single-source-of-truth assistant state (presence/identity/pause). */
+  readonly assistantState: AssistantStateService
+  /** Push the roster + followed peer into the collaborators bar (scene-editor view). */
+  setCollaboratorsOnView(participants: CollaboratorEntry[], followedPeerId: string | null): void
+  /** Surface a transient message to the user (a toast). */
+  showToast(message: string): void
+}
+
+/**
+ * Owns the maker's collaboration-presence surface — the AI-assistant
+ * cursor/identity, the collaborators-bar roster, camera-follow, and the
+ * live-session awareness subscriptions. Extracted out of the
+ * `ApplicationWindow` god-object so the window stays a thin coordinator
+ * (ApplicationWindow split, step 3).
+ *
+ * Injected host accessors keep it reading the window's live state. The
+ * window's public `setAssistant*` / `followParticipant` / `getParticipants`
+ * API (driven by the Control/MCP plane) delegates here unchanged; session
+ * wiring calls {@link attachSession} when a session opens/closes.
+ */
+export class CollabPresenceController {
+  private _announced = false
+  private _followedPeerId: string | null = null
+  /** Subscriptions to the live session awareness — torn down on session change. */
+  private _awarenessUnsubs: Array<() => void> = []
+  /** peerIds currently shown in the collaborators bar — to skip rebuilds on cursor-only ticks. */
+  private _renderedPeerIds = new Set<string>()
+
+  constructor(private readonly host: CollabPresenceHost) {}
+
+  // ── AI-assistant presence surface (driven by the Control/MCP plane) ──
+
+  /** Whether the user has paused the assistant (read by the Control plane's pause guard). */
+  isAssistantPaused(): boolean {
+    return this.host.assistantState.paused
+  }
+
+  /** Show/move the AI-assistant collaborator cursor at tile (x, y). Returns false without an engine. */
+  setAssistantCursor(tileX: number, tileY: number): boolean {
+    const applied = this.host.getEngine()?.setAssistantCursor(tileX, tileY) ?? false
+    if (applied && this.host.assistantState.setPresent(true)) {
+      this._announceOnce()
+      this.refreshCollaborators()
+    }
+    return applied
+  }
+
+  /**
+   * Mark the AI assistant present without moving its cursor. The Control
+   * D-Bus surface calls this on every mutating method, so ANY external
+   * driver (MCP bridge, scripts) shows up in the participants bar the
+   * moment it starts acting — visibility must not depend on the driver
+   * announcing itself via `SetAssistantInfo` / `SetAssistantCursor` first.
+   */
+  ensureAssistantPresence(): void {
+    if (!this.host.assistantState.setPresent(true)) return
+    // Mirror into the engine (when one is live) so `isAssistantActive`
+    // and the participants bar agree about the assistant being around.
+    // A later engine recreation re-mirrors via `_syncEngineUiState`.
+    this.host.getEngine()?.setAssistantInfo(this.host.assistantState.name, this.host.assistantState.color)
+    this._announceOnce()
+    this.refreshCollaborators()
+  }
+
+  /** Set the AI-assistant cursor's display name + colour. */
+  setAssistantInfo(displayName: string, color: string): void {
+    this.host.getEngine()?.setAssistantInfo(displayName, color)
+    this.host.assistantState.setInfo(displayName, color)
+    if (this.host.assistantState.setPresent(true)) this._announceOnce()
+    this.refreshCollaborators()
+  }
+
+  /** Remove the AI-assistant cursor/presence. */
+  hideAssistant(): void {
+    this.host.getEngine()?.hideAssistant()
+    this.host.assistantState.setPresent(false)
+    this._announced = false
+    if (this._followedPeerId === ASSISTANT_PEER_ID) this._setFollowedPeer(null)
+    this.refreshCollaborators()
+  }
+
+  /**
+   * Announce the FIRST assistant activation with a toast — a clear,
+   * consent-style "an AI is now acting here" cue (not a silent takeover).
+   * Re-armed on {@link hideAssistant}.
+   */
+  private _announceOnce(): void {
+    if (this._announced) return
+    this._announced = true
+    this.host.showToast(_('AI assistant is now editing with you'))
+  }
+
+  // ── Collaborators-bar roster + camera-follow ──
+
+  /**
+   * The live participant roster: the local AI assistant (if present) +
+   * every networked peer from the session awareness. A relayed AI on a
+   * joiner arrives as a session peer with `ASSISTANT_PEER_ID` — flagged
+   * `isAI`. Shared by the collaborators bar + `getDebugStatus`.
+   */
+  getParticipants(): CollaboratorEntry[] {
+    const assistant = this.host.assistantState
+    return buildParticipantRoster(
+      assistant.present ? { name: assistant.name, color: assistant.color } : null,
+      this.host.getActiveCollab()?.awareness.getPeers() ?? [],
+      ASSISTANT_PEER_ID,
+    )
+  }
+
+  /** Rebuild the collaborators bar from the live roster. */
+  refreshCollaborators(): void {
+    const participants = this.getParticipants()
+    this._renderedPeerIds = new Set(participants.map((p) => p.peerId))
+    this.host.setCollaboratorsOnView(participants, this._followedPeerId)
+  }
+
+  /** Toggle camera-follow for the clicked participant (clicking the followed one stops following). */
+  onParticipantActivated(peerId: string): void {
+    this.followParticipant(this._followedPeerId === peerId ? null : peerId)
+  }
+
+  /**
+   * Follow `peerId` with the camera (pass `null` to stop). Public so the
+   * Control interface can drive it too; chip clicks route through here via
+   * {@link onParticipantActivated}.
+   */
+  followParticipant(peerId: string | null): void {
+    this._setFollowedPeer(peerId)
+    // Jump straight to a followed human peer's current cursor (the engine
+    // self-pans for the AI).
+    if (peerId && peerId !== ASSISTANT_PEER_ID) {
+      const peer = this.host.getActiveCollab()?.awareness.getPeer(peerId)
+      if (peer?.cursor) this.host.getEngine()?.panCameraTo(peer.cursor.x, peer.cursor.y)
+    }
+    this.refreshCollaborators()
+  }
+
+  /** The currently-followed participant peerId, or null. */
+  get followedPeerId(): string | null {
+    return this._followedPeerId
+  }
+
+  private _setFollowedPeer(peerId: string | null): void {
+    this._followedPeerId = peerId
+    const engine = this.host.getEngine()
+    // The engine pans itself for the AI (it owns the AI cursor); human
+    // peers are panned from `onPeerChanged` as their cursors arrive.
+    engine?.setFollowAssistant(peerId === ASSISTANT_PEER_ID)
+    // Stop the smooth glide when following no one.
+    if (!peerId) engine?.stopCameraFollow()
+  }
+
+  /** A session peer's awareness changed — pan if it's the followed one; rebuild only on roster changes. */
+  private _onPeerChanged(peer: AwarenessPeerState): void {
+    if (peer.peerId === this._followedPeerId && peer.peerId !== ASSISTANT_PEER_ID && peer.cursor) {
+      this.host.getEngine()?.panCameraTo(peer.cursor.x, peer.cursor.y)
+    }
+    if (!this._renderedPeerIds.has(peer.peerId)) this.refreshCollaborators()
+  }
+
+  /** A session peer left — drop follow if it was followed, rebuild the bar. */
+  private _onPeerLeft(peerId: string): void {
+    if (this._followedPeerId === peerId) this._setFollowedPeer(null)
+    this.refreshCollaborators()
+  }
+
+  /**
+   * (Re)bind to a session's awareness roster — called by the window's
+   * session-wiring when a session opens (`collab`) or closes (`null`).
+   * Tears down the previous subscriptions first, then either subscribes to
+   * the new session's peer-changed/peer-left or, on close, stops following
+   * a now-gone human peer. Ends by refreshing the bar.
+   */
+  attachSession(collab: CollabSession | null): void {
+    for (const unsub of this._awarenessUnsubs) unsub()
+    this._awarenessUnsubs = []
+    if (collab) {
+      this._awarenessUnsubs.push(collab.awareness.on('peer-changed', (peer) => this._onPeerChanged(peer)))
+      this._awarenessUnsubs.push(collab.awareness.on('peer-left', ({ peerId }) => this._onPeerLeft(peerId)))
+    } else if (this._followedPeerId && this._followedPeerId !== ASSISTANT_PEER_ID) {
+      // Session ended — stop following a (now-gone) human peer.
+      this._setFollowedPeer(null)
+    }
+    this.refreshCollaborators()
+  }
+}

--- a/apps/maker-gjs/src/services/participant-roster.spec.ts
+++ b/apps/maker-gjs/src/services/participant-roster.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure collaborators-bar roster builder behind `ApplicationWindow`'s
+ * participant list. Pins the two correctness properties that are easy to
+ * drift when this logic is moved off the window:
+ *  - the local-AI dedup (a relayed peer carrying the assistant's peerId is
+ *    skipped while the local assistant is already listed), and
+ *  - the `isAI` flag, which keys on the peerId alone (so a relayed AI on a
+ *    joiner, with no local assistant, is still flagged AI).
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+
+import type { AwarenessPeerState } from '@pixelrpg/engine'
+
+import { buildParticipantRoster } from './participant-roster.ts'
+
+const AI = 'ai-assistant'
+
+/** Minimal valid `AwarenessPeerState` for a roster input. */
+function peer(peerId: string, displayName: string, color: string): AwarenessPeerState {
+  return { peerId, info: { displayName, color }, cursor: null, selection: null, lastUpdate: 0 }
+}
+
+export default async () => {
+  await describe('buildParticipantRoster', async () => {
+    await it('returns an empty roster with no assistant and no peers', async () => {
+      expect(buildParticipantRoster(null, [], AI)).toStrictEqual([])
+    })
+
+    await it('lists the local assistant alone, flagged isAI', async () => {
+      expect(buildParticipantRoster({ name: 'AI Assistant', color: '#9141ac' }, [], AI)).toStrictEqual([
+        { peerId: AI, name: 'AI Assistant', color: '#9141ac', isAI: true },
+      ])
+    })
+
+    await it('lists human peers in order, none flagged isAI', async () => {
+      expect(buildParticipantRoster(null, [peer('p1', 'Ada', '#fff'), peer('p2', 'Bo', '#000')], AI)).toStrictEqual([
+        { peerId: 'p1', name: 'Ada', color: '#fff', isAI: false },
+        { peerId: 'p2', name: 'Bo', color: '#000', isAI: false },
+      ])
+    })
+
+    await it('dedups a relayed-AI peer when the local assistant is present', async () => {
+      const roster = buildParticipantRoster(
+        { name: 'AI Assistant', color: '#9141ac' },
+        [peer(AI, 'AI Assistant', '#9141ac'), peer('p1', 'Ada', '#fff')],
+        AI,
+      )
+      expect(roster).toStrictEqual([
+        { peerId: AI, name: 'AI Assistant', color: '#9141ac', isAI: true },
+        { peerId: 'p1', name: 'Ada', color: '#fff', isAI: false },
+      ])
+    })
+
+    await it('flags a relayed-AI peer isAI on a joiner with no local assistant', async () => {
+      expect(
+        buildParticipantRoster(null, [peer('p1', 'Ada', '#fff'), peer(AI, 'AI Assistant', '#9141ac')], AI),
+      ).toStrictEqual([
+        { peerId: 'p1', name: 'Ada', color: '#fff', isAI: false },
+        { peerId: AI, name: 'AI Assistant', color: '#9141ac', isAI: true },
+      ])
+    })
+
+    await it('lists the assistant first when both are present', async () => {
+      const roster = buildParticipantRoster({ name: 'AI', color: '#000' }, [peer('p1', 'Ada', '#fff')], AI)
+      expect(roster[0]?.peerId).toBe(AI)
+      expect(roster[1]?.peerId).toBe('p1')
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/participant-roster.ts
+++ b/apps/maker-gjs/src/services/participant-roster.ts
@@ -1,0 +1,45 @@
+import type { AwarenessPeerState } from '@pixelrpg/engine'
+import type { CollaboratorEntry } from '@pixelrpg/gjs'
+
+/** The local AI assistant's roster entry inputs, or `null` when not present. */
+export interface AssistantRosterEntry {
+  readonly name: string
+  readonly color: string
+}
+
+/**
+ * Build the collaborators-bar roster from the local AI-assistant presence
+ * plus the live session awareness peers. Pure (gi-free, node-testable):
+ * the controller resolves the live sources (`AssistantStateService` +
+ * `CollabSession.awareness`) into these plain inputs.
+ *
+ * Rules (behaviour-equivalent to the former `ApplicationWindow.getParticipants`):
+ *  - The local assistant, if present, is listed FIRST with `isAI: true`.
+ *  - Every awareness peer follows, EXCEPT a peer carrying the assistant's
+ *    own peerId while the local assistant is already listed (dedup).
+ *  - A relayed AI peer (the assistant peerId) on a joiner — i.e. when the
+ *    local assistant is NOT present — is listed and flagged `isAI`.
+ *
+ * `assistant != null` is exactly the window's old `_assistantState.present`
+ * condition: the controller passes `present ? {name,color} : null`.
+ */
+export function buildParticipantRoster(
+  assistant: AssistantRosterEntry | null,
+  peers: readonly AwarenessPeerState[],
+  assistantPeerId: string,
+): CollaboratorEntry[] {
+  const participants: CollaboratorEntry[] = []
+  if (assistant) {
+    participants.push({ peerId: assistantPeerId, name: assistant.name, color: assistant.color, isAI: true })
+  }
+  for (const peer of peers) {
+    if (peer.peerId === assistantPeerId && assistant) continue // already listed locally
+    participants.push({
+      peerId: peer.peerId,
+      name: peer.info.displayName,
+      color: peer.info.color,
+      isAI: peer.peerId === assistantPeerId,
+    })
+  }
+  return participants
+}

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -15,6 +15,7 @@ import lanSignallingIntegrationSuite from './services/lan-signalling-integration
 import lanSignallingTimeoutSuite from './services/lan-signalling-timeout.spec.js'
 import mapEditorDataSuite from './services/map-editor-data.spec.js'
 import orphanPublisherCleanupSuite from './services/orphan-publisher-cleanup.spec.js'
+import participantRosterSuite from './services/participant-roster.spec.js'
 import pixelrpgUrlSuite from './services/pixelrpg-url.spec.js'
 import projectLoaderSuite from './services/project-loader.spec.js'
 import projectStoreSuite from './services/project-store.spec.js'
@@ -41,6 +42,7 @@ run({
   lanSignallingTimeoutSuite,
   mapEditorDataSuite,
   orphanPublisherCleanupSuite,
+  participantRosterSuite,
   pixelrpgUrlSuite,
   projectLoaderSuite,
   projectStoreSuite,

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -6,7 +6,6 @@ import Gtk from '@girs/gtk-4.0'
 import {
   type AgentMapData,
   ASSISTANT_PEER_ID,
-  type AwarenessPeerState,
   buildAgentMapData,
   createMapEditorDataOp,
   type EditorTool,
@@ -32,6 +31,7 @@ import { EngineController } from '../services/engine-controller.ts'
 import { buildVariant } from '../services/gvariant.ts'
 import { syncEngineState } from '../services/engine-state-sync.ts'
 import type { DiscoveredService } from '../services/lan-discovery-parse.ts'
+import { CollabPresenceController } from '../services/collab-presence-controller.ts'
 import { LanSessionBackend } from '../services/lan-session-backend.ts'
 import { MapPersistenceController } from '../services/map-persistence-controller.ts'
 import { ObjectsController } from '../services/objects-controller.ts'
@@ -215,8 +215,6 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
   private _objectsAction: Gio.SimpleAction | null = null
   private _gridAction: Gio.SimpleAction | null = null
   private _transparencyAction: Gio.SimpleAction | null = null
-  /** Guards the one-shot "AI assistant joined" toast; re-armed on HideAssistant. */
-  private _assistantAnnounced = false
   /**
    * Single source of truth for the local AI assistant's presence,
    * identity and the user's pause switch. The engine only carries
@@ -225,12 +223,6 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
    * the live CollabSession awareness.
    */
   private readonly _assistantState = new AssistantStateService()
-  /** The participant the camera is following (peerId), or null. */
-  private _followedPeerId: string | null = null
-  /** Subscriptions to the live session awareness — torn down on state change. */
-  private _collabAwarenessUnsubs: Array<() => void> = []
-  /** peerIds currently shown in the collaborators bar — to skip rebuilds on cursor-only ticks. */
-  private _renderedPeerIds = new Set<string>()
   /**
    * The `win.mode` GAction. Stateful string — `'world'` / `'cast'` /
    * `'tiles'` / `'audio'` / `'data'`. The change-state handler routes
@@ -261,6 +253,18 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this._activeCollab()?.sendProjectOp(({ peerId, seq }) =>
         createMapEditorDataOp({ peerId, seq, mapId, editorData }),
       ),
+  })
+  // AI-assistant presence + collaborators-bar roster + camera-follow +
+  // the live-session awareness subscriptions. Injected accessors read this
+  // window's live state; the window keeps thin delegations for the Control
+  // plane's public API. See ApplicationWindow split, step 3.
+  private _collabPresenceCtl = new CollabPresenceController({
+    getEngine: () => this._engineCtl.engine?.excalibur ?? null,
+    getActiveCollab: () => this._activeCollab(),
+    assistantState: this._assistantState,
+    setCollaboratorsOnView: (participants, followedPeerId) =>
+      this._scene_editor_view.setCollaborators(participants, followedPeerId),
+    showToast: (message) => this._showToast(message),
   })
   /**
    * Per-mode controllers — own their view's data + mutation +
@@ -473,7 +477,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       // Collaborators bar: clicking a participant chip follows it. Wired
       // once — the signal lives on the scene-editor view for the window's
       // lifetime.
-      this._scene_editor_view.onParticipantActivated((peerId) => this._onParticipantActivated(peerId))
+      this._scene_editor_view.onParticipantActivated((peerId) => this._collabPresenceCtl.onParticipantActivated(peerId))
     }
 
     // Welcome view ↔ SessionService bridge. The window owns the
@@ -654,16 +658,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     this._projectStore.setCollabSession(collab)
 
     // Track the live session roster for the collaborators bar + follow.
-    for (const unsub of this._collabAwarenessUnsubs) unsub()
-    this._collabAwarenessUnsubs = []
-    if (collab) {
-      this._collabAwarenessUnsubs.push(collab.awareness.on('peer-changed', (peer) => this._onPeerChanged(peer)))
-      this._collabAwarenessUnsubs.push(collab.awareness.on('peer-left', ({ peerId }) => this._onPeerLeft(peerId)))
-    } else if (this._followedPeerId && this._followedPeerId !== ASSISTANT_PEER_ID) {
-      // Session ended — stop following a (now-gone) human peer.
-      this._setFollowedPeer(null)
-    }
-    this._refreshCollaborators()
+    this._collabPresenceCtl.attachSession(collab)
   }
 
   /**
@@ -1139,8 +1134,9 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     winActions.add_action(assistantPausedAction)
 
     // Camera-follow is now per-participant: clicking a chip in the
-    // collaborators bar follows that participant (see
-    // _onParticipantActivated), so there's no standalone follow action.
+    // collaborators bar follows that participant (the scene-editor view's
+    // onParticipantActivated routes to the collab-presence controller), so
+    // there's no standalone follow action.
 
     // Keyboard accelerators: Ctrl+Z = undo, Ctrl+Shift+Z = redo,
     // Ctrl+G = toggle grid, Ctrl+T = toggle non-active-layer
@@ -1519,7 +1515,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       showGrid: boolState(this._gridAction, false),
       dimInactiveLayers: boolState(this._transparencyAction, false),
       assistant: this._assistantState.snapshot(),
-      followAssistant: this._followedPeerId === ASSISTANT_PEER_ID,
+      followAssistant: this.followedPeerId === ASSISTANT_PEER_ID,
     })
     // Re-point the Phase-5 relay (and the collab-roster wiring) at the
     // live session — idempotent, a no-op chain when the session is idle.
@@ -1681,7 +1677,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       // copy is a push-down cache that resets on recreation.
       assistantPaused: this._assistantState.paused,
       participants: this.getParticipants(),
-      followedPeerId: this._followedPeerId,
+      followedPeerId: this.followedPeerId,
     }
   }
 
@@ -1749,63 +1745,32 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
 
   /** Whether the user has paused the assistant (read by the Control plane's pause guard). */
   isAssistantPaused(): boolean {
-    return this._assistantState.paused
+    return this._collabPresenceCtl.isAssistantPaused()
   }
 
   /** Show/move the AI-assistant collaborator cursor at tile (x, y). Returns false without an engine. */
   setAssistantCursor(tileX: number, tileY: number): boolean {
-    const applied = this._engineCtl.engine?.excalibur?.setAssistantCursor(tileX, tileY) ?? false
-    if (applied && this._assistantState.setPresent(true)) {
-      this._announceAssistantOnce()
-      this._refreshCollaborators()
-    }
-    return applied
+    return this._collabPresenceCtl.setAssistantCursor(tileX, tileY)
   }
 
   /**
    * Mark the AI assistant present without moving its cursor. The Control
    * D-Bus surface calls this on every mutating method, so ANY external
    * driver (MCP bridge, scripts) shows up in the participants bar the
-   * moment it starts acting — visibility must not depend on the driver
-   * remembering to announce itself via `SetAssistantInfo` /
-   * `SetAssistantCursor` first.
+   * moment it starts acting.
    */
   ensureAssistantPresence(): void {
-    if (!this._assistantState.setPresent(true)) return
-    // Mirror into the engine (when one is live) so `isAssistantActive`
-    // and the participants bar agree about the assistant being around.
-    // A later engine recreation re-mirrors via `_syncEngineUiState`.
-    this._engineCtl.engine?.excalibur?.setAssistantInfo(this._assistantState.name, this._assistantState.color)
-    this._announceAssistantOnce()
-    this._refreshCollaborators()
+    this._collabPresenceCtl.ensureAssistantPresence()
   }
 
   /** Set the AI-assistant cursor's display name + colour. */
   setAssistantInfo(displayName: string, color: string): void {
-    this._engineCtl.engine?.excalibur?.setAssistantInfo(displayName, color)
-    this._assistantState.setInfo(displayName, color)
-    if (this._assistantState.setPresent(true)) this._announceAssistantOnce()
-    this._refreshCollaborators()
+    this._collabPresenceCtl.setAssistantInfo(displayName, color)
   }
 
   /** Remove the AI-assistant cursor/presence. */
   hideAssistant(): void {
-    this._engineCtl.engine?.excalibur?.hideAssistant()
-    this._assistantState.setPresent(false)
-    this._assistantAnnounced = false
-    if (this._followedPeerId === ASSISTANT_PEER_ID) this._setFollowedPeer(null)
-    this._refreshCollaborators()
-  }
-
-  /**
-   * Announce the FIRST assistant activation with a toast — a clear,
-   * consent-style "an AI is now acting here" cue (not a silent takeover).
-   * Re-armed on `HideAssistant`.
-   */
-  private _announceAssistantOnce(): void {
-    if (this._assistantAnnounced) return
-    this._assistantAnnounced = true
-    this._showToast(_('AI assistant is now editing with you'))
+    this._collabPresenceCtl.hideAssistant()
   }
 
   /** The live `CollabSession` (host or joiner) if a session is active, else null. */
@@ -1814,97 +1779,22 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     return state && 'collab' in state ? state.collab : null
   }
 
-  /**
-   * Rebuild the collaborators bar from the live roster: the local AI
-   * assistant (if present) + every networked peer from the session
-   * awareness. A relayed AI on a joiner arrives as a session peer with
-   * `ASSISTANT_PEER_ID` — flagged `isAI` so it gets the assistant styling.
-   */
-  private _refreshCollaborators(): void {
-    const participants = this.getParticipants()
-    this._renderedPeerIds = new Set(participants.map((p) => p.peerId))
-    this._scene_editor_view.setCollaborators(participants, this._followedPeerId)
-  }
-
-  /**
-   * The live participant roster: the local AI assistant (if present) +
-   * every networked peer from the session awareness. A relayed AI on a
-   * joiner arrives as a session peer with `ASSISTANT_PEER_ID` — flagged
-   * `isAI`. Shared by the collaborators bar + `getDebugStatus`.
-   */
+  /** The live participant roster (collaborators bar + `getDebugStatus`). */
   getParticipants(): CollaboratorEntry[] {
-    const participants: CollaboratorEntry[] = []
-    if (this._assistantState.present) {
-      participants.push({
-        peerId: ASSISTANT_PEER_ID,
-        name: this._assistantState.name,
-        color: this._assistantState.color,
-        isAI: true,
-      })
-    }
-    const collab = this._activeCollab()
-    if (collab) {
-      for (const peer of collab.awareness.getPeers()) {
-        if (peer.peerId === ASSISTANT_PEER_ID && this._assistantState.present) continue // already listed locally
-        participants.push({
-          peerId: peer.peerId,
-          name: peer.info.displayName,
-          color: peer.info.color,
-          isAI: peer.peerId === ASSISTANT_PEER_ID,
-        })
-      }
-    }
-    return participants
-  }
-
-  /** Toggle camera-follow for the clicked participant (clicking the followed one stops following). */
-  private _onParticipantActivated(peerId: string): void {
-    this.followParticipant(this._followedPeerId === peerId ? null : peerId)
+    return this._collabPresenceCtl.getParticipants()
   }
 
   /**
    * Follow `peerId` with the camera (pass `null` to stop). Public so the
-   * Control interface can drive it too; chip clicks route through here via
-   * {@link _onParticipantActivated}.
+   * Control interface can drive it too.
    */
   followParticipant(peerId: string | null): void {
-    this._setFollowedPeer(peerId)
-    // Jump straight to a followed human peer's current cursor (the engine
-    // self-pans for the AI).
-    if (peerId && peerId !== ASSISTANT_PEER_ID) {
-      const peer = this._activeCollab()?.awareness.getPeer(peerId)
-      if (peer?.cursor) this._engineCtl.engine?.excalibur?.panCameraTo(peer.cursor.x, peer.cursor.y)
-    }
-    this._refreshCollaborators()
+    this._collabPresenceCtl.followParticipant(peerId)
   }
 
   /** The currently-followed participant peerId, or null. */
   get followedPeerId(): string | null {
-    return this._followedPeerId
-  }
-
-  private _setFollowedPeer(peerId: string | null): void {
-    this._followedPeerId = peerId
-    const engine = this._engineCtl.engine?.excalibur
-    // The engine pans itself for the AI (it owns the AI cursor); human
-    // peers are panned from `_onPeerChanged` as their cursors arrive.
-    engine?.setFollowAssistant(peerId === ASSISTANT_PEER_ID)
-    // Stop the smooth glide when following no one.
-    if (!peerId) engine?.stopCameraFollow()
-  }
-
-  /** A session peer's awareness changed — pan if it's the followed one; rebuild only on roster changes. */
-  private _onPeerChanged(peer: AwarenessPeerState): void {
-    if (peer.peerId === this._followedPeerId && peer.peerId !== ASSISTANT_PEER_ID && peer.cursor) {
-      this._engineCtl.engine?.excalibur?.panCameraTo(peer.cursor.x, peer.cursor.y)
-    }
-    if (!this._renderedPeerIds.has(peer.peerId)) this._refreshCollaborators()
-  }
-
-  /** A session peer left — drop follow if it was followed, rebuild the bar. */
-  private _onPeerLeft(peerId: string): void {
-    if (this._followedPeerId === peerId) this._setFollowedPeer(null)
-    this._refreshCollaborators()
+    return this._collabPresenceCtl.followedPeerId
   }
 
   /**


### PR DESCRIPTION
## What

**ApplicationWindow split, step 3** (after #243's `MapPersistenceController`) — the densest, collab-correctness-sensitive cut. Move the collaboration-presence subsystem out of the ~2000-LOC window god-object into a focused controller, and extract its tricky pure kernel for unit coverage.

## Why

Presence — the AI-assistant cursor/identity surface, the collaborators-bar roster, camera-follow, and the live-session awareness subscriptions — is a cohesive subsystem entangled across the window. Pulling it out continues the audit's lowest-risk-first split plan (step 1 = `gvariant` #233, step 2 = `MapPersistenceController` #243).

## Changes

- **`services/collab-presence-controller.ts`** (210 LOC) — `CollabPresenceController` owns `setAssistantCursor` / `ensureAssistantPresence` / `setAssistantInfo` / `hideAssistant` / `isAssistantPaused`, the roster (`getParticipants` / `refreshCollaborators`), follow (`followParticipant` / `onParticipantActivated` / `followedPeerId`), the awareness handlers, and `attachSession(collab | null)`. Injected host accessors (`getEngine` / `getActiveCollab` / `assistantState` / `setCollaboratorsOnView` / `showToast`) — the #243 pattern. It owns the awareness subscriptions; the window's `_wireAssistantRelay` keeps only the frame-relay + project-store wiring (step-4 territory) and calls `attachSession`.
- **`services/participant-roster.ts`** (gi-free) — `buildParticipantRoster(assistant, peers, assistantPeerId)`, the local-AI **dedup** + **isAI** flagging kernel, with a node spec (6 cases incl. the relayed-AI-dedup-when-local-present and relayed-AI-flagged-isAI-on-joiner edges).
- **`application-window.ts`** — constructs `_collabPresenceCtl`, keeps the **8 public members as thin delegations** (Control/MCP plane unchanged), drops the moved fields + methods, rewires `_wireAssistantRelay` / chip-click / `getDebugStatus` / `_syncEngineUiState`'s `followAssistant`. Net **−110 lines**; removed the now-unused `AwarenessPeerState` import.

## Behavior preservation

Every moved method is byte-equivalent in effect. Specifically preserved: the announce-once latch + its re-arm on `hideAssistant`; the three distinct `setPresent(true)` guard-shapes; the follow-pan **AI-vs-human asymmetry** (engine self-pans the AI, the host pans human peers; `stopCameraFollow` only when following nobody); the `_renderedPeerIds` cursor-only-tick skip; and the `attachSession` teardown→(subscribe | follow-drop)→refresh **ordering**.

## Verification

- `gjsify test` (maker) green on both gjs + node targets (new `participant-roster` suite, 6 cases).
- `tsc` clean, Biome clean, spec-registration guard passes, `gjsify build` (maker app) produces the bundle.
- Controller is gi-coupled (engine/view) → build-verified, like the sibling Cast/Objects/Data/MapPersistence controllers.

> Design produced via a Plan agent with an explicit behavior-preservation risk list; the public API + all call sites verified against `control-dbus.service.ts`.