### PR TITLE
feat(welcome): searchable templates + rich recents home view

### DIFF
--- a/apps/maker-gjs/src/services/recent-projects.ts
+++ b/apps/maker-gjs/src/services/recent-projects.ts
@@ -13,6 +13,12 @@ export interface RecentProject {
   name: string
   /** Caption (project's `properties.description`, truncated). */
   caption: string
+  /**
+   * Scene (map) count at the time of opening — feeds the welcome row's
+   * "N scenes" meta. Optional: entries written before this field existed
+   * simply omit it from the label.
+   */
+  sceneCount?: number
   /** Unix ms timestamp when the project was last opened by the user. */
   openedAt: number
 }

--- a/apps/maker-gjs/src/services/recent-time.spec.ts
+++ b/apps/maker-gjs/src/services/recent-time.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from '@gjsify/unit'
+
+import { formatRelativeTime } from './recent-time.ts'
+
+export default async () => {
+  await describe('formatRelativeTime', async () => {
+    // Fixed reference: 2026-07-02 15:00 local time.
+    const now = new Date(2026, 6, 2, 15, 0).getTime()
+
+    await it('renders same-day timestamps as "today, HH:MM"', async () => {
+      const at = new Date(2026, 6, 2, 14, 32).getTime()
+      expect(formatRelativeTime(at, now)).toBe('today, 14:32')
+      const morning = new Date(2026, 6, 2, 8, 5).getTime()
+      expect(formatRelativeTime(morning, now)).toBe('today, 08:05')
+    })
+
+    await it('treats future timestamps (clock skew) as today', async () => {
+      const future = new Date(2026, 6, 2, 23, 59).getTime()
+      expect(formatRelativeTime(future, now)).toBe('today, 23:59')
+    })
+
+    await it('renders yesterday and day counts', async () => {
+      expect(formatRelativeTime(new Date(2026, 6, 1, 22, 0).getTime(), now)).toBe('yesterday')
+      expect(formatRelativeTime(new Date(2026, 5, 29, 9, 0).getTime(), now)).toBe('3 days ago')
+      expect(formatRelativeTime(new Date(2026, 5, 26, 9, 0).getTime(), now)).toBe('6 days ago')
+    })
+
+    await it('renders week buckets', async () => {
+      expect(formatRelativeTime(new Date(2026, 5, 24, 9, 0).getTime(), now)).toBe('last week')
+      expect(formatRelativeTime(new Date(2026, 5, 10, 9, 0).getTime(), now)).toBe('3 weeks ago')
+    })
+
+    await it('falls back to an absolute date beyond ~2 months', async () => {
+      expect(formatRelativeTime(new Date(2026, 3, 1, 9, 0).getTime(), now)).toBe('2026-04-01')
+    })
+  })
+}

--- a/apps/maker-gjs/src/services/recent-time.ts
+++ b/apps/maker-gjs/src/services/recent-time.ts
@@ -1,0 +1,28 @@
+/**
+ * Human-friendly "when was this last opened" label for recent-project
+ * rows ("today, 14:32" · "yesterday" · "3 days ago" · "last week" · a
+ * plain date). Kept free of GTK imports so it is unit-testable on any
+ * runtime; `nowMs` is injectable for deterministic tests.
+ */
+export function formatRelativeTime(thenMs: number, nowMs: number = Date.now()): string {
+  const then = new Date(thenMs)
+  const startOfDay = (ms: number) => {
+    const d = new Date(ms)
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime()
+  }
+  const dayDiff = Math.round((startOfDay(nowMs) - startOfDay(thenMs)) / 86_400_000)
+
+  // Same calendar day — or a future timestamp from clock skew, which we
+  // deliberately show as "today" rather than something nonsensical.
+  if (dayDiff <= 0) {
+    const hh = String(then.getHours()).padStart(2, '0')
+    const mm = String(then.getMinutes()).padStart(2, '0')
+    return `today, ${hh}:${mm}`
+  }
+  if (dayDiff === 1) return 'yesterday'
+  if (dayDiff < 7) return `${dayDiff} days ago`
+  if (dayDiff < 14) return 'last week'
+  if (dayDiff < 60) return `${Math.floor(dayDiff / 7)} weeks ago`
+  // Older than that: an absolute date beats fuzzy math.
+  return then.toISOString().slice(0, 10)
+}

