### PR TITLE
refactor(gjs): extract MapPreview bake cache

### DIFF
--- a/packages/gjs/src/test.mts
+++ b/packages/gjs/src/test.mts
@@ -7,6 +7,7 @@
 // test that.
 import { run } from '@gjsify/unit'
 
+import bakeCacheSuite from './widgets/editor/bake-cache.spec.js'
 import mapPreviewGeometrySuite from './widgets/editor/map-preview.geometry.spec.js'
 
-run({ mapPreviewGeometrySuite })
+run({ bakeCacheSuite, mapPreviewGeometrySuite })

--- a/packages/gjs/src/widgets/editor/bake-cache.spec.ts
+++ b/packages/gjs/src/widgets/editor/bake-cache.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * The MapPreview bake cache + cache-key builder.
+ *
+ * Two correctness contracts are pinned here:
+ *  - the cache is least-recently-STORED (not -read): `set` refreshes order,
+ *    `get` does not — so a read can't save an entry from eviction; and
+ *  - the cache key rounds the viewport centre to the nearest pixel, so a
+ *    tiny pan re-uses the cached bake instead of forcing a redundant
+ *    re-render.
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+
+import { BakeCache, buildCacheKey } from './bake-cache.ts'
+
+export default async () => {
+  await describe('BakeCache', async () => {
+    await it('misses on an unknown key', async () => {
+      const cache = new BakeCache<number>(2)
+      expect(cache.get('x')).toBe(undefined)
+    })
+
+    await it('stores and retrieves a value', async () => {
+      const cache = new BakeCache<number>(2)
+      cache.set('a', 1)
+      expect(cache.get('a')).toBe(1)
+      expect(cache.size).toBe(1)
+    })
+
+    await it('updates the value when an existing key is re-set', async () => {
+      const cache = new BakeCache<number>(2)
+      cache.set('a', 1)
+      cache.set('a', 2)
+      expect(cache.get('a')).toBe(2)
+      expect(cache.size).toBe(1)
+    })
+
+    await it('keeps exactly maxSize entries without evicting', async () => {
+      const cache = new BakeCache<number>(2)
+      cache.set('a', 1)
+      cache.set('b', 2)
+      expect(cache.size).toBe(2)
+      expect(cache.get('a')).toBe(1)
+      expect(cache.get('b')).toBe(2)
+    })
+
+    await it('evicts the oldest-stored entry when exceeding maxSize', async () => {
+      const cache = new BakeCache<number>(2)
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('c', 3) // size 3 > 2 → evict 'a'
+      expect(cache.size).toBe(2)
+      expect(cache.get('a')).toBe(undefined)
+      expect(cache.get('b')).toBe(2)
+      expect(cache.get('c')).toBe(3)
+    })
+
+    await it('does NOT refresh order on read (least-recently-stored, not -read)', async () => {
+      const cache = new BakeCache<number>(2)
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.get('a') // a read must not save 'a' from eviction
+      cache.set('c', 3) // evicts the oldest STORED → 'a'
+      expect(cache.get('a')).toBe(undefined)
+      expect(cache.get('b')).toBe(2)
+      expect(cache.get('c')).toBe(3)
+    })
+
+    await it('refreshes order when re-storing a key, so it survives the next eviction', async () => {
+      const cache = new BakeCache<number>(2)
+      cache.set('a', 1)
+      cache.set('b', 2)
+      cache.set('a', 11) // re-store 'a' → now newest; 'b' is oldest
+      cache.set('c', 3) // evicts the oldest STORED → 'b'
+      expect(cache.get('b')).toBe(undefined)
+      expect(cache.get('a')).toBe(11)
+      expect(cache.get('c')).toBe(3)
+    })
+  })
+
+  await describe('buildCacheKey', async () => {
+    await it('returns null for a null base (not cacheable)', async () => {
+      expect(buildCacheKey(null, null)).toBe(null)
+      expect(buildCacheKey(null, { centerX: 1, centerY: 2, zoom: 3 })).toBe(null)
+    })
+
+    await it('keys on the base alone when there is no viewport', async () => {
+      expect(buildCacheKey('path:/p', null)).toBe('path:/p')
+    })
+
+    await it('appends a rounded viewport suffix', async () => {
+      expect(buildCacheKey('map:/p:m1:fp', { centerX: 100, centerY: 200, zoom: 3 })).toBe('map:/p:m1:fp:vp:3:100:200')
+    })
+
+    await it('rounds the centre so nearby pans collapse to the same key', async () => {
+      expect(buildCacheKey('b', { centerX: 12.4, centerY: 0, zoom: 2 })).toBe('b:vp:2:12:0')
+      expect(buildCacheKey('b', { centerX: 12.6, centerY: 0, zoom: 2 })).toBe('b:vp:2:13:0')
+    })
+
+    await it('rounds negative centres', async () => {
+      expect(buildCacheKey('b', { centerX: -8.5, centerY: -0.4, zoom: 1 })).toBe('b:vp:1:-8:0')
+    })
+  })
+}

