### PR TITLE
test(mcp-bridge): add harness + routing spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,3 +150,12 @@ jobs:
         # built in the build step above (via the pinned global `gjsify`
         # on PATH) and drives it with real `ws` clients from Node.
         run: gjsify foreach test -v -p --include @pixelrpg/signalling-server
+
+      - name: Run mcp-bridge tests (instance → D-Bus address routing)
+        # The @pixelrpg/mcp-bridge suite. The bridge proper opens a live
+        # session bus at module load (GJS-only), so this covers its
+        # dependency-free helpers — the instance-label → bus-name/path
+        # routing whose `sanitizeLabel` must stay byte-identical to the
+        # maker's `sanitizeInstanceId` (else the bridge dials a name nobody
+        # owns). Runs under both gjs + node.
+        run: gjsify foreach test -v -p --include @pixelrpg/mcp-bridge

--- a/apps/mcp-bridge/package.json
+++ b/apps/mcp-bridge/package.json
@@ -10,6 +10,7 @@
     "build:app": "gjsify build src/index.ts --app gjs --globals auto --shebang --outfile dist/mcp-bridge.gjs.mjs",
     "build": "gjsify run build:app",
     "check": "tsc --noEmit",
+    "test": "gjsify test",
     "start": "gjsify run dist/mcp-bridge.gjs.mjs"
   },
   "keywords": [

--- a/apps/mcp-bridge/src/index.ts
+++ b/apps/mcp-bridge/src/index.ts
@@ -21,36 +21,13 @@ import Gio from '@girs/gio-2.0'
 import GLib from '@girs/glib-2.0'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
+import { BASE_NAME, resolve, sanitizeLabel } from './instance-routing.ts'
 import { GjsStdioTransport } from './stdio-transport.ts'
 
-const BASE_NAME = 'org.pixelrpg.maker'
-const BASE_PATH = '/org/pixelrpg/maker'
 const CONTROL_IFACE = 'org.pixelrpg.maker.Control'
 const DBUS_IFACE = 'org.freedesktop.DBus'
 
 const bus = Gio.bus_get_sync(Gio.BusType.SESSION, null)
-
-// --- instance addressing ---
-
-/**
- * Coerce a label into the same app-id segment the app derives from
- * PIXELRPG_INSTANCE. CONTRACT: byte-identical copy of
- * `apps/maker-gjs/src/application.ts` `sanitizeInstanceId` (this app
- * is deliberately dependency-free, so it cannot import it). The
- * maker-side `instance-id.spec.ts` pins the mapping; change BOTH
- * copies + the spec together.
- */
-function sanitizeLabel(label: string): string {
-  const cleaned = label.toLowerCase().replace(/[^a-z0-9]/g, '')
-  return /^[a-z]/.test(cleaned) ? cleaned : `i${cleaned || '0'}`
-}
-
-/** Resolve an instance label to its D-Bus name + Control object path. */
-function resolve(label?: string): { busName: string; controlPath: string; label: string } {
-  const l = label && label !== 'default' ? sanitizeLabel(label) : 'default'
-  if (l === 'default') return { busName: BASE_NAME, controlPath: `${BASE_PATH}/control`, label: 'default' }
-  return { busName: `${BASE_NAME}.${l}`, controlPath: `${BASE_PATH}/${l}/control`, label: l }
-}
 
 // --- process management ---
 

--- a/apps/mcp-bridge/src/instance-routing.spec.ts
+++ b/apps/mcp-bridge/src/instance-routing.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Instance-label → D-Bus address routing for the MCP bridge.
+ *
+ * `sanitizeLabel` is a byte-identical copy of the maker's
+ * `sanitizeInstanceId` (the bridge is dependency-free and can't import it);
+ * the maker side is pinned by `apps/maker-gjs/src/instance-id.spec.ts`.
+ * These cases MIRROR it so the two copies can't drift — if the bridge
+ * sanitises a label differently from how the app derived its bus name, the
+ * bridge dials a name nobody owns.
+ *
+ * `resolve` is the multi-instance addressing: the default instance keeps
+ * the bare base name/path, a named one gets a suffixed bus name + path.
+ */
+
+import { describe, expect, it } from '@gjsify/unit'
+
+import { BASE_NAME, BASE_PATH, resolve, sanitizeLabel } from './instance-routing.ts'
+
+export default async () => {
+  await describe('sanitizeLabel — bridge↔app contract', async () => {
+    await it('lowercases and strips non-alphanumerics', async () => {
+      expect(sanitizeLabel('My Test-Editor_2')).toBe('mytesteditor2')
+    })
+
+    await it('prefixes digit-led labels so the segment stays letter-led', async () => {
+      expect(sanitizeLabel('2nd')).toBe('i2nd')
+    })
+
+    await it("maps an empty/cleaned-away label to 'i0'", async () => {
+      expect(sanitizeLabel('')).toBe('i0')
+      expect(sanitizeLabel('---')).toBe('i0')
+    })
+
+    await it('passes a plain lowercase label through unchanged', async () => {
+      expect(sanitizeLabel('alpha')).toBe('alpha')
+    })
+  })
+
+  await describe('resolve', async () => {
+    await it('routes the default instance to the bare base name + path', async () => {
+      expect(resolve()).toStrictEqual({
+        busName: BASE_NAME,
+        controlPath: `${BASE_PATH}/control`,
+        label: 'default',
+      })
+    })
+
+    await it("treats an explicit 'default' label the same as none", async () => {
+      expect(resolve('default')).toStrictEqual(resolve())
+    })
+
+    await it('suffixes a named instance on both the bus name and the path', async () => {
+      expect(resolve('Alpha')).toStrictEqual({
+        busName: 'org.pixelrpg.maker.alpha',
+        controlPath: '/org/pixelrpg/maker/alpha/control',
+        label: 'alpha',
+      })
+    })
+
+    await it('sanitises the label before routing (digit-led → i-prefixed)', async () => {
+      expect(resolve('2nd')).toStrictEqual({
+        busName: 'org.pixelrpg.maker.i2nd',
+        controlPath: '/org/pixelrpg/maker/i2nd/control',
+        label: 'i2nd',
+      })
+    })
+  })
+}

--- a/apps/mcp-bridge/src/instance-routing.ts
+++ b/apps/mcp-bridge/src/instance-routing.ts
@@ -1,0 +1,36 @@
+/**
+ * Instance-label → D-Bus address routing for the MCP↔D-Bus bridge. Kept
+ * dependency-free (no `gi://` import) so it unit-tests under the node
+ * target — the rest of the bridge (`index.ts`) opens a live session bus at
+ * module load and can only run under GJS.
+ */
+
+/** Well-known base bus name the maker owns for its default instance. */
+export const BASE_NAME = 'org.pixelrpg.maker'
+/** Base object path the maker exports its Control interface under. */
+export const BASE_PATH = '/org/pixelrpg/maker'
+
+/**
+ * Coerce a label into the same app-id segment the app derives from
+ * PIXELRPG_INSTANCE. CONTRACT: byte-identical mapping to
+ * `apps/maker-gjs/src/instance-id.ts` `sanitizeInstanceId` (the bridge is
+ * deliberately dependency-free, so it cannot import it). The maker-side
+ * `instance-id.spec.ts` AND this package's `instance-routing.spec.ts` pin
+ * the mapping — change all copies + both specs together.
+ */
+export function sanitizeLabel(label: string): string {
+  const cleaned = label.toLowerCase().replace(/[^a-z0-9]/g, '')
+  return /^[a-z]/.test(cleaned) ? cleaned : `i${cleaned || '0'}`
+}
+
+/**
+ * Resolve an instance label to its D-Bus name + Control object path. The
+ * default instance keeps the bare base name/path; a named instance gets a
+ * `.<segment>` bus-name suffix and a `/<segment>/control` path — so the
+ * bridge dials the right editor process when several run at once.
+ */
+export function resolve(label?: string): { busName: string; controlPath: string; label: string } {
+  const l = label && label !== 'default' ? sanitizeLabel(label) : 'default'
+  if (l === 'default') return { busName: BASE_NAME, controlPath: `${BASE_PATH}/control`, label: 'default' }
+  return { busName: `${BASE_NAME}.${l}`, controlPath: `${BASE_PATH}/${l}/control`, label: l }
+}

--- a/apps/mcp-bridge/src/test.mts
+++ b/apps/mcp-bridge/src/test.mts
@@ -1,0 +1,11 @@
+// NOTE: HAND-MAINTAINED — `gjsify test` runs only the suites imported +
+// passed to `run()` here, not every `*.spec.ts` on disk (enforced by the
+// root `check:specs` guard). The bridge proper (`index.ts`) opens a live
+// session bus at module load, so only its dependency-free helpers (the
+// instance-label → D-Bus address routing) can run under the node target —
+// colocate pure logic in a gi-free module and test that.
+import { run } from '@gjsify/unit'
+
+import instanceRoutingSuite from './instance-routing.spec.js'
+
+run({ instanceRoutingSuite })

--- a/scripts/check-spec-registration.mjs
+++ b/scripts/check-spec-registration.mjs
@@ -23,7 +23,7 @@ import { fileURLToPath } from 'node:url'
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
 
 /** Packages whose `test.mts` registers suites (have a `test` script). */
-const PACKAGES = ['packages/engine', 'packages/gjs', 'apps/maker-gjs', 'apps/signalling-server']
+const PACKAGES = ['packages/engine', 'packages/gjs', 'apps/maker-gjs', 'apps/signalling-server', 'apps/mcp-bridge']
 
 /** Recursively collect `*.spec.ts` files under `dir` (skips node_modules/dist). */
 function collectSpecs(dir, acc = []) {


### PR DESCRIPTION
## What

Establish a test harness for `@pixelrpg/mcp-bridge` (it had **none**) and cover its dependency-free instance→D-Bus routing.

## Runtime note (answers "does it run on GJS?")

Yes — the bridge runs as a **GJS bundle via gjsify** and talks to the maker over **native Gio D-Bus** (`@girs/gio-2.0`), opening a live session bus at module load. That's exactly why it can't be imported into a node test. So this follows the #229 pattern: extract the gi-free logic and test it; the harness runs on **both** gjs + node targets, and the gjs target keeps native Gio available for future integration tests.

## Changes

- **Harness wiring**: `@gjsify/unit` via the workspace hoist (no lockfile change), hand-maintained `src/test.mts`, a `test` script, `apps/mcp-bridge` added to `scripts/check-spec-registration.mjs`, and a CI step (`Run mcp-bridge tests`).
- **`src/instance-routing.ts`** (gi-free) — `sanitizeLabel` + `resolve` + the `BASE_NAME`/`BASE_PATH` constants, lifted out of `index.ts`.
- **`src/instance-routing.spec.ts`** — 9 cases:
  - `sanitizeLabel` **mirrors** the maker's `instance-id.spec.ts` cases so the byte-identical copies can't drift (if the bridge sanitises a label differently from how the app derived its bus name, the bridge dials a name nobody owns).
  - `resolve` — the multi-instance addressing (default → bare base; named → `.<segment>` bus name + `/<segment>/control` path).

`index.ts` imports the extracted helpers (−23 net lines); behavior-neutral.

## Verification

- `gjsify test` (@pixelrpg/mcp-bridge) green on both gjs + node targets (9 cases).
- `tsc --noEmit` clean, Biome clean (whole `apps/mcp-bridge`), spec-registration guard now covers the package and passes.

## Follow-up enabled

With the harness in place, gjs-only native-Gio-D-Bus integration tests (drive a launched maker over the session bus) are now a natural next step.