--- a/apps/maker-gjs/src/test.mts
+++ b/apps/maker-gjs/src/test.mts
@@ -18,6 +18,7 @@ import orphanPublisherCleanupSuite from './services/orphan-publisher-cleanup.spe
 import participantRosterSuite from './services/participant-roster.spec.js'
 import pixelrpgUrlSuite from './services/pixelrpg-url.spec.js'
 import projectLoaderSuite from './services/project-loader.spec.js'
+import recentTimeSuite from './services/recent-time.spec.js'
 import projectStoreSuite from './services/project-store.spec.js'
 import relaySignallingSuite from './services/relay-signalling.spec.js'
 import sandboxPathSuite from './services/sandbox-path.spec.js'
@@ -48,6 +49,7 @@ run({
   pixelrpgUrlSuite,
   projectLoaderSuite,
   projectStoreSuite,
+  recentTimeSuite,
   relaySignallingSuite,
   sandboxPathSuite,
   sessionServiceSuite,

--- a/apps/maker-gjs/src/widgets/application-window.ts
+++ b/apps/maker-gjs/src/widgets/application-window.ts
@@ -787,8 +787,12 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
    * to every view's own pair. Effect: the sidebars retain their state
    * across view switches — opening the library in atlas keeps it open
    * after navigating to scene-editor, and closing it stays closed when
-   * the user goes back. Welcome's library-less layout binds only the
-   * inspector.
+   * the user goes back.
+   *
+   * Welcome is deliberately NOT bound: its recents column is part of the
+   * home layout (visible by default, inlined below the hero on phone),
+   * not a project inspector — sharing state would hide it whenever the
+   * user last closed an editor inspector.
    */
   private _shareSidebarState(): void {
     const flags = GObject.BindingFlags.SYNC_CREATE | GObject.BindingFlags.BIDIRECTIONAL
@@ -802,7 +806,6 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       this.bind_property('show-library', view, 'show-library', flags)
       this.bind_property('show-inspector', view, 'show-inspector', flags)
     }
-    this.bind_property('show-inspector', this._welcome_view, 'show-inspector', flags)
     // The Data view has a mode rail but no inspector — bind only the library.
     this.bind_property('show-library', this._data_view, 'show-library', flags)
   }
@@ -1529,7 +1532,7 @@ export class ApplicationWindow extends Adw.ApplicationWindow {
       // welcome list so backing out of the project shows the project we
       // just opened at the top.
       const caption = (project.resource.data?.properties?.description as string | undefined) ?? ''
-      recordRecentProject({ path: projectPath, name: project.projectName, caption })
+      recordRecentProject({ path: projectPath, name: project.projectName, caption, sceneCount: project.scenes.length })
       this._welcome_view.setRecentProjects(loadRecentProjects())
       this._showAtlas()
     } catch (error) {

--- a/apps/maker-gjs/src/widgets/welcome-view.blp
+++ b/apps/maker-gjs/src/widgets/welcome-view.blp
@@ -4,173 +4,176 @@ using Adw 1;
 template $WelcomeView : Adw.Bin {
   Adw.OverlaySplitView outer_split {
     sidebar-position: end;
-    min-sidebar-width: 280;
-    max-sidebar-width: 360;
+    min-sidebar-width: 300;
+    max-sidebar-width: 380;
     sidebar-width-fraction: 0.7;
     pin-sidebar: true;
     collapsed: bind template.inspector-collapsed;
     show-sidebar: bind template.show-inspector bidirectional;
 
-    // Sidebar: plain scrolled recents column. No flat header here —
-    // unlike the canvas-based atlas + scene-editor views, the
-    // welcome view has a real central headerbar (see content
-    // below) that hosts the window-close X + sidebar toggle, so
-    // the sidebar doesn't need its own header.
+    // Sidebar: plain scrolled recents column, visible by default at
+    // desktop width (the design's right-hand "Recent Projects" column
+    // — one-click resume is the home view's primary job). On phone the
+    // column is REPARENTED inline below the hero (see
+    // inline_recents_slot) instead of hiding in a drawer, so the slot
+    // here is just its desktop home.
     sidebar: Gtk.ScrolledWindow {
       hscrollbar-policy: never;
       vscrollbar-policy: automatic;
       min-content-width: 1;
 
-      child: Gtk.Box recents_column {
-        orientation: vertical;
-        spacing: 12;
-        margin-top: 16;
-        margin-bottom: 16;
-        margin-start: 16;
-        margin-end: 16;
+      child: Adw.Bin sidebar_recents_slot {
+        child: Gtk.Box recents_column {
+          orientation: vertical;
+          spacing: 12;
+          margin-top: 16;
+          margin-bottom: 16;
+          margin-start: 16;
+          margin-end: 16;
 
-        Gtk.Box recents_header {
-          orientation: horizontal;
-          spacing: 6;
+          Gtk.Box recents_header {
+            orientation: horizontal;
+            spacing: 6;
 
-          Gtk.Label {
-            label: _("Recent Projects");
-            halign: start;
-            hexpand: true;
-            styles ["heading"]
-          }
-
-          Gtk.Button browse_button {
-            label: _("Browse all…");
-            styles ["flat"]
-          }
-        }
-
-        Gtk.ListBox recents_list {
-          selection-mode: none;
-          styles ["boxed-list"]
-
-          Adw.ActionRow empty_recents_row {
-            title: _("No recent projects");
-            subtitle: _("Open a project to populate this list.");
-            activatable: false;
-
-            [prefix]
-            Gtk.Image {
-              icon-name: "folder-open-symbolic";
-              pixel-size: 22;
+            Gtk.Label {
+              label: _("Recent Projects");
+              halign: start;
+              hexpand: true;
+              styles ["heading"]
             }
-          }
-        }
 
-        Gtk.Box sessions_header {
-          orientation: horizontal;
-          spacing: 6;
-          margin-top: 18;
-
-          Gtk.Label {
-            label: _("Sessions on this network");
-            halign: start;
-            hexpand: true;
-            styles ["heading"]
-          }
-        }
-
-        // List rebuilt dynamically by `welcome-view.ts` from
-        // SessionService's `service-discovered` / `service-gone`
-        // events. Empty state stays visible until the first
-        // service resolves.
-        Gtk.ListBox sessions_list {
-          selection-mode: none;
-          styles ["boxed-list"]
-
-          Adw.ActionRow empty_sessions_row {
-            title: _("No sessions found");
-            subtitle: _("Hosts on the same network will appear here.");
-            activatable: false;
-
-            [prefix]
-            Gtk.Image {
-              icon-name: "network-workgroup-symbolic";
-              pixel-size: 22;
-            }
-          }
-        }
-
-        // Paste-link / room-code entry — the cross-internet
-        // counterpart of the LAN discovery list above. The single
-        // field accepts both `pixelrpg://join/<roomid>` URLs and
-        // bare room codes; the welcome-view normalises before
-        // emitting `join-by-code`.
-        Adw.PreferencesGroup join_link_group {
-          margin-top: 12;
-
-          Adw.EntryRow join_link_row {
-            title: _("Join session by code or link");
-
-            [suffix]
-            Gtk.Button join_link_button {
-              icon-name: "go-next-symbolic";
-              valign: center;
-              tooltip-text: _("Join session");
+            Gtk.Button browse_button {
+              label: _("Browse all…");
               styles ["flat"]
             }
           }
-        }
 
-        Gtk.Box {
-          vexpand: true;
-        }
+          Gtk.ListBox recents_list {
+            selection-mode: none;
+            styles ["boxed-list"]
 
-        Gtk.Button tour_button {
-          styles ["card"]
-          halign: fill;
+            Adw.ActionRow empty_recents_row {
+              title: _("No recent projects");
+              subtitle: _("Open a project to populate this list.");
+              activatable: false;
 
-          child: Gtk.Box {
-            spacing: 12;
-            margin-top: 8;
-            margin-bottom: 8;
-            margin-start: 12;
-            margin-end: 12;
-
-            Gtk.Image {
-              icon-name: "media-playback-start-symbolic";
-              pixel-size: 18;
-              styles ["accent"]
+              [prefix]
+              Gtk.Image {
+                icon-name: "folder-open-symbolic";
+                pixel-size: 22;
+              }
             }
+          }
 
-            Gtk.Box {
-              orientation: vertical;
-              hexpand: true;
+          Gtk.Box sessions_header {
+            orientation: horizontal;
+            spacing: 6;
+            margin-top: 18;
+
+            Gtk.Label {
+              label: _("Sessions on this network");
               halign: start;
+              hexpand: true;
+              styles ["heading"]
+            }
+          }
 
-              Gtk.Label {
-                label: _("Take the tour");
-                halign: start;
-                styles ["heading"]
-              }
+          // List rebuilt dynamically by `welcome-view.ts` from
+          // SessionService's `service-discovered` / `service-gone`
+          // events. Empty state stays visible until the first
+          // service resolves.
+          Gtk.ListBox sessions_list {
+            selection-mode: none;
+            styles ["boxed-list"]
 
-              Gtk.Label {
-                label: _("Three-minute walkthrough of the editor.");
-                halign: start;
-                styles ["caption", "dim-label"]
+            Adw.ActionRow empty_sessions_row {
+              title: _("No sessions found");
+              subtitle: _("Hosts on the same network will appear here.");
+              activatable: false;
+
+              [prefix]
+              Gtk.Image {
+                icon-name: "network-workgroup-symbolic";
+                pixel-size: 22;
               }
             }
+          }
 
-            Gtk.Image {
-              icon-name: "go-next-symbolic";
-              styles ["dim-label"]
+          // Paste-link / room-code entry — the cross-internet
+          // counterpart of the LAN discovery list above. The single
+          // field accepts both `pixelrpg://join/<roomid>` URLs and
+          // bare room codes; the welcome-view normalises before
+          // emitting `join-by-code`.
+          Adw.PreferencesGroup join_link_group {
+            margin-top: 12;
+
+            Adw.EntryRow join_link_row {
+              title: _("Join session by code or link");
+
+              [suffix]
+              Gtk.Button join_link_button {
+                icon-name: "go-next-symbolic";
+                valign: center;
+                tooltip-text: _("Join session");
+                styles ["flat"]
+              }
             }
-          };
-        }
+          }
+
+          Gtk.Box {
+            vexpand: true;
+          }
+
+          Gtk.Button tour_button {
+            styles ["card"]
+            halign: fill;
+
+            child: Gtk.Box {
+              spacing: 12;
+              margin-top: 8;
+              margin-bottom: 8;
+              margin-start: 12;
+              margin-end: 12;
+
+              Gtk.Image {
+                icon-name: "media-playback-start-symbolic";
+                pixel-size: 18;
+                styles ["accent"]
+              }
+
+              Gtk.Box {
+                orientation: vertical;
+                hexpand: true;
+                halign: start;
+
+                Gtk.Label {
+                  label: _("Take the tour");
+                  halign: start;
+                  styles ["heading"]
+                }
+
+                Gtk.Label {
+                  label: _("Three-minute walkthrough of the editor.");
+                  halign: start;
+                  styles ["caption", "dim-label"]
+                }
+              }
+
+              Gtk.Image {
+                icon-name: "go-next-symbolic";
+                styles ["dim-label"]
+              }
+            };
+          }
+        };
       };
     };
 
     // Content: regular Adw.ToolbarView with a real headerbar.
     // No canvas here = no Gtk.Overlay + no floating OSD pills.
     // The headerbar hosts the window-close X (show-end-title-buttons)
-    // + the recents toggle. Cleaner + less layout overhead than the
-    // overlay-with-floating-button pattern the canvas views need.
+    // + the recents toggle (desktop only — on phone the recents are
+    // inlined, so there is no drawer to toggle).
     content: Adw.ToolbarView {
       [top]
       Adw.HeaderBar {
@@ -182,93 +185,129 @@ template $WelcomeView : Adw.Bin {
           icon-name: "sidebar-show-right-symbolic";
           tooltip-text: _("Toggle recent projects");
           active: bind template.show-inspector bidirectional;
+          visible: bind template.inspector-collapsed inverted;
         }
       }
 
-      content: Adw.Clamp {
-        maximum-size: 720;
-        tightening-threshold: 480;
-        hexpand: true;
-        vexpand: true;
+      // Scrolls once the stacked phone layout (hero + inline recents +
+      // templates) outgrows the viewport; at desktop height the content
+      // is shorter than the window and stays vertically centered.
+      content: Gtk.ScrolledWindow {
+        hscrollbar-policy: never;
+        vscrollbar-policy: automatic;
+        propagate-natural-height: true;
 
-        child: Gtk.Box hero_column {
-          orientation: vertical;
-          spacing: 0;
-          valign: center;
-          margin-top: 12;
-          margin-bottom: 36;
-          margin-start: 24;
-          margin-end: 24;
+        child: Adw.Clamp {
+          maximum-size: 760;
+          tightening-threshold: 500;
+          hexpand: true;
+          vexpand: true;
 
-          $PixelRpgProjectHeroIcon hero_icon {
-            size: 96;
-            halign: center;
-          }
-
-          Gtk.Label welcome_title {
-            label: _("Welcome to Pixel RPG Editor");
-            halign: center;
-            // Wrap so the large title doesn't force a wide minimum window
-            // width — a non-wrapping title-1's min width is the full text.
-            wrap: true;
-            wrap-mode: word_char;
-            justify: center;
+          child: Gtk.Box hero_column {
+            orientation: vertical;
+            spacing: 0;
+            valign: center;
+            vexpand: true;
             margin-top: 24;
-            margin-bottom: 6;
-            styles ["title-1"]
-          }
-
-          Gtk.Label welcome_subtitle {
-            label: _("Draw maps from tilesets, place a hero and NPCs, hook scenes together with teleports, and script events.");
-            halign: center;
-            wrap: true;
-            wrap-mode: word_char;
-            justify: center;
-            margin-bottom: 24;
-            styles ["dim-label"]
-          }
-
-          // FlowBox so the two CTA pills stack vertically once
-          // the width drops below their combined natural.
-          Gtk.FlowBox cta_box {
-            orientation: horizontal;
-            halign: center;
-            selection-mode: none;
-            min-children-per-line: 1;
-            max-children-per-line: 2;
-            column-spacing: 8;
-            row-spacing: 8;
-            homogeneous: false;
             margin-bottom: 36;
+            margin-start: 24;
+            margin-end: 24;
 
-            Gtk.Button create_button {
-              label: _("New Project…");
-              styles ["suggested-action", "pill"]
+            // Left-aligned hero per the design handoff — the brand
+            // mark, title, and CTAs read as a column, with the
+            // templates gallery below and the recents column beside
+            // (desktop) or beneath (phone).
+            $PixelRpgProjectHeroIcon hero_icon {
+              size: 80;
+              halign: start;
             }
 
-            Gtk.Button open_button {
-              label: _("Open Project…");
-              styles ["pill"]
+            Gtk.Label welcome_title {
+              label: _("Welcome to Pixel RPG Editor");
+              halign: start;
+              xalign: 0;
+              // Wrap so the large title doesn't force a wide minimum window
+              // width — a non-wrapping title-1's min width is the full text.
+              wrap: true;
+              wrap-mode: word_char;
+              margin-top: 20;
+              margin-bottom: 6;
+              styles ["title-1"]
             }
-          }
 
-          Gtk.Label templates_heading {
-            label: _("Start from a template");
-            halign: center;
-            margin-bottom: 10;
-            styles ["caption-heading", "dim-label"]
-          }
+            Gtk.Label welcome_subtitle {
+              label: _("Draw maps from tilesets, place a hero and NPCs, hook scenes together with teleports, and script events.");
+              halign: start;
+              xalign: 0;
+              wrap: true;
+              wrap-mode: word_char;
+              margin-bottom: 22;
+              styles ["dim-label"]
+            }
 
-          Gtk.FlowBox templates_grid {
-            halign: fill;
-            selection-mode: none;
-            min-children-per-line: 1;
-            max-children-per-line: 3;
-            column-spacing: 10;
-            row-spacing: 10;
-            homogeneous: true;
-            margin-bottom: 12;
-          }
+            // FlowBox so the two CTA pills stack vertically once
+            // the width drops below their combined natural.
+            Gtk.FlowBox cta_box {
+              orientation: horizontal;
+              halign: start;
+              selection-mode: none;
+              min-children-per-line: 1;
+              max-children-per-line: 2;
+              column-spacing: 10;
+              row-spacing: 8;
+              homogeneous: false;
+              margin-bottom: 32;
+
+              Gtk.Button create_button {
+                label: _("New Project…");
+                height-request: 44;
+                styles ["suggested-action", "pill"]
+              }
+
+              Gtk.Button open_button {
+                label: _("Open Project…");
+                height-request: 44;
+                styles ["pill"]
+              }
+            }
+
+            // Phone slot: `recents_column` moves here (between the CTAs
+            // and the templates) while the window breakpoint keeps
+            // `inspector-collapsed` set — the design stacks recents
+            // above the template gallery on small screens.
+            Adw.Bin inline_recents_slot {
+              visible: false;
+            }
+
+            Gtk.Box templates_header {
+              orientation: horizontal;
+              spacing: 12;
+              margin-bottom: 10;
+
+              Gtk.Label templates_heading {
+                label: _("Templates");
+                halign: start;
+                hexpand: true;
+                styles ["caption-heading", "dim-label"]
+              }
+
+              Gtk.SearchEntry template_filter {
+                placeholder-text: _("Filter templates…");
+                max-width-chars: 18;
+              }
+            }
+
+            Gtk.FlowBox templates_grid {
+              halign: fill;
+              selection-mode: none;
+              min-children-per-line: 1;
+              max-children-per-line: 2;
+              column-spacing: 10;
+              row-spacing: 10;
+              homogeneous: true;
+              margin-bottom: 12;
+            }
+          };
         };
       };
     };

--- a/apps/maker-gjs/src/widgets/welcome-view.ts
+++ b/apps/maker-gjs/src/widgets/welcome-view.ts
@@ -4,6 +4,7 @@ import Gtk from '@girs/gtk-4.0'
 import { MapPreview, ProjectHeroIcon, SignalScope } from '@pixelrpg/gjs'
 import type { DiscoveredService } from '../services/lan-discovery-parse.ts'
 import { parsePixelrpgUrl } from '../services/pixelrpg-url.ts'
+import { formatRelativeTime } from '../services/recent-time.ts'
 import type { RecentProject } from '../services/recent-projects.ts'
 import { STARTER_TEMPLATES } from '../services/templates.ts'
 
@@ -34,18 +35,26 @@ export class WelcomeView extends Adw.Bin {
   declare _browse_button: Gtk.Button
   declare _tour_button: Gtk.Button
   declare _templates_grid: Gtk.FlowBox
+  declare _template_filter: Gtk.SearchEntry
   declare _recents_list: Gtk.ListBox
   declare _empty_recents_row: Adw.ActionRow
   declare _sessions_list: Gtk.ListBox
   declare _empty_sessions_row: Adw.ActionRow
   declare _join_link_row: Adw.EntryRow
   declare _join_link_button: Gtk.Button
+  declare _sidebar_recents_slot: Adw.Bin
+  declare _inline_recents_slot: Adw.Bin
+  declare _recents_column: Gtk.Box
 
   private _recentRows: Gtk.Widget[] = []
   /** `name` → row, so `service-gone` events can remove the right entry. */
   private _sessionRows = new Map<string, Adw.ActionRow>()
+  /** Template card FlowBox child → lowercase searchable text, for the filter. */
+  private _templateSearchText = new Map<Gtk.Widget, string>()
   private _inspectorCollapsed = false
-  private _showInspector = false
+  // Recents are part of the home layout, so the column defaults to
+  // visible (unlike the editor views' project inspectors).
+  private _showInspector = true
 
   private signals = new SignalScope()
 
@@ -61,12 +70,16 @@ export class WelcomeView extends Adw.Bin {
           'browse_button',
           'tour_button',
           'templates_grid',
+          'template_filter',
           'recents_list',
           'empty_recents_row',
           'sessions_list',
           'empty_sessions_row',
           'join_link_row',
           'join_link_button',
+          'sidebar_recents_slot',
+          'inline_recents_slot',
+          'recents_column',
         ],
         Properties: {
           // Mirror SceneEditorView + AtlasView so the same
@@ -84,7 +97,7 @@ export class WelcomeView extends Adw.Bin {
             'Show inspector',
             'Whether the right-side recent-projects panel is visible',
             GObject.ParamFlags.READWRITE,
-            false,
+            true,
           ),
         },
         Signals: {
@@ -117,10 +130,20 @@ export class WelcomeView extends Adw.Bin {
     if (this._inspectorCollapsed === value) return
     this._inspectorCollapsed = value
     this.notify('inspector-collapsed')
+    this._relocateRecents()
+    // Recents live inline on phone, so the split-view drawer would
+    // otherwise show empty. Collapse hides it; expanding restores the
+    // desktop sidebar. (Welcome owns its own inspector state — it's not
+    // bound to the shared window sidebar, so this can't fight the editors.)
+    this.showInspector = !value
   }
 
   get showInspector(): boolean {
-    return this._showInspector ?? false
+    // Fallback matches the ParamSpec default: the template's
+    // `show-sidebar` binding reads this during `super()` BEFORE the
+    // class-field initializer runs, so `?? false` would freeze the
+    // sidebar closed regardless of the field's value.
+    return this._showInspector ?? true
   }
 
   set showInspector(value: boolean) {
@@ -132,6 +155,7 @@ export class WelcomeView extends Adw.Bin {
   constructor() {
     super()
     this._buildTemplateGrid()
+    this._templates_grid.set_filter_func((child) => this._templateFilterFunc(child))
   }
 
   vfunc_map(): void {
@@ -143,6 +167,7 @@ export class WelcomeView extends Adw.Bin {
     this.signals.connect(this._join_link_button, 'clicked', () => this._submitJoinLink())
     // Pressing Enter in the entry submits — same path as the button.
     this.signals.connect(this._join_link_row, 'entry-activated', () => this._submitJoinLink())
+    this.signals.connect(this._template_filter, 'search-changed', () => this._templates_grid.invalidate_filter())
   }
 
   vfunc_unmap(): void {
@@ -166,17 +191,59 @@ export class WelcomeView extends Adw.Bin {
     this._empty_recents_row.set_visible(false)
 
     for (const recent of recents) {
+      // Meta line: "<caption> · <N scenes> · <when>" — parts drop out
+      // when unknown (caption may be empty; sceneCount is absent on
+      // entries recorded before the field existed).
+      const parts: string[] = []
+      if (recent.caption) parts.push(recent.caption)
+      if (recent.sceneCount) parts.push(recent.sceneCount === 1 ? '1 scene' : `${recent.sceneCount} scenes`)
+      if (recent.openedAt) parts.push(formatRelativeTime(recent.openedAt))
       const row = new Adw.ActionRow({
         title: recent.name,
-        subtitle: recent.caption || recent.path,
+        subtitle: parts.join(' · ') || recent.path,
+        subtitle_lines: 2,
+        tooltip_text: recent.path,
         activatable: true,
       })
-      row.add_prefix(new Gtk.Image({ icon_name: 'folder-symbolic', pixel_size: 22 }))
+      // Live map thumbnail — same MapPreview pipeline as the template
+      // cards. Deferred so eight rows don't block the main loop in a
+      // row; a vanished project file just leaves the accent fallback.
+      const preview = new MapPreview()
+      preview.set_size_request(48, 32)
+      preview.add_css_class('engine-canvas')
+      preview.valign = Gtk.Align.CENTER
+      void Promise.resolve()
+        .then(() => preview.loadProject(recent.path))
+        .catch(() => {})
+      row.add_prefix(preview)
       row.add_suffix(new Gtk.Image({ icon_name: 'go-next-symbolic', pixel_size: 12 }))
       row.connect('activated', () => this.emit('recent-selected', recent.path))
       this._recents_list.append(row)
       this._recentRows.push(row)
     }
+  }
+
+  /**
+   * Move the recents column between its desktop home (the end sidebar)
+   * and the inline slot below the hero — the phone layout stacks
+   * recents between the CTAs and the template gallery instead of
+   * hiding them in a drawer.
+   */
+  private _relocateRecents(): void {
+    const target = this._inspectorCollapsed ? this._inline_recents_slot : this._sidebar_recents_slot
+    const source = this._inspectorCollapsed ? this._sidebar_recents_slot : this._inline_recents_slot
+    if (target.get_child() !== this._recents_column) {
+      source.set_child(null)
+      target.set_child(this._recents_column)
+    }
+    this._inline_recents_slot.set_visible(this._inspectorCollapsed)
+  }
+
+  private _templateFilterFunc(child: Gtk.FlowBoxChild): boolean {
+    const query = this._template_filter.get_text().trim().toLowerCase()
+    if (!query) return true
+    const text = this._templateSearchText.get(child.get_child() as Gtk.Widget) ?? ''
+    return text.includes(query)
   }
 
   /**
@@ -270,6 +337,7 @@ export class WelcomeView extends Adw.Bin {
     accentColor: string
   }): Gtk.Button {
     const button = new Gtk.Button({ css_classes: ['card'] })
+    this._templateSearchText.set(button, `${template.name} ${template.caption}`.toLowerCase())
     const box = new Gtk.Box({
       orientation: Gtk.Orientation.VERTICAL,
       spacing: 8,


### PR DESCRIPTION
Turns the welcome view into the design-handoff home surface (`soll-welcome`): one-click resume of recent work + a browsable template gallery.

## What

- **Template filter** — a `GtkSearchEntry` above the gallery live-filters the `FlowBox` over each template's name + caption.
- **Rich recent rows** — each row now renders a live `MapPreview` thumbnail and a meta line (`caption · N scenes · when`) instead of a folder icon + raw path. `RecentProject` gains an optional `sceneCount`; a GTK-free `formatRelativeTime` helper produces the when-label (today/yesterday/N days/…), unit-tested and registered in `test.mts`.
- **Recents are home, not an inspector** — the column is visible by default at desktop/tablet width. On phone (`inspector-collapsed`) it **reparents inline** below the hero (matching the mobile artboard's stacked layout) rather than hiding in a drawer, and the now-empty split-view drawer is suppressed. Welcome is decoupled from the editors' shared sidebar state so it can own this.
- Left-aligned hero + 44px CTA pills per the artboard.

## Verified

- `gjsify workspace @pixelrpg/maker-gjs` `check` + `build` + `test` green (456 tests, GJS + Node).
- Control D-Bus screenshot bridge, **desktop**: recents column with thumbnails/meta + template filter. **phone** (400×880): single scrolling column, recents inline below the CTAs, no empty drawer.

## Notes

- Some existing `games/*` templates fail `MapValidationError` on preview render (pre-existing placement-data issue, unrelated) — those cards fall back to the accent tint.

https://claude.ai/code/session_011B9ADCSnzUm3dXaPzbSBWe