### PR TITLE
refactor(engine): per-frame durations for character animations

### DIFF
--- a/apps/maker-gjs/src/services/cast-controller.ts
+++ b/apps/maker-gjs/src/services/cast-controller.ts
@@ -347,14 +347,15 @@ export class CastController {
   }
 
   /**
-   * Set one animation's per-loop duration on a sheet. Public so both the
-   * Cast detail (via `callbacks`) and the unified Sheets view's animation
-   * editor drive the same sheet-owned mutation.
+   * Set a uniform per-frame duration across one animation on a sheet
+   * ("apply to all frames"). Public so both the Cast detail (via
+   * `callbacks`) and the animation editor drive the same sheet-owned
+   * mutation; per-frame durations are set frame-by-frame in the editor.
    */
   setAnimationDuration(sheetId: string, animId: string, durationMs: number): void {
     this._mutateSheetAnimations(sheetId, (anims) => {
       const anim = anims.find((a) => a.id === animId)
-      if (anim) anim.durationMs = durationMs
+      if (anim) anim.frames = anim.frames.map((f) => ({ ...f, duration: durationMs }))
     })
   }
 

--- a/apps/maker-gjs/src/services/project-store.ts
+++ b/apps/maker-gjs/src/services/project-store.ts
@@ -529,7 +529,10 @@ export class ProjectStore {
       characterAnimations:
         kind === 'character'
           ? (data.characterAnimations ??
-            REQUIRED_ROLES.map((role) => ({ id: role, frames: [DEFAULT_FRAME], durationMs: DEFAULT_ANIMATION_MS })))
+            REQUIRED_ROLES.map((role) => ({
+              id: role,
+              frames: [{ spriteId: DEFAULT_FRAME, duration: DEFAULT_ANIMATION_MS }],
+            })))
           : undefined,
       image: { ...(data.image ?? { id: 'main', type: 'image' as const }), path: imageFile },
     }

--- a/docs/concepts/entity-and-appearance-model.md
+++ b/docs/concepts/entity-and-appearance-model.md
@@ -36,7 +36,7 @@ Runtime   ECS                 definition+placement flatten into an Excalibur ent
 
 ### Layer 1 — Appearance
 
-An **Appearance** is today's `SpriteSetData { kind:'character' }` — image + grid + `characterAnimations` + the uniform body collision box — renamed and treated as a first-class library asset next to Tilesets. The Cast "Sprite sheet" editor already produces exactly this; it moves conceptually into the asset library instead of being a peer tab of Character. `CharacterAnimation` (frames + durationMs + loop) is unchanged. No file split for Layer 0 until two appearances genuinely share one image (YAGNI).
+An **Appearance** is today's `SpriteSetData { kind:'character' }` — image + grid + `characterAnimations` + the uniform body collision box — renamed and treated as a first-class library asset next to Tilesets. The Cast "Sprite sheet" editor already produces exactly this; it moves conceptually into the asset library instead of being a peer tab of Character. `CharacterAnimation` is `{ id, frames: AnimationFrame[], loop? }` — each frame carries its own `{ spriteId, duration }`, sharing the frame shape with the tile/object `AnimationData` (the animation timeline editor tunes duration per frame). No file split for Layer 0 until two appearances genuinely share one image (YAGNI).
 
 An entity's visual is a union — single sprite for a chest/sign, full animation set for anything that walks:
 