--- a/packages/gjs/src/widgets/editor/bake-cache.ts
+++ b/packages/gjs/src/widgets/editor/bake-cache.ts
@@ -1,0 +1,62 @@
+/**
+ * The MapPreview bake cache + cache-key logic. Kept GTK-free (no `gi://`
+ * import) so it unit-tests under the node target — the `MapPreview` widget
+ * itself subclasses `Gtk.Widget` and can't run headlessly.
+ */
+
+/**
+ * A bounded, insertion-order cache: eviction is least-recently-STORED, not
+ * least-recently-READ. `set` refreshes a key's position (so re-storing the
+ * same key moves it to newest); `get` does NOT — reads never affect
+ * eviction order. The oldest entry is dropped once the cache exceeds
+ * `maxSize`. Generic over the value `V`, which the cache treats opaquely
+ * (MapPreview stores baked `Gdk.Texture`s, but none of that leaks here).
+ */
+export class BakeCache<V> {
+  private readonly map = new Map<string, V>()
+
+  constructor(private readonly maxSize: number) {}
+
+  get(key: string): V | undefined {
+    return this.map.get(key)
+  }
+
+  set(key: string, value: V): void {
+    // delete-then-set refreshes insertion order so eviction is
+    // least-recently-stored.
+    this.map.delete(key)
+    this.map.set(key, value)
+    if (this.map.size > this.maxSize) {
+      const oldest = this.map.keys().next().value
+      if (oldest !== undefined) this.map.delete(oldest)
+    }
+  }
+
+  get size(): number {
+    return this.map.size
+  }
+}
+
+/** A bake's cache-key viewport component (map-pixel centre + native-pixel zoom). */
+export interface CacheKeyViewport {
+  centerX: number
+  centerY: number
+  zoom: number
+}
+
+/**
+ * Build a bake's cache key from its stable base (`path:<project>` or
+ * `map:<project>:<id>:<fingerprint>`) and the optional viewport. A `null`
+ * base means "not cacheable" → `null`; no viewport (fit-whole-map mode)
+ * keys on the base alone.
+ *
+ * The centre is rounded to the nearest pixel so two nearby pan centres
+ * collapse to the SAME key (a cache hit instead of a redundant re-bake);
+ * `zoom` rides verbatim.
+ */
+export function buildCacheKey(base: string | null, viewport: CacheKeyViewport | null): string | null {
+  if (!base) return null
+  if (!viewport) return base
+  const { zoom, centerX, centerY } = viewport
+  return `${base}:vp:${zoom}:${Math.round(centerX)}:${Math.round(centerY)}`
+}

--- a/packages/gjs/src/widgets/editor/index.ts
+++ b/packages/gjs/src/widgets/editor/index.ts
@@ -2,6 +2,7 @@
 
 export * from './atlas-canvas.story'
 export * from './atlas-canvas'
+export * from './bake-cache'
 export * from './component-inspector'
 export * from './entity-components-editor.story'
 export * from './entity-components-editor'

--- a/packages/gjs/src/widgets/editor/map-preview.ts
+++ b/packages/gjs/src/widgets/editor/map-preview.ts
@@ -7,6 +7,7 @@ import Gtk from '@girs/gtk-4.0'
 import { GameProjectResource, type MapData } from '@pixelrpg/engine'
 import type { GdkSpriteSheet } from '../../sprite/objects/GdkSpriteSheet'
 import { GdkSpriteSetResource } from '../../sprite/resource/GdkSpriteSetResource'
