### PR TITLE
feat(sheets): readable tile-grid thumbnails + search & sort

### DIFF
--- a/apps/maker-gjs/src/widgets/tiles-view.blp
+++ b/apps/maker-gjs/src/widgets/tiles-view.blp
@@ -164,6 +164,31 @@ template $TilesView : $PixelRpgResponsiveEditorView {
                     styles ["dim-label"]
                   }
 
+                  // Search + sort over the sheet cards (soll-sheets).
+                  Gtk.Box {
+                    orientation: horizontal;
+                    spacing: 8;
+
+                    Gtk.SearchEntry search_entry {
+                      placeholder-text: _("Search sheets…");
+                      hexpand: true;
+                    }
+
+                    Gtk.DropDown sort_dropdown {
+                      valign: center;
+                      tooltip-text: _("Sort tilesets");
+
+                      model: Gtk.StringList {
+                        strings [
+                          _("Default order"),
+                          _("Name"),
+                          _("Tile size"),
+                          _("Usage"),
+                        ]
+                      };
+                    }
+                  }
+
                   Gtk.Box gallery_header {
                     orientation: horizontal;
                     spacing: 8;

--- a/apps/maker-gjs/src/widgets/tiles-view.ts
+++ b/apps/maker-gjs/src/widgets/tiles-view.ts
@@ -24,10 +24,13 @@ import {
   type SpriteSetChoice,
   SpriteSetImportDialog,
   type SpriteSetImportResult,
+  TileGridThumbnail,
   TileInspector,
   TilePalette,
 } from '@pixelrpg/gjs'
 import { gettext as _ } from 'gettext'
+
+import { countMapUsers } from '../services/sprite-set-usage.ts'
 
 import { characterSpriteSetIds, isCharacterSpriteSet } from '../services/sprite-set-classification.ts'
 import { ResponsiveEditorView } from './responsive-editor-view.ts'
@@ -78,6 +81,8 @@ export class TilesView extends ResponsiveEditorView {
   declare _inspector: TileInspector
   declare _palette: TilePalette
   declare _tilesets_gallery: CardGallery
+  declare _search_entry: Gtk.SearchEntry
+  declare _sort_dropdown: Gtk.DropDown
   declare _nav: Adw.NavigationView
   declare _detail_page: Adw.NavigationPage
   // Responsive tile inspector. On desktop the inspector lives in the
@@ -112,6 +117,10 @@ export class TilesView extends ResponsiveEditorView {
 
   private signals = new SignalScope()
   private _spriteSets: TilesetEntry[] = []
+  /** tileset id → how many maps reference it (for the card's "used by K" line). */
+  private _mapUsage = new Map<string, number>()
+  private _search = ''
+  private _sort: 'default' | 'name' | 'size' | 'usage' = 'default'
   private _activeSpriteSetId: string | null = null
   private _selectedSpriteId: number | null = null
   // Which kind the quick-view + single gallery highlight currently reflect.
@@ -155,6 +164,8 @@ export class TilesView extends ResponsiveEditorView {
           'inspector',
           'palette',
           'tilesets_gallery',
+          'search_entry',
+          'sort_dropdown',
           'nav',
           'detail_page',
           'tile_split',
@@ -255,6 +266,15 @@ export class TilesView extends ResponsiveEditorView {
     super.vfunc_map()
     this.signals.connect(this._mode_rail, 'mode-changed', (_v: ModeRail, mode: string) => {
       this.emit('mode-changed', mode)
+    })
+    // Search + sort the tileset cards.
+    this.signals.connect(this._search_entry, 'search-changed', () => {
+      this._search = this._search_entry.get_text()
+      this._rebuildGallery()
+    })
+    this.signals.connect(this._sort_dropdown, 'notify::selected', () => {
+      this._sort = (['default', 'name', 'size', 'usage'] as const)[this._sort_dropdown.get_selected()] ?? 'default'
+      this._rebuildGallery()
     })
     this.signals.connect(this._tilesets_gallery, 'item-activated', (_v: CardGallery, id: string) => {
       this._selectTileset(id)
@@ -495,6 +515,7 @@ export class TilesView extends ResponsiveEditorView {
     const order = new Map((project.data?.spriteSets ?? []).map((ref, i) => [ref.id, i]))
     items.sort((a, b) => (order.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (order.get(b.id) ?? Number.MAX_SAFE_INTEGER))
     this._spriteSets = items
+    this._mapUsage = countMapUsers(project)
 
     // Keep the active selection if still present; otherwise fall back
     // to the first set.
@@ -566,9 +587,34 @@ export class TilesView extends ResponsiveEditorView {
   }
 
   private _rebuildGallery(): void {
-    this._tilesets_gallery.setItems(this._spriteSets.map((entry) => this._buildTilesetItem(entry)))
+    const entries = this._filteredSortedTilesets()
+    const byId = new Map(entries.map((e) => [e.id, e]))
+    this._tilesets_gallery.setItems(
+      entries.map((entry) => this._buildTilesetItem(entry)),
+      (item) => {
+        const entry = byId.get(item.id)
+        return entry ? this._buildTilesetPreview(entry) : null
+      },
+    )
     // Only one card across both galleries is lit — the active selection's.
     this._tilesets_gallery.setActiveId(this._activeKind === 'tileset' ? this._activeSpriteSetId : null)
+  }
+
+  /** Apply the search filter + sort order to the tileset list for the gallery. */
+  private _filteredSortedTilesets(): TilesetEntry[] {
+    const query = this._search.trim().toLowerCase()
+    const filtered = query
+      ? this._spriteSets.filter((e) => (e.resource.data?.name ?? e.id).toLowerCase().includes(query))
+      : [...this._spriteSets]
+    if (this._sort === 'name') {
+      filtered.sort((a, b) => (a.resource.data?.name ?? a.id).localeCompare(b.resource.data?.name ?? b.id))
+    } else if (this._sort === 'size') {
+      filtered.sort((a, b) => (b.resource.data?.spriteWidth ?? 0) - (a.resource.data?.spriteWidth ?? 0))
+    } else if (this._sort === 'usage') {
+      filtered.sort((a, b) => (this._mapUsage.get(b.id) ?? 0) - (this._mapUsage.get(a.id) ?? 0))
+    }
+    // 'default' keeps the project's sprite-set order (set in the hydrate).
+    return filtered
   }
 
   /**
@@ -579,16 +625,34 @@ export class TilesView extends ResponsiveEditorView {
    * only for project sets (built-ins have no files + can't be removed).
    */
   private _buildTilesetItem(entry: TilesetEntry): GalleryCardItem {
-    const count = entry.resource.data?.sprites?.length ?? 0
+    const data = entry.resource.data
+    const count = data?.sprites?.length ?? 0
+    const w = data?.spriteWidth ?? 0
+    const h = data?.spriteHeight ?? 0
+    const users = this._mapUsage.get(entry.id) ?? 0
+    // "N tiles · W×H · used by K maps" — surfaces the tile dimensions +
+    // where the set is used, right on the card (soll-sheets).
+    const parts = [count === 1 ? _('1 tile') : _(`${count} tiles`)]
+    if (w && h) parts.push(`${w}×${h}`)
+    parts.push(users === 1 ? _('used by 1 map') : _(`used by ${users} maps`))
     return {
       id: entry.id,
-      title: entry.resource.data?.name ?? entry.id,
-      subtitle: count === 1 ? _('1 tile') : _(`${count} tiles`),
-      paintable: entry.gdk?.createSheetThumbnail() ?? null,
+      title: data?.name ?? entry.id,
+      subtitle: parts.join(' · '),
+      // Tile-size chip.
+      badge: w ? _(`${w}px tiles`) : null,
       fallbackIcon: 'view-grid-symbolic',
       deletable: !isBuiltInSpriteSet(entry.id),
       renamable: !isBuiltInSpriteSet(entry.id),
     }
+  }
+
+  /** Representative tile-grid excerpt for a tileset card (soll-sheets). */
+  private _buildTilesetPreview(entry: TilesetEntry): Gtk.Widget | null {
+    if (!entry.gdk) return null
+    const thumb = new TileGridThumbnail()
+    thumb.setSpriteSet(entry.gdk, entry.resource.data?.columns ?? 6)
+    return thumb
   }
 
   /**

--- a/packages/gjs/src/widgets/tiles/index.ts
+++ b/packages/gjs/src/widgets/tiles/index.ts
@@ -1,1 +1,2 @@
+export * from './tile-grid-thumbnail'
 export * from './tile-inspector'

--- a/packages/gjs/src/widgets/tiles/tile-grid-thumbnail.ts
+++ b/packages/gjs/src/widgets/tiles/tile-grid-thumbnail.ts
@@ -1,0 +1,91 @@
+import Gdk from '@girs/gdk-4.0'
+import GObject from '@girs/gobject-2.0'
+import Graphene from '@girs/graphene-1.0'
+import Gtk from '@girs/gtk-4.0'
+
+import type { GdkSpriteSetResource } from '../../sprite/index.ts'
+
+/** Grid dimensions + cell size of the representative tileset excerpt. */
+const MAX_COLS = 6
+const MAX_ROWS = 4
+const CELL_PX = 24
+const GRID_ALPHA = 0.18
+
+/**
+ * A readable tileset thumbnail: a representative excerpt of the first
+ * few tiles laid out on a grid (soll-sheets), instead of the whole
+ * sheet downscaled to an unreadable strip. Each cell renders a real
+ * sprite's paintable at a uniform size with thin grid lines between —
+ * so a wide tileset still shows recognisable tiles at a legible scale.
+ *
+ * Drawn entirely in `vfunc_snapshot` (paintable snapshots + grid rects);
+ * no offscreen texture. Fed via {@link setSpriteSet}.
+ */
+export class TileGridThumbnail extends Gtk.Widget {
+  private _paintables: Gdk.Paintable[] = []
+  private _cols = MAX_COLS
+  private _rows = MAX_ROWS
+
+  static {
+    GObject.registerClass({ GTypeName: 'PixelRpgTileGridThumbnail' }, TileGridThumbnail)
+  }
+
+  constructor() {
+    super()
+    this.set_overflow(Gtk.Overflow.HIDDEN)
+  }
+
+  /**
+   * Populate from a sprite-set's first tiles. `columns` bounds the grid
+   * width so a narrow sheet doesn't render empty trailing cells.
+   */
+  setSpriteSet(resource: GdkSpriteSetResource | null, columns: number): void {
+    this._paintables = []
+    if (resource) {
+      this._cols = Math.max(1, Math.min(MAX_COLS, columns || MAX_COLS))
+      const max = this._cols * MAX_ROWS
+      for (let i = 0; i < max; i++) {
+        const sprite = resource.getSprite(i)
+        if (!sprite) break
+        this._paintables.push(sprite.createPaintable())
+      }
+      this._rows = Math.max(1, Math.min(MAX_ROWS, Math.ceil(this._paintables.length / this._cols)))
+    }
+    this.queue_resize()
+    this.queue_draw()
+  }
+
+  vfunc_measure(orientation: Gtk.Orientation, _forSize: number): [number, number, number, number] {
+    const size = orientation === Gtk.Orientation.HORIZONTAL ? this._cols * CELL_PX : this._rows * CELL_PX
+    return [size, size, -1, -1]
+  }
+
+  vfunc_snapshot(snapshot: Gtk.Snapshot): void {
+    const cols = this._cols
+    for (let i = 0; i < this._paintables.length; i++) {
+      const col = i % cols
+      const row = Math.floor(i / cols)
+      snapshot.save()
+      snapshot.translate(new Graphene.Point({ x: col * CELL_PX, y: row * CELL_PX }))
+      this._paintables[i].snapshot(snapshot, CELL_PX, CELL_PX)
+      snapshot.restore()
+    }
+    this._drawGrid(snapshot)
+  }
+
+  private _drawGrid(snapshot: Gtk.Snapshot): void {
+    const grid = new Gdk.RGBA()
+    grid.parse(`rgba(255,255,255,${GRID_ALPHA})`)
+    const w = this._cols * CELL_PX
+    const h = this._rows * CELL_PX
+    const line = (x: number, y: number, lw: number, lh: number) => {
+      const rect = new Graphene.Rect()
+      rect.init(x, y, lw, lh)
+      snapshot.append_color(grid, rect)
+    }
+    for (let c = 1; c < this._cols; c++) line(c * CELL_PX, 0, 1, h)
+    for (let r = 1; r < this._rows; r++) line(0, r * CELL_PX, w, 1)
+  }
+}
+
+GObject.type_ensure(TileGridThumbnail.$gtype)


### PR DESCRIPTION
Redesigns the Sheets tileset cards per `soll-sheets` — the thin-strip whole-sheet thumbnails become legible tile-grid excerpts.

## What

- **New `TileGridThumbnail`** — draws a representative excerpt of the first tiles (up to 6×4) at a uniform, readable cell size with thin grid lines, via `vfunc_snapshot` over the sprite paintables (no offscreen texture). Wide tilesets now show recognisable tiles instead of an unreadable downscaled strip.
- **Tile-size chip** ("8px tiles") + a richer subtitle **"N tiles · W×H · used by K maps"** (usage from `sprite-set-usage`'s `countMapUsers`).
- **Search entry + sort dropdown** (default / name / tile size / usage) that filter + order the tileset gallery.

## Verified

- `gjsify foreach check` clean; maker **456** tests green; full build OK; lint at the 1 pre-existing warning.
- Control D-Bus screenshot on `oot2d-2014` (19 tilesets): each card shows a gridded tile mosaic + "8px tiles" chip + "N tiles · 8×8 · used by…"; search + sort controls render above the gallery.

https://claude.ai/code/session_011B9ADCSnzUm3dXaPzbSBWe