### PR TITLE
refactor(maker): extract ShareSessionController + snapshot

### DIFF
--- a/apps/maker-gjs/src/services/session-snapshot.spec.ts
+++ b/apps/maker-gjs/src/services/session-snapshot.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure `SessionState` → `SessionSnapshot` projection behind the Control
+ * plane's `GetSessionState`. The load-bearing property: the snapshot is a
+ * scalar whitelist, so the live `CollabSession` carried on the
+ * `awaiting-engine` / `connected` arms (`state.collab`) can NEVER reach the
+ * JSON wire — a future SessionState field can't silently serialise a live
+ * object over D-Bus.
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+
+import type { SessionState } from './session-service.ts'
+import { toSessionSnapshot } from './session-snapshot.ts'
+
+export default async () => {
+  await describe('toSessionSnapshot', async () => {
+    await it('maps null (no service yet) to idle', async () => {
+      expect(toSessionSnapshot(null)).toStrictEqual({ kind: 'idle' })
+    })
+
+    await it('maps idle with no stray keys', async () => {
+      expect(toSessionSnapshot({ kind: 'idle' })).toStrictEqual({ kind: 'idle' })
+    })
+
+    await it('maps browsing', async () => {
+      expect(toSessionSnapshot({ kind: 'browsing' })).toStrictEqual({ kind: 'browsing' })
+    })
+
+    await it('maps connecting', async () => {
+      expect(toSessionSnapshot({ kind: 'connecting' })).toStrictEqual({ kind: 'connecting' })
+    })
+
+    await it('maps hosting with roomId + port only', async () => {
+      expect(toSessionSnapshot({ kind: 'hosting', roomId: 'r1', port: 5555 })).toStrictEqual({
+        kind: 'hosting',
+        roomId: 'r1',
+        port: 5555,
+      })
+    })
+
+    await it('maps awaiting-engine without leaking the live collab', async () => {
+      const state = {
+        kind: 'awaiting-engine',
+        role: 'joiner',
+        roomId: 'r2',
+        sandboxProjectPath: '/tmp/sandbox/game-project.json',
+        collab: { __live: 'collab-session' },
+      } as unknown as SessionState
+      const snap = toSessionSnapshot(state)
+      expect(snap).toStrictEqual({
+        kind: 'awaiting-engine',
+        role: 'joiner',
+        roomId: 'r2',
+        sandboxProjectPath: '/tmp/sandbox/game-project.json',
+      })
+      expect('collab' in snap).toBe(false)
+    })
+
+    await it('maps connected with role + roomId only, no port, no collab leak', async () => {
+      const state = { kind: 'connected', role: 'host', roomId: 'r3', collab: {} } as unknown as SessionState
+      const snap = toSessionSnapshot(state)
+      expect(snap).toStrictEqual({ kind: 'connected', role: 'host', roomId: 'r3' })
+      expect('collab' in snap).toBe(false)
+      expect('port' in snap).toBe(false)
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/session-snapshot.ts
+++ b/apps/maker-gjs/src/services/session-snapshot.ts
@@ -1,0 +1,33 @@
+import type { SessionState } from './session-service.ts'
+
+/**
+ * JSON-safe view of the collaboration session state for external tooling
+ * (the Control D-Bus plane `JSON.stringify`s it).
+ */
+export interface SessionSnapshot {
+  kind: string
+  roomId?: string
+  port?: number
+  role?: string
+  sandboxProjectPath?: string
+}
+
+/**
+ * Project a `SessionService` state into the flat JSON snapshot the Control
+ * plane returns. Pure (type-only import) so it unit-tests under node;
+ * `null` (no service yet) maps to `{ kind: 'idle' }`.
+ *
+ * The key whitelist is deliberate: the `awaiting-engine` / `connected`
+ * arms carry a live `CollabSession` on `state.collab`, which must NEVER
+ * reach the JSON wire — only the scalar `roomId`/`port`/`role`/
+ * `sandboxProjectPath` are copied across.
+ */
+export function toSessionSnapshot(state: SessionState | null): SessionSnapshot {
+  const s = state ?? { kind: 'idle' as const }
+  const snap: SessionSnapshot = { kind: s.kind }
+  if ('roomId' in s) snap.roomId = s.roomId
+  if ('port' in s) snap.port = s.port
+  if ('role' in s) snap.role = s.role
+  if ('sandboxProjectPath' in s) snap.sandboxProjectPath = s.sandboxProjectPath
+  return snap
+}

--- a/apps/maker-gjs/src/services/share-session-controller.ts
+++ b/apps/maker-gjs/src/services/share-session-controller.ts
@@ -1,0 +1,116 @@
+import type Gdk from '@girs/gdk-4.0'
+import type Gtk from '@girs/gtk-4.0'
+import { gettext as _ } from 'gettext'
+
+import { ShareDialog } from '../widgets/share-dialog.ts'
+import { buildPixelrpgJoinUrl } from './pixelrpg-url.ts'
+import type { SessionService } from './session-service.ts'
+
+/** What the {@link ShareSessionController} needs from its host (the `ApplicationWindow`). */
+export interface ShareSessionHost {
+  /** The session orchestrator, or `null` until the window is mapped. */
+  getSessionService(): SessionService | null
+  /** The loaded project's display name, or `null` when no project is open. */
+  getProjectName(): string | null
+  /** Surface a transient message to the user (a toast). */
+  showToast(message: string): void
+  /** The widget the modal dialog is parented to (the window). */
+  getParentWindow(): Gtk.Widget
+  /** The `Gdk.Display` for clipboard access, or `null` if unrealised. */
+  getDisplay(): Gdk.Display | null
+  /** Static host display name for the mDNS TXT record. */
+  getHostDisplayName(): string
+  /**
+   * Hand a session-event unsubscribe back to the host so the window's
+   * single teardown list drains it on unmap. The share dialog's
+   * `state-changed` subscription lives for the window's lifetime exactly
+   * like the other SessionService subscriptions, so it belongs in the same
+   * (atomic) drain — not a separate controller lifecycle.
+   */
+  registerSessionUnsub(unsub: () => void): void
+}
+
+/**
+ * Owns the Share dialog lifecycle — the self-contained UI surface the
+ * window used to host inline. Extracted out of the `ApplicationWindow`
+ * god-object (split, step 4). Build-verify only (GTK-coupled), like the
+ * sibling controllers; the session lifecycle itself (the desync-critical
+ * `_sessionSvc` / awareness-relay seam) deliberately stays in the window.
+ */
+export class ShareSessionController {
+  private _dialog: ShareDialog | null = null
+
+  constructor(private readonly host: ShareSessionHost) {}
+
+  /**
+   * Open the Share dialog (built lazily on first call). The dialog stays
+   * alive for the window's lifetime — re-presenting after a `closed` is a
+   * no-op since `present(parent)` only takes effect when unmapped.
+   */
+  present(): void {
+    if (!this.host.getProjectName()) {
+      this.host.showToast(_('Open a project before sharing it.'))
+      return
+    }
+    const svc = this.host.getSessionService()
+    if (!svc) return
+    this._ensureDialog(svc)
+    this._dialog?.syncWithSession(svc.getState(), buildPixelrpgJoinUrl)
+    this._dialog?.present(this.host.getParentWindow())
+  }
+
+  private _ensureDialog(svc: SessionService): void {
+    if (this._dialog) return
+
+    const dialog = new ShareDialog()
+
+    dialog.connect('share-requested', () => {
+      void this._startShare()
+    })
+    dialog.connect('stop-requested', () => {
+      void this._stopShare()
+    })
+    dialog.connect('copy-link-requested', () => {
+      const display = this.host.getDisplay()
+      if (!display) return
+      if (dialog.copyShareUrlToClipboard(display)) {
+        this.host.showToast(_('Share link copied to clipboard.'))
+      }
+    })
+
+    // Mirror SessionService state into the dialog so the user sees hosting
+    // transitions live (URL appears the moment startHosting resolves;
+    // status row swaps to "Editing with peer" on connect). Registered into
+    // the host's teardown list so it drains with the other session subs.
+    this.host.registerSessionUnsub(
+      svc.on('state-changed', (state) => dialog.syncWithSession(state, buildPixelrpgJoinUrl)),
+    )
+
+    this._dialog = dialog
+  }
+
+  private async _startShare(): Promise<void> {
+    const svc = this.host.getSessionService()
+    const projectName = this.host.getProjectName()
+    if (!svc || projectName == null) return
+    try {
+      const roomId = await svc.startHosting({
+        sessionName: projectName,
+        projectName,
+        hostDisplayName: this.host.getHostDisplayName(),
+      })
+      this.host.showToast(_(`Sharing as room ${roomId}.`))
+    } catch (err) {
+      this.host.showToast(_(`Could not start sharing: ${(err as Error).message}`))
+    }
+  }
+
+  private async _stopShare(): Promise<void> {
+    const svc = this.host.getSessionService()
+    if (!svc) return
+    await svc.stopHosting()
+    // syncWithSession flips the dialog back to its idle page via the
+    // state-changed subscription wired in _ensureDialog.
+    this.host.showToast(_('Stopped sharing.'))
+  }
+}

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -22,6 +22,7 @@ import projectStoreSuite from './services/project-store.spec.js'
 import relaySignallingSuite from './services/relay-signalling.spec.js'
 import sandboxPathSuite from './services/sandbox-path.spec.js'
 import sessionServiceSuite from './services/session-service.spec.js'
+import sessionSnapshotSuite from './services/session-snapshot.spec.js'
 import sessionServiceE2eSuite from './services/session-service-e2e.spec.js'
 import zoomMathSuite from './services/zoom-math.spec.js'
 
@@ -50,5 +51,6 @@ run({
   sandboxPathSuite,
   sessionServiceSuite,
   sessionServiceE2eSuite,
+  sessionSnapshotSuite,
   zoomMathSuite,
 })

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -35,12 +35,13 @@ import { CollabPresenceController } from '../services/collab-presence-controller
 import { LanSessionBackend } from '../services/lan-session-backend.ts'
 import { MapPersistenceController } from '../services/map-persistence-controller.ts'
 import { ObjectsController } from '../services/objects-controller.ts'
-import { buildPixelrpgJoinUrl } from '../services/pixelrpg-url.ts'
 import { type LoadedProject, loadProjectAsAtlas } from '../services/project-loader.ts'
 import { ProjectStore, type ProjectStoreNotice } from '../services/project-store.ts'
 import { loadRecentProjects, recordRecentProject } from '../services/recent-projects.ts'
 import { captureWidgetPng } from '../services/screenshot.ts'
 import { generatePeerId, SessionService, type SessionState } from '../services/session-service.ts'
+import { type SessionSnapshot, toSessionSnapshot } from '../services/session-snapshot.ts'
+import { ShareSessionController } from '../services/share-session-controller.ts'
 import { findBlankTemplate, findTemplateById } from '../services/templates.ts'
 import { TilesController } from '../services/tiles-controller.ts'
 import Template from './application-window.blp'
@@ -50,7 +51,6 @@ import { CastView } from './cast-view.ts'
 import { DataView } from './data-view.ts'
 import { ObjectsView } from './objects-view.ts'
 import type { SceneEditorView } from './scene-editor-view.ts'
-import { ShareDialog } from './share-dialog.ts'
 import { TilesView } from './tiles-view.ts'
 import type { WelcomeView } from './welcome-view.ts'
 
@@ -124,14 +124,9 @@ export interface ActionList {
 
 type ActionScope = 'app' | 'win'
 
-/** JSON-safe view of the collaboration session state for external tooling. */
-export interface SessionSnapshot {
-  kind: string
-  roomId?: string
-  port?: number
-  role?: string
-  sandboxProjectPath?: string
-}
+// The session-state JSON projection lives in `services/session-snapshot.ts`
+// (pure + unit-tested); re-exported so existing import sites keep working.
+export type { SessionSnapshot }
 
 /**
  * Top-level window.
@@ -266,6 +261,19 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this._scene_editor_view.setCollaborators(participants, followedPeerId),
     showToast: (message) => this._showToast(message),
   })
+  // Share-dialog lifecycle (the self-contained UI surface). The
+  // session-event subscription it opens is funnelled back into this
+  // window's `_sessionUnsubscribes` so teardown stays atomic. The session
+  // lifecycle itself stays in the window. See ApplicationWindow split, step 4.
+  private _shareSessionCtl = new ShareSessionController({
+    getSessionService: () => this._sessionSvc,
+    getProjectName: () => this._loadedProject?.projectName ?? null,
+    showToast: (message) => this._showToast(message),
+    getParentWindow: () => this,
+    getDisplay: () => this.get_display(),
+    getHostDisplayName: () => GLib.get_user_name() ?? 'host',
+    registerSessionUnsub: (unsub) => this._sessionUnsubscribes.push(unsub),
+  })
   /**
    * Per-mode controllers — own their view's data + mutation +
    * persistence path so this window stays a thin coordinator. Both
@@ -283,12 +291,6 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
    * until an engine is available.
    */
   private _sessionSvc: SessionService | null = null
-  /**
-   * Modal Share dialog. One instance reused across opens — the
-   * `closed` signal lets us re-present it without leaking widgets.
-   * Wired to the SessionService on first build.
-   */
-  private _shareDialog: ShareDialog | null = null
   /**
    * Stateful `win.share-session` action. Disabled when no project is
    * loaded so the mode-rail share button greys out.
@@ -661,75 +663,9 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
     this._collabPresenceCtl.attachSession(collab)
   }
 
-  /**
-   * Open the Share dialog, building it lazily on first call. The
-   * dialog stays alive for the window's lifetime — re-presenting it
-   * after a `closed` is a no-op, since `present(parent)` only takes
-   * effect when the dialog isn't currently mapped.
-   */
+  /** `win.share-session` — open the Share dialog (delegated to the controller). */
   private _onShareSession(): void {
-    if (!this._loadedProject) {
-      this._showToast(_('Open a project before sharing it.'))
-      return
-    }
-    if (!this._sessionSvc) return
-    this._setupShareDialog()
-    this._shareDialog?.syncWithSession(this._sessionSvc.getState(), buildPixelrpgJoinUrl)
-    this._shareDialog?.present(this)
-  }
-
-  private _setupShareDialog(): void {
-    if (this._shareDialog || !this._sessionSvc) return
-
-    const dialog = new ShareDialog()
-    const svc = this._sessionSvc
-
-    dialog.connect('share-requested', () => {
-      void this._startShare()
-    })
-    dialog.connect('stop-requested', () => {
-      void this._stopShare()
-    })
-    dialog.connect('copy-link-requested', () => {
-      const display = this.get_display()
-      if (!display) return
-      if (dialog.copyShareUrlToClipboard(display)) {
-        this._showToast(_('Share link copied to clipboard.'))
-      }
-    })
-
-    // Mirror SessionService state into the dialog so the user sees
-    // hosting transitions live (URL appears the moment startHosting
-    // resolves; status row swaps to "Editing with peer" on connect).
-    this._sessionUnsubscribes.push(
-      svc.on('state-changed', (state) => dialog.syncWithSession(state, buildPixelrpgJoinUrl)),
-    )
-
-    this._shareDialog = dialog
-  }
-
-  private async _startShare(): Promise<void> {
-    if (!this._sessionSvc || !this._loadedProject) return
-    try {
-      const roomId = await this._sessionSvc.startHosting({
-        sessionName: this._loadedProject.projectName,
-        projectName: this._loadedProject.projectName,
-        // Static display name — replaced by a GSettings-backed
-        // value once the user can pick one in preferences.
-        hostDisplayName: GLib.get_user_name() ?? 'host',
-      })
-      this._showToast(_(`Sharing as room ${roomId}.`))
-    } catch (err) {
-      this._showToast(_(`Could not start sharing: ${(err as Error).message}`))
-    }
-  }
-
-  private async _stopShare(): Promise<void> {
-    if (!this._sessionSvc) return
-    await this._sessionSvc.stopHosting()
-    // syncWithSession will flip the dialog back to its idle page via
-    // the state-changed subscription wired in _setupShareDialog.
-    this._showToast(_('Stopped sharing.'))
+    this._shareSessionCtl.present()
   }
 
   /**
@@ -1882,13 +1818,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
 
   /** JSON-safe snapshot of the current collaboration session state. */
   getSessionState(): SessionSnapshot {
-    const state = this._sessionSvc?.getState() ?? { kind: 'idle' as const }
-    const snap: SessionSnapshot = { kind: state.kind }
-    if ('roomId' in state) snap.roomId = state.roomId
-    if ('port' in state) snap.port = state.port
-    if ('role' in state) snap.role = state.role
-    if ('sandboxProjectPath' in state) snap.sandboxProjectPath = state.sandboxProjectPath
-    return snap
+    return toSessionSnapshot(this._sessionSvc?.getState() ?? null)
   }
 
   /**


### PR DESCRIPTION
## What

**ApplicationWindow split, step 4 (final).** Scoped cut of the session cluster — a `ShareSessionController` (the share-dialog lifecycle) + a pure `session-snapshot.ts` kernel (the `GetSessionState` projection).

## Why scoped, not a full SessionCoordinator

A Plan-agent design pass concluded a full `SessionCoordinator` owning `_sessionSvc` would be **net-negative and unsafe**: unlike persistence (#243) / presence (#244), the session cluster sits on the *integration seam* between the engine-recreation lifecycle, the project-load path, the welcome view, and the two prior controllers. `_wireAssistantRelay` orchestrates `_projectStore.setCollabSession` + `_collabPresenceCtl.attachSession` + the engine relay in a fixed order on **every** engine recreation — the audit's desync class. Moving that across a boundary is pure regression risk for no reduction.

So this moves only the two genuinely self-contained pieces and leaves `_sessionSvc`, the subscription array, `_wireAssistantRelay`, the engine-attach race handling, and leave-on-close **byte-for-byte in the window**.

## Changes

- **`services/share-session-controller.ts`** — `ShareSessionController` owns the Share dialog (build/present, the `share`/`stop`/`copy-link` signals, host start/stop) behind an injected host. Its `state-changed` subscription is funnelled back into the window's single `_sessionUnsubscribes` via `registerSessionUnsub` — so the share sub drains atomically with the other five session subs (no split awareness-relay teardown). Build-verify only, like the sibling controllers.
- **`services/session-snapshot.ts`** (gi-free) — `toSessionSnapshot(state)`, the `SessionState` → `SessionSnapshot` projection, with a node spec (7 cases, one per union arm). The **load-bearing** case: the `awaiting-engine` / `connected` arms carry a live `CollabSession` on `state.collab`, and the scalar-whitelist projection must never serialise it onto the D-Bus JSON wire.
- **`application-window.ts`** — constructs `_shareSessionCtl`, collapses `_onShareSession` to a delegation, drops the moved methods + `_shareDialog` field + the `ShareDialog`/`buildPixelrpgJoinUrl` imports, delegates `getSessionState`. Net **−70 lines** (−233 across steps 2–4). `SessionSnapshot` re-exported so consumers are unaffected.

## Verification

- `gjsify test` (maker) green on both gjs + node targets (new `session-snapshot` suite, 7 cases incl. the no-collab-leak guards).
- `tsc` clean, Biome clean, spec-registration guard passes, `gjsify build` (maker app) produces the bundle.
- Public API (`win.startSession` / `joinSession` / `getSessionState` / `openProject`) unchanged — verified against `control-dbus.service.ts`.

> This completes the ApplicationWindow split (steps 1–4: #233, #243, #244, this). Remaining session lifecycle stays in the window deliberately, as the thin coordinator that wires the controllers.