+import { BakeCache, buildCacheKey } from './bake-cache.ts'
 import { clampViewportCenter, fingerprintMapData } from './map-preview.geometry.ts'
 
 interface DrawOp {
@@ -122,7 +123,9 @@ export class MapPreview extends Gtk.Widget {
   private _cacheKeyBase: string | null = null
 
   // ── module-wide bake machinery ────────────────────────────────────
-  private static _cache = new Map<string, BakedPreview>()
+  // LRU (least-recently-STORED) bake cache — the bounded-cache + cache-key
+  // logic lives in the GTK-free `bake-cache.ts` so it is unit-tested.
+  private static _cache = new BakeCache<BakedPreview>(BAKE_CACHE_MAX)
   private static _queue: MapPreview[] = []
   private static _pumpScheduled = false
 
@@ -141,16 +144,6 @@ export class MapPreview extends Gtk.Widget {
       MapPreview._pump()
       return GLib.SOURCE_REMOVE
     })
-  }
-
-  private static _cacheStore(key: string, baked: BakedPreview): void {
-    // Refresh insertion order so eviction is least-recently-stored.
-    MapPreview._cache.delete(key)
-    MapPreview._cache.set(key, baked)
-    if (MapPreview._cache.size > BAKE_CACHE_MAX) {
-      const oldest = MapPreview._cache.keys().next().value
-      if (oldest !== undefined) MapPreview._cache.delete(oldest)
-    }
   }
 
   static {
@@ -330,10 +323,7 @@ export class MapPreview extends Gtk.Widget {
 
   /** Full LRU key for the current content + viewport. */
   private _cacheKey(): string | null {
-    if (!this._cacheKeyBase) return null
-    if (!this._viewport) return this._cacheKeyBase
-    const { zoom, centerX, centerY } = this._viewport
-    return `${this._cacheKeyBase}:vp:${zoom}:${Math.round(centerX)}:${Math.round(centerY)}`
+    return buildCacheKey(this._cacheKeyBase, this._viewport)
   }
 
   /** Paint a cached bake without rebuilding anything. */
@@ -455,7 +445,7 @@ export class MapPreview extends Gtk.Widget {
     }
     const cacheKey = this._cacheKey()
     if (cacheKey && this._cacheWrite) {
-      MapPreview._cacheStore(cacheKey, {
+      MapPreview._cache.set(cacheKey, {
         texture,
         mapWidth: this._mapWidth,
         mapHeight: this._mapHeight,


### PR DESCRIPTION
## What

Continue the `MapPreview` decomposition (#229 extracted its geometry helpers) — lift the module-wide LRU bake cache + the cache-key builder out of the GTK-bound widget into a GTK-free `bake-cache.ts` with a node spec.

## Why

`MapPreview` rasterises map thumbnails once into a texture (a "bake") and keeps finished bakes in a small module-wide LRU cache keyed by a content fingerprint + viewport. That cache + key logic was inline static state on the `Gtk.Widget` subclass, so it could only be exercised by running the widget. As pure modules it's node-testable — and the bits with real correctness properties get pinned.

## Changes

- **`widgets/editor/bake-cache.ts`** (GTK-free):
  - `BakeCache<V>` — the bounded **least-recently-STORED** cache (`delete`-then-`set` refresh + evict-oldest when `size > maxSize`). Generic, so the baked `Gdk.Texture` values stay opaque and the eviction logic tests under node.
  - `buildCacheKey(base, viewport)` — the cache-key projection. The `Math.round` on the viewport centre is **load-bearing**: nearby pan centres must collapse to the same key for a cache hit instead of a redundant re-bake.
- **`bake-cache.spec.ts`** — 12 cases: eviction edges (a read does **not** refresh order; a re-store does; the exact `> maxSize` boundary) + key rounding (incl. negative centres).
- **`map-preview.ts`** — holds `new BakeCache<BakedPreview>(BAKE_CACHE_MAX)`, drops `_cacheStore`, delegates `_cacheKey`. Behavior-neutral (−10 net lines).

The GLib-idle bake **queue** stays in the widget — its pump is tightly coupled to `GLib.idle_add` + the `_runBake` instance method, so a node-testable cut isn't worth it (noted, not done).

## Verification

- `gjsify test` (@pixelrpg/gjs) green on both gjs + node targets (new `bake-cache` suite, 12 cases).
- `tsc` clean, Biome clean, barrels regenerated, spec-registration guard passes.