--- a/games/blank-starter/spritesets/scientist.json
+++ b/games/blank-starter/spritesets/scientist.json
@@ -120,70 +120,122 @@
     {
       "id": "idle-up",
       "frames": [
-        0
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 0,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-up",
       "frames": [
-        1,
-        2,
-        3,
-        4
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 1,
+          "duration": 200
+        },
+        {
+          "spriteId": 2,
+          "duration": 200
+        },
+        {
+          "spriteId": 3,
+          "duration": 200
+        },
+        {
+          "spriteId": 4,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-down",
       "frames": [
-        5
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 5,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-down",
       "frames": [
-        6,
-        7,
-        8,
-        9
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 6,
+          "duration": 200
+        },
+        {
+          "spriteId": 7,
+          "duration": 200
+        },
+        {
+          "spriteId": 8,
+          "duration": 200
+        },
+        {
+          "spriteId": 9,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-left",
       "frames": [
-        10
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 10,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-left",
       "frames": [
-        11,
-        12,
-        13,
-        14
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 11,
+          "duration": 200
+        },
+        {
+          "spriteId": 12,
+          "duration": 200
+        },
+        {
+          "spriteId": 13,
+          "duration": 200
+        },
+        {
+          "spriteId": 14,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-right",
       "frames": [
-        15
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 15,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-right",
       "frames": [
-        16,
-        17,
-        18,
-        19
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 16,
+          "duration": 200
+        },
+        {
+          "spriteId": 17,
+          "duration": 200
+        },
+        {
+          "spriteId": 18,
+          "duration": 200
+        },
+        {
+          "spriteId": 19,
+          "duration": 200
+        }
+      ]
     }
   ]
 }

--- a/games/minimalist-starter/spritesets/scientist.json
+++ b/games/minimalist-starter/spritesets/scientist.json
@@ -120,70 +120,122 @@
     {
       "id": "idle-up",
       "frames": [
-        0
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 0,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-up",
       "frames": [
-        1,
-        2,
-        3,
-        4
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 1,
+          "duration": 200
+        },
+        {
+          "spriteId": 2,
+          "duration": 200
+        },
+        {
+          "spriteId": 3,
+          "duration": 200
+        },
+        {
+          "spriteId": 4,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-down",
       "frames": [
-        5
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 5,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-down",
       "frames": [
-        6,
-        7,
-        8,
-        9
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 6,
+          "duration": 200
+        },
+        {
+          "spriteId": 7,
+          "duration": 200
+        },
+        {
+          "spriteId": 8,
+          "duration": 200
+        },
+        {
+          "spriteId": 9,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-left",
       "frames": [
-        10
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 10,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-left",
       "frames": [
-        11,
-        12,
-        13,
-        14
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 11,
+          "duration": 200
+        },
+        {
+          "spriteId": 12,
+          "duration": 200
+        },
+        {
+          "spriteId": 13,
+          "duration": 200
+        },
+        {
+          "spriteId": 14,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-right",
       "frames": [
-        15
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 15,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-right",
       "frames": [
-        16,
-        17,
-        18,
-        19
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 16,
+          "duration": 200
+        },
+        {
+          "spriteId": 17,
+          "duration": 200
+        },
+        {
+          "spriteId": 18,
+          "duration": 200
+        },
+        {
+          "spriteId": 19,
+          "duration": 200
+        }
+      ]
     }
   ]
 }

--- a/games/oot2d-2014/spritesets/link.json
+++ b/games/oot2d-2014/spritesets/link.json
@@ -120,70 +120,122 @@
     {
       "id": "idle-up",
       "frames": [
-        0
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 0,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-up",
       "frames": [
-        1,
-        2,
-        3,
-        4
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 1,
+          "duration": 200
+        },
+        {
+          "spriteId": 2,
+          "duration": 200
+        },
+        {
+          "spriteId": 3,
+          "duration": 200
+        },
+        {
+          "spriteId": 4,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-down",
       "frames": [
-        5
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 5,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-down",
       "frames": [
-        6,
-        7,
-        8,
-        9
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 6,
+          "duration": 200
+        },
+        {
+          "spriteId": 7,
+          "duration": 200
+        },
+        {
+          "spriteId": 8,
+          "duration": 200
+        },
+        {
+          "spriteId": 9,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-left",
       "frames": [
-        10
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 10,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-left",
       "frames": [
-        11,
-        12,
-        13,
-        14
-      ],
-      "durationMs": 130
+        {
+          "spriteId": 11,
+          "duration": 130
+        },
+        {
+          "spriteId": 12,
+          "duration": 130
+        },
+        {
+          "spriteId": 13,
+          "duration": 130
+        },
+        {
+          "spriteId": 14,
+          "duration": 130
+        }
+      ]
     },
     {
       "id": "idle-right",
       "frames": [
-        15
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 15,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-right",
       "frames": [
-        16,
-        17,
-        18,
-        19
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 16,
+          "duration": 200
+        },
+        {
+          "spriteId": 17,
+          "duration": 200
+        },
+        {
+          "spriteId": 18,
+          "duration": 200
+        },
+        {
+          "spriteId": 19,
+          "duration": 200
+        }
+      ]
     }
   ]
 }

--- a/games/zelda-like/spritesets/link.json
+++ b/games/zelda-like/spritesets/link.json
@@ -120,70 +120,122 @@
     {
       "id": "idle-up",
       "frames": [
-        0
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 0,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-up",
       "frames": [
-        1,
-        2,
-        3,
-        4
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 1,
+          "duration": 200
+        },
+        {
+          "spriteId": 2,
+          "duration": 200
+        },
+        {
+          "spriteId": 3,
+          "duration": 200
+        },
+        {
+          "spriteId": 4,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-down",
       "frames": [
-        5
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 5,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-down",
       "frames": [
-        6,
-        7,
-        8,
-        9
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 6,
+          "duration": 200
+        },
+        {
+          "spriteId": 7,
+          "duration": 200
+        },
+        {
+          "spriteId": 8,
+          "duration": 200
+        },
+        {
+          "spriteId": 9,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-left",
       "frames": [
-        10
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 10,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-left",
       "frames": [
-        11,
-        12,
-        13,
-        14
-      ],
-      "durationMs": 130
+        {
+          "spriteId": 11,
+          "duration": 130
+        },
+        {
+          "spriteId": 12,
+          "duration": 130
+        },
+        {
+          "spriteId": 13,
+          "duration": 130
+        },
+        {
+          "spriteId": 14,
+          "duration": 130
+        }
+      ]
     },
     {
       "id": "idle-right",
       "frames": [
-        15
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 15,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-right",
       "frames": [
-        16,
-        17,
-        18,
-        19
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 16,
+          "duration": 200
+        },
+        {
+          "spriteId": 17,
+          "duration": 200
+        },
+        {
+          "spriteId": 18,
+          "duration": 200
+        },
+        {
+          "spriteId": 19,
+          "duration": 200
+        }
+      ]
     }
   ]
 }

--- a/games/zelda-like/spritesets/scientist.json
+++ b/games/zelda-like/spritesets/scientist.json
@@ -120,70 +120,122 @@
     {
       "id": "idle-up",
       "frames": [
-        0
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 0,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-up",
       "frames": [
-        1,
-        2,
-        3,
-        4
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 1,
+          "duration": 200
+        },
+        {
+          "spriteId": 2,
+          "duration": 200
+        },
+        {
+          "spriteId": 3,
+          "duration": 200
+        },
+        {
+          "spriteId": 4,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-down",
       "frames": [
-        5
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 5,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-down",
       "frames": [
-        6,
-        7,
-        8,
-        9
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 6,
+          "duration": 200
+        },
+        {
+          "spriteId": 7,
+          "duration": 200
+        },
+        {
+          "spriteId": 8,
+          "duration": 200
+        },
+        {
+          "spriteId": 9,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-left",
       "frames": [
-        10
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 10,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-left",
       "frames": [
-        11,
-        12,
-        13,
-        14
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 11,
+          "duration": 200
+        },
+        {
+          "spriteId": 12,
+          "duration": 200
+        },
+        {
+          "spriteId": 13,
+          "duration": 200
+        },
+        {
+          "spriteId": 14,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "idle-right",
       "frames": [
-        15
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 15,
+          "duration": 200
+        }
+      ]
     },
     {
       "id": "walk-right",
       "frames": [
-        16,
-        17,
-        18,
-        19
-      ],
-      "durationMs": 200
+        {
+          "spriteId": 16,
+          "duration": 200
+        },
+        {
+          "spriteId": 17,
+          "duration": 200
+        },
+        {
+          "spriteId": 18,
+          "duration": 200
+        },
+        {
+          "spriteId": 19,
+          "duration": 200
+        }
+      ]
     }
   ]
 }

--- a/packages/engine/src/entity/placement-graphic.spec.ts
+++ b/packages/engine/src/entity/placement-graphic.spec.ts
@@ -27,7 +27,15 @@ const fakeCharacterSheet = {
   sprites: { 0: fakeSprite(), 1: fakeSprite() },
   animations: {},
   data: {
-    characterAnimations: [{ id: 'idle-down', frames: [0, 1], durationMs: 200 }],
+    characterAnimations: [
+      {
+        id: 'idle-down',
+        frames: [
+          { spriteId: 0, duration: 200 },
+          { spriteId: 1, duration: 200 },
+        ],
+      },
+    ],
   },
 } as unknown as SpriteSetResource
 

--- a/packages/engine/src/types/data/CharacterDefinition.ts
+++ b/packages/engine/src/types/data/CharacterDefinition.ts
@@ -1,3 +1,4 @@
+import type { AnimationFrame } from './AnimationFrame'
 import type { CharacterAnimationRole } from './CharacterAnimationRole'
 
 /**
@@ -8,15 +9,15 @@ import type { CharacterAnimationRole } from './CharacterAnimationRole'
  * `wave`, …) it can be any user-chosen string. One-field-per-thing —
  * no separate `role` slot, no enum-and-id duplication.
  *
- * Frames are sprite indices into the character's `spriteSetId`. The
- * frame duration is uniform across the animation (the user spec —
- * "die geschwindigkeit soll in ms eingestellt werden können, wobei
- * sie alle pro animation gleich sind"). Loop defaults to `true`.
+ * Each {@link AnimationFrame} carries its own `spriteId` (index into the
+ * character's `spriteSetId`) **and** `duration` in ms — the timeline
+ * editor tunes duration per frame (chip width), with an "apply to all"
+ * affordance for the uniform case. Shares the frame shape with the
+ * tile/object {@link AnimationData}. Loop defaults to `true`.
  */
 export interface CharacterAnimation {
   id: string
-  frames: number[]
-  durationMs: number
+  frames: AnimationFrame[]
   loop?: boolean
 }
 

--- a/packages/engine/src/utils/character.ts
+++ b/packages/engine/src/utils/character.ts
@@ -51,7 +51,7 @@ export function buildCharacterAnimations(
 
 /**
  * Build a single Excalibur {@link Animation} from a {@link CharacterAnimation}
- * (frame indices into the sheet's sprites, uniform `durationMs`, loop by
+ * (each frame carries its own sprite index + duration, loop by
  * default). Returns `null` when no frame resolves to a loaded sprite.
  *
  * Shared by the player path ({@link buildCharacterAnimations}) and the
@@ -60,9 +60,9 @@ export function buildCharacterAnimations(
  */
 export function buildCharacterAnimation(anim: CharacterAnimation, sprites: Record<number, Sprite>): Animation | null {
   const frames = anim.frames
-    .map((spriteId) => sprites[spriteId])
-    .filter((s): s is Sprite => s != null)
-    .map((sprite) => ({ graphic: sprite.clone(), duration: anim.durationMs }))
+    .map((frame) => ({ sprite: sprites[frame.spriteId], duration: frame.duration }))
+    .filter((f): f is { sprite: Sprite; duration: number } => f.sprite != null)
+    .map(({ sprite, duration }) => ({ graphic: sprite.clone(), duration }))
   if (frames.length === 0) return null
   return new Animation({
     frames,

--- a/packages/gjs/src/widgets/cast/add-animation-dialog.ts
+++ b/packages/gjs/src/widgets/cast/add-animation-dialog.ts
@@ -201,9 +201,11 @@ export class AddAnimationDialog extends Adw.Dialog {
     this._editingId = existingAnimation?.id ?? null
 
     if (existingAnimation) {
-      this._frames = [...existingAnimation.frames]
+      // This dialog sequences sprite indices with one uniform duration;
+      // unpack the per-frame shape into indices + the first frame's ms.
+      this._frames = existingAnimation.frames.map((f) => f.spriteId)
       this._name_row.set_text(existingAnimation.id)
-      this._duration_row.set_value(existingAnimation.durationMs)
+      this._duration_row.set_value(existingAnimation.frames[0]?.duration ?? 200)
       const isRequiredRole = (REQUIRED_ROLES as readonly string[]).includes(existingAnimation.id)
       this._name_row.set_sensitive(!isRequiredRole)
       this.set_title(_('Edit animation'))
@@ -536,10 +538,12 @@ export class AddAnimationDialog extends Adw.Dialog {
   private _buildAnimation(): CharacterAnimation | null {
     const name = this._name_row.get_text().trim()
     if (!name || this._frames.length === 0) return null
+    // Apply the single dialog duration uniformly across the sequenced
+    // frames (per-frame tuning happens in the timeline editor).
+    const duration = Math.round(this._duration_row.get_value())
     return {
       id: name,
-      frames: [...this._frames],
-      durationMs: Math.round(this._duration_row.get_value()),
+      frames: this._frames.map((spriteId) => ({ spriteId, duration })),
     }
   }
 }

--- a/packages/gjs/src/widgets/cast/animation-list.ts
+++ b/packages/gjs/src/widgets/cast/animation-list.ts
@@ -158,10 +158,11 @@ export class AnimationList extends Adw.Bin {
     row.add_prefix(prefix)
 
     if (anim) {
+      const totalMs = anim.frames.reduce((sum, f) => sum + f.duration, 0)
       const subtitle =
         anim.frames.length === 0
           ? _('No frames')
-          : `${anim.frames.length} ${anim.frames.length === 1 ? _('frame') : _('frames')} · ${anim.durationMs} ms`
+          : `${anim.frames.length} ${anim.frames.length === 1 ? _('frame') : _('frames')} · ${totalMs} ms`
       row.set_subtitle(subtitle)
     } else {
       row.set_subtitle(_('Not configured'))
@@ -235,7 +236,7 @@ export class AnimationList extends Adw.Bin {
     })
     const visible = Math.min(anim.frames.length, ROW_THUMBNAIL_CAP)
     for (let i = 0; i < visible; i++) {
-      const spriteId = anim.frames[i]
+      const spriteId = anim.frames[i].spriteId
       const sprite = this._spriteSet?.getSprite(spriteId) ?? null
       const paintable = sprite?.createPaintable({ keepAspectRatio: true }) ?? null
       const picture = new Gtk.Picture({

--- a/packages/gjs/src/widgets/cast/cast-inspector.ts
+++ b/packages/gjs/src/widgets/cast/cast-inspector.ts
@@ -153,7 +153,9 @@ export class CastInspector extends Adw.Bin {
     try {
       if (animation) {
         this._selected_anim_row.set_subtitle(animation.id)
-        this._duration_row.set_value(animation.durationMs)
+        // Sheet-mode duration row is a single value; per-frame durations
+        // are edited in the timeline editor. Show the first frame's ms.
+        this._duration_row.set_value(animation.frames[0]?.duration ?? 200)
         this._duration_row.set_sensitive(true)
       } else {
         this._selected_anim_row.set_subtitle('(none selected)')

--- a/packages/gjs/src/widgets/cast/character-preview.ts
+++ b/packages/gjs/src/widgets/cast/character-preview.ts
@@ -20,8 +20,8 @@ const DIRECTION_CYCLE_MS = 1600
 /**
  * Animated preview of a {@link CharacterDefinition}'s sprite. Plays the
  * `<kind>-<direction>` animation for the currently-selected direction
- * (default: `walk-down`), driven by a JS interval keyed off
- * `durationMs`. Four direction-pad buttons set the facing, a fifth
+ * (default: `walk-down`), driven by a JS interval keyed off the
+ * animation's frame durations. Four direction-pad buttons set the facing, a fifth
  * Pause toggle flips the kind between `walk` and `idle` — so the same
  * arrow stays selected while the character switches from walking to
  * standing still.
@@ -510,7 +510,7 @@ export class CharacterPreview extends Adw.Bin {
       this._picture.set_paintable(null)
       return
     }
-    const spriteId = anim.frames[this._frameIndex % anim.frames.length]
+    const spriteId = anim.frames[this._frameIndex % anim.frames.length].spriteId
     const sprite = this._spriteSet.getSprite(spriteId)
     // Single-sprite display → opt in to aspect-preserving snapshot. The
     // sprite-set's character cells are tall (e.g. scientist is 16×32),
@@ -524,7 +524,10 @@ export class CharacterPreview extends Adw.Bin {
   private _scheduleNext(): void {
     const anim = this._activeAnimation()
     if (!anim || anim.frames.length <= 1) return
-    const duration = Math.max(50, anim.durationMs)
+    // Frames now carry per-frame durations; the compact list preview
+    // ticks at the first frame's rate (migrated data is uniform). The
+    // per-frame-accurate playback lives in the timeline editor.
+    const duration = Math.max(50, anim.frames[0]?.duration ?? 200)
     this._timeoutId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, duration, () => {
       this._frameIndex = (this._frameIndex + 1) % anim.frames.length
       this._applyFrame()


### PR DESCRIPTION
Foundation for the animation timeline editor (`soll-anim-editor`): character animations move from a uniform per-animation duration to a per-frame duration, converging on the `AnimationFrame` shape that tile/object animations already use.

## What

- `CharacterAnimation.frames: number[] + durationMs` → `frames: AnimationFrame[]` (`{ spriteId, duration }`); `durationMs` dropped.
- Updated `buildCharacterAnimation` + every reader (character-preview, animation-list, cast-inspector, add-animation-dialog) and writer (`cast-controller.setAnimationDuration` now applies a uniform duration across frames; project-store role seed) + the placement-graphic spec fixture.
- Migrated all **5** `games/*/spritesets` files (each old frame index → `{ spriteId, duration }`), localized to the `characterAnimations` blocks. Pre-release format, no migration shims.
- Concept doc (`entity-and-appearance-model.md`) updated.

## Verified

- `gjsify foreach check` clean; engine **905** + maker **456** tests green; `check:specs` passes; full build OK.
- `grep durationMs` leaves only unrelated camera params + the apply-to-all callback param names.
- Runtime smoke: Cast view renders Scientist + Link previews from the new shape (animation build path exercised, no crash).

Pure data-model change — no UI behavior change. Unblocks the Cast master-detail + animation matrix/timeline PRs.

https://claude.ai/code/session_011B9ADCSnzUm3dXaPzbSBWe