### PR TITLE
feat(data): settings-only view with linked-asset references

### DIFF
--- a/apps/maker-gjs/src/services/data-controller.ts
+++ b/apps/maker-gjs/src/services/data-controller.ts
@@ -1,43 +1,36 @@
-import { EDITOR_CONSTANTS, type SpriteSetData, type SpriteSetKind, type SpriteSetResource } from '@pixelrpg/engine'
-import { GdkSpriteSetResource } from '@pixelrpg/gjs'
-import { gettext as _ } from 'gettext'
+import { EDITOR_CONSTANTS, type SpriteSetKind } from '@pixelrpg/engine'
 
 // biome-ignore lint/suspicious/noShadowRestrictedNames: GTK view-class naming convention (CastView/TilesView/DataView); the JS DataView global is unused in this app
-import type { DataAssetRow, DataView, DataViewModel } from '../widgets/data-view.ts'
+import type { DataView, DataViewModel } from '../widgets/data-view.ts'
 import type { ProjectStore } from './project-store.ts'
 import { isCharacterSpriteSet } from './sprite-set-classification.ts'
-import { countCharacterUsers, countMapUsers } from './sprite-set-usage.ts'
+import { countCharacterUsers } from './sprite-set-usage.ts'
 import { TypedEmitter } from './typed-emitter.ts'
 
-/** Thumbnail edge passed to the sheet downscaler (≥ the row size, for sharpness). */
-const THUMB_PX = 96
-
 /**
- * Typed event map for {@link DataController.on} — asset actions the
- * host window resolves (dialogs + cross-view navigation; this
- * controller stays dialog-free).
+ * Typed event map for {@link DataController.on}. The Data view no longer
+ * manages assets (that moved to Cast / Sheets — it just references them),
+ * so these are currently dormant; kept as the seam for any future
+ * project-level action the Data view might route to the host window.
+ * TODO: remove once confirmed no consumer needs them (also drop the
+ * window's now-inert `_presentAssetImport`/`_openAsset`/`_presentRenameAsset`/
+ * `_presentDeleteAsset` handlers + their subscriptions).
  */
 export interface DataControllerEvents {
-  /** The user asked to import an asset of `kind` (file-picker dialog). */
   'import-requested': { kind: SpriteSetKind }
-  /** The user asked to open an asset in its editor (the Sheets view). */
   'open-requested': { id: string; kind: SpriteSetKind }
-  /** The user asked to rename an asset (rename dialog). */
   'rename-requested': { id: string; currentName: string }
-  /** The user asked to delete an asset (usage-aware confirm dialog). */
   'delete-requested': { id: string; name: string; usedBy: number }
 }
 
 /**
- * Owns the Data view's "Assets and project" model: builds the asset
- * list (sprite sheets + tilesets, each with a thumbnail, metadata and a
- * "used by" count from the reference graph) and routes project-metadata
- * edits into the {@link ProjectStore} — the single owner of project
- * persistence + the `__project/meta.update` collab broadcast. Asset
- * import / delete / rename / "open" need host dialogs, so they surface
- * as typed events the window subscribes to; the resulting mutations
- * land on the store, whose `sprite-sets-changed` /
- * `project-meta-changed` events re-hydrate this view.
+ * Owns the Data view's model: project metadata (name / author / version /
+ * description / tile size) routed into the {@link ProjectStore} (the
+ * single owner of project persistence + the `__project/meta.update` collab
+ * broadcast), plus asset COUNTS for the "Linked assets" reference rows.
+ * Assets themselves are owned + edited in Cast / Sheets — Data only links
+ * to them. The store's `sprite-sets-changed` / `project-meta-changed`
+ * events re-hydrate this view.
  */
 export class DataController {
   private readonly _events = new TypedEmitter<DataControllerEvents>()
@@ -47,10 +40,6 @@ export class DataController {
     private readonly store: ProjectStore,
   ) {
     view.bindCallbacks({
-      importAsset: (kind) => this._events.emit('import-requested', { kind }),
-      openAsset: (id, kind) => this._events.emit('open-requested', { id, kind }),
-      renameAsset: (id, currentName) => this._events.emit('rename-requested', { id, currentName }),
-      deleteAsset: (id, name, usedBy) => this._events.emit('delete-requested', { id, name, usedBy }),
       setProjectField: (field, value) => this.setProjectField(field, value),
     })
     store.on('project-changed', (project) => {
@@ -58,16 +47,16 @@ export class DataController {
         this.view.setData(null)
         return
       }
-      void this._rebuild()
+      this._rebuild()
     })
-    // The asset list mirrors the sprite-set library — re-hydrate on any
-    // set change; an inbound peer meta update re-renders the metadata
-    // rows (local edits don't, by design — no row re-render mid-typing).
+    // The counts mirror the sprite-set library — re-hydrate on any set
+    // change; an inbound peer meta update re-renders the metadata rows
+    // (local edits don't, by design — no row re-render mid-typing).
     store.on('sprite-sets-changed', () => {
-      if (this.store.project) void this._rebuild()
+      if (this.store.project) this._rebuild()
     })
     store.on('project-meta-changed', () => {
-      if (this.store.project) void this._rebuild()
+      if (this.store.project) this._rebuild()
     })
   }
 
@@ -107,8 +96,13 @@ export class DataController {
     this.store.commitProjectMeta()
   }
 
-  /** Rebuild the whole view model: project metadata + asset rows + usage. */
-  private async _rebuild(): Promise<void> {
+  /**
+   * Rebuild the view model: project metadata + asset COUNTS. Assets are
+   * owned + edited in Cast / Sheets; Data only references them, so this
+   * just tallies how many appearances vs tilesets exist (classified the
+   * same way the Cast/Sheets split does).
+   */
+  private _rebuild(): void {
     const resource = this.store.resource
     if (!resource?.data) {
       this.view.setData(null)
@@ -118,27 +112,14 @@ export class DataController {
     const props = data.properties ?? {}
 
     const charUsers = countCharacterUsers(resource)
-    const mapUsers = countMapUsers(resource)
-
-    const sheets: DataAssetRow[] = []
-    const tilesets: DataAssetRow[] = []
+    let appearanceCount = 0
+    let tilesetCount = 0
     for (const [id, engineSet] of resource.spriteSets) {
       const sd = engineSet.data
       if (!sd) continue
-      const usedByChars = charUsers.get(id) ?? 0
-      const isCharacter = isCharacterSpriteSet(sd.kind, usedByChars > 0)
-      const row = await this._buildRow(
-        id,
-        engineSet,
-        sd,
-        isCharacter ? 'character' : 'tileset',
-        usedByChars,
-        mapUsers.get(id) ?? 0,
-      )
-      ;(isCharacter ? sheets : tilesets).push(row)
+      if (isCharacterSpriteSet(sd.kind, (charUsers.get(id) ?? 0) > 0)) appearanceCount++
+      else tilesetCount++
     }
-    sheets.sort((a, b) => a.name.localeCompare(b.name))
-    tilesets.sort((a, b) => a.name.localeCompare(b.name))
 
     const model: DataViewModel = {
       name: data.name ?? '',
@@ -147,42 +128,9 @@ export class DataController {
       description: typeof props.description === 'string' ? props.description : '',
       tileSize: typeof props.defaultTileSize === 'number' ? props.defaultTileSize : EDITOR_CONSTANTS.DEFAULT_TILE_SIZE,
       path: resource.path,
-      sheets,
-      tilesets,
+      appearanceCount,
+      tilesetCount,
     }
     this.view.setData(model)
-  }
-
-  private async _buildRow(
-    id: string,
-    engineSet: SpriteSetResource,
-    sd: SpriteSetData,
-    kind: SpriteSetKind,
-    usedByChars: number,
-    usedByMaps: number,
-  ): Promise<DataAssetRow> {
-    const width = sd.columns * sd.spriteWidth
-    const height = sd.rows * sd.spriteHeight
-    const count = sd.sprites?.length ?? 0
-    const unit =
-      kind === 'character' ? (count === 1 ? _('sprite') : _('sprites')) : count === 1 ? _('tile') : _('tiles')
-    let paintable = null
-    try {
-      const gdk = await GdkSpriteSetResource.fromEngineResource(engineSet)
-      paintable =
-        kind === 'character'
-          ? (gdk.getSprite(0)?.createPaintable({ keepAspectRatio: true }) ?? null)
-          : gdk.createSheetThumbnail(THUMB_PX)
-    } catch (err) {
-      console.warn('[DataController] Failed to build asset thumbnail:', err)
-    }
-    return {
-      id,
-      name: sd.name || id,
-      kind,
-      paintable,
-      meta: `${width}×${height} · ${count} ${unit}`,
-      usedBy: usedByChars + usedByMaps,
-    }
   }
 }

--- a/apps/maker-gjs/src/widgets/data-view.blp
+++ b/apps/maker-gjs/src/widgets/data-view.blp
@@ -45,7 +45,7 @@ template $PixelRpgDataView : $PixelRpgResponsiveEditorView {
 
         Adw.PreferencesGroup {
           title: _("Project");
-          description: _("Project-wide settings saved into game-project.json.");
+          description: _("Settings saved into game-project.json.");
 
           Adw.EntryRow name_row {
             show-apply-button: true;
@@ -66,6 +66,10 @@ template $PixelRpgDataView : $PixelRpgResponsiveEditorView {
             show-apply-button: true;
             title: _("Description");
           }
+        }
+
+        Adw.PreferencesGroup {
+          title: _("Tile settings");
 
           Adw.SpinRow tilesize_row {
             title: _("Default tile size");
@@ -85,28 +89,36 @@ template $PixelRpgDataView : $PixelRpgResponsiveEditorView {
           }
         }
 
-        Adw.PreferencesGroup sheets_group {
-          title: _("Appearances");
-          description: _("Character animation sheets used by the Cast.");
+        // Assets are OWNED + edited in Cast / Sheets — Data only links to
+        // them (no duplicated import/rename/delete here). Suffix links jump
+        // to the managing view (soll-data).
+        Adw.PreferencesGroup {
+          title: _("Linked assets");
+          description: _("Managed in the Cast and Sheets views — Data just references them.");
 
-          header-suffix: Gtk.Button import_sheet_button {
-            valign: center;
-            icon-name: "list-add-symbolic";
-            tooltip-text: _("Import an appearance from an image");
-            styles ["flat", "circular"]
-          };
-        }
+          Adw.ActionRow appearances_ref_row {
+            title: _("Appearances");
+            activatable-widget: appearances_open_button;
 
-        Adw.PreferencesGroup tilesets_group {
-          title: _("Tilesets");
-          description: _("World-building tile images used by the map editor.");
+            [suffix]
+            Gtk.Button appearances_open_button {
+              valign: center;
+              label: _("Open in Cast");
+              styles ["flat"]
+            }
+          }
 
-          header-suffix: Gtk.Button import_tileset_button {
-            valign: center;
-            icon-name: "list-add-symbolic";
-            tooltip-text: _("Import a tileset from an image");
-            styles ["flat", "circular"]
-          };
+          Adw.ActionRow tilesets_ref_row {
+            title: _("Tilesets");
+            activatable-widget: tilesets_open_button;
+
+            [suffix]
+            Gtk.Button tilesets_open_button {
+              valign: center;
+              label: _("Open in Sheets");
+              styles ["flat"]
+            }
+          }
         }
       };
     };

--- a/apps/maker-gjs/src/widgets/data-view.ts
+++ b/apps/maker-gjs/src/widgets/data-view.ts
@@ -1,29 +1,18 @@
-import Adw from '@girs/adw-1'
-import type Gdk from '@girs/gdk-4.0'
-import Gio from '@girs/gio-2.0'
+import type Adw from '@girs/adw-1'
+import GLib from '@girs/glib-2.0'
 import GObject from '@girs/gobject-2.0'
-import Gtk from '@girs/gtk-4.0'
-import type { SpriteSetKind } from '@pixelrpg/engine'
+import type Gtk from '@girs/gtk-4.0'
 import { type ModeRail, SignalScope } from '@pixelrpg/gjs'
 import { gettext as _ } from 'gettext'
 
 import Template from './data-view.blp'
 import { ResponsiveEditorView } from './responsive-editor-view.ts'
 
-/** One asset (sprite sheet or tileset) as a management row. */
-export interface DataAssetRow {
-  id: string
-  name: string
-  kind: SpriteSetKind
-  /** Bounded thumbnail (first sprite for sheets, downscaled sheet for tilesets). */
-  paintable: Gdk.Paintable | null
-  /** e.g. "320×32 · 20 sprites". */
-  meta: string
-  /** How many characters/maps reference it — 0 ⇒ orphan. */
-  usedBy: number
-}
-
-/** The whole Data-view model the controller pushes in one shot. */
+/**
+ * The whole Data-view model the controller pushes in one shot. Assets are
+ * summarised as COUNTS only — they're owned + edited in Cast / Sheets, so
+ * Data references them rather than duplicating the management surface.
+ */
 export interface DataViewModel {
   name: string
   author: string
@@ -31,27 +20,21 @@ export interface DataViewModel {
   description: string
   tileSize: number
   path: string
-  sheets: DataAssetRow[]
-  tilesets: DataAssetRow[]
+  appearanceCount: number
+  tilesetCount: number
 }
 
 export interface DataViewCallbacks {
-  importAsset: (kind: SpriteSetKind) => void
-  openAsset: (id: string, kind: SpriteSetKind) => void
-  renameAsset: (id: string, currentName: string) => void
-  deleteAsset: (id: string, name: string, usedBy: number) => void
   setProjectField: (field: 'name' | 'author' | 'version' | 'description' | 'tileSize', value: string) => void
 }
 
-const THUMB_SIZE = 44
-
 /**
- * Data view — the project's "Assets and project" surface. A management
- * list (Adwaita rows grouped by type) of every imported sprite sheet +
- * tileset, each with a thumbnail, metadata, a "used by" count (orphans
- * flagged) and a ⋯ menu (open / rename / delete), plus editable
- * project metadata. Complements the visual Cast/Tiles galleries — same
- * assets, file/management angle. See `data-controller.ts` for the data.
+ * Data view — the project's settings surface. Editable project metadata
+ * (name / author / version / description) + tile settings, plus a
+ * "Linked assets" group that just *references* the appearances (Cast) and
+ * tilesets (Sheets) with a count + a jump-to-managing-view link. The
+ * assets themselves are owned + edited in those views — Data no longer
+ * duplicates the import/rename/delete surface. See `data-controller.ts`.
  */
 // biome-ignore lint/suspicious/noShadowRestrictedNames: GTK view-class naming convention (CastView/TilesView/DataView); the JS DataView global is unused in this app
 export class DataView extends ResponsiveEditorView {
@@ -63,18 +46,16 @@ export class DataView extends ResponsiveEditorView {
   declare _description_row: Adw.EntryRow
   declare _tilesize_row: Adw.SpinRow
   declare _path_row: Adw.ActionRow
-  declare _sheets_group: Adw.PreferencesGroup
-  declare _tilesets_group: Adw.PreferencesGroup
-  declare _import_sheet_button: Gtk.Button
-  declare _import_tileset_button: Gtk.Button
+  declare _appearances_ref_row: Adw.ActionRow
+  declare _tilesets_ref_row: Adw.ActionRow
+  declare _appearances_open_button: Gtk.Button
+  declare _tilesets_open_button: Gtk.Button
 
   private signals = new SignalScope()
   private _callbacks: DataViewCallbacks | null = null
   // True while `setData` writes the row texts, so the `notify`/`apply`
   // handlers don't fire the edit callbacks back during a refresh.
   private _loading = false
-  private _sheetRows: Adw.ActionRow[] = []
-  private _tilesetRows: Adw.ActionRow[] = []
 
   static {
     GObject.registerClass(
@@ -91,10 +72,10 @@ export class DataView extends ResponsiveEditorView {
           'description_row',
           'tilesize_row',
           'path_row',
-          'sheets_group',
-          'tilesets_group',
-          'import_sheet_button',
-          'import_tileset_button',
+          'appearances_ref_row',
+          'tilesets_ref_row',
+          'appearances_open_button',
+          'tilesets_open_button',
         ],
         // show-library / library-collapsed (+ inspector) props + the
         // mode-changed signal are inherited from ResponsiveEditorView.
@@ -111,8 +92,13 @@ export class DataView extends ResponsiveEditorView {
     this.signals.connect(this._mode_rail, 'mode-changed', (_r: ModeRail, mode: string) =>
       this.emit('mode-changed', mode),
     )
-    this.signals.connect(this._import_sheet_button, 'clicked', () => this._callbacks?.importAsset('character'))
-    this.signals.connect(this._import_tileset_button, 'clicked', () => this._callbacks?.importAsset('tileset'))
+    // Reference links jump to the view that OWNS the asset type.
+    this.signals.connect(this._appearances_open_button, 'clicked', () =>
+      this.activate_action('win.mode', GLib.Variant.new_string('cast')),
+    )
+    this.signals.connect(this._tilesets_open_button, 'clicked', () =>
+      this.activate_action('win.mode', GLib.Variant.new_string('tiles')),
+    )
 
     this.signals.connect(this._name_row, 'apply', () => this._emitField('name', this._name_row.get_text()))
     this.signals.connect(this._author_row, 'apply', () => this._emitField('author', this._author_row.get_text()))
@@ -162,85 +148,18 @@ export class DataView extends ResponsiveEditorView {
     ]) {
       row.set_sensitive(sensitive)
     }
-    this._import_sheet_button.set_sensitive(sensitive)
-    this._import_tileset_button.set_sensitive(sensitive)
 
-    this._rebuild(this._sheets_group, this._sheetRows, model?.sheets ?? [], _('No appearances yet.'))
-    this._rebuild(this._tilesets_group, this._tilesetRows, model?.tilesets ?? [], _('No tilesets yet.'))
-  }
-
-  private _rebuild(
-    group: Adw.PreferencesGroup,
-    tracked: Adw.ActionRow[],
-    rows: DataAssetRow[],
-    emptyText: string,
-  ): void {
-    for (const row of tracked) group.remove(row)
-    tracked.length = 0
-    if (rows.length === 0) {
-      const empty = new Adw.ActionRow({ title: emptyText, sensitive: false })
-      group.add(empty)
-      tracked.push(empty)
-      return
-    }
-    for (const model of rows) {
-      const row = this._buildAssetRow(model)
-      group.add(row)
-      tracked.push(row)
-    }
-  }
-
-  private _buildAssetRow(model: DataAssetRow): Adw.ActionRow {
-    const usedLabel = model.usedBy === 0 ? _('unused') : `${_('used by')} ${model.usedBy}`
-    const row = new Adw.ActionRow({
-      title: model.name,
-      subtitle: `${model.meta} · ${usedLabel}`,
-    })
-    if (model.usedBy === 0) row.add_css_class('dim-label')
-
-    // Bounded thumbnail prefix (paintable is already small/downscaled).
-    if (model.paintable) {
-      const picture = new Gtk.Picture({
-        contentFit: Gtk.ContentFit.CONTAIN,
-        canShrink: true,
-        widthRequest: THUMB_SIZE,
-        heightRequest: THUMB_SIZE,
-        valign: Gtk.Align.CENTER,
-      })
-      picture.set_paintable(model.paintable)
-      row.add_prefix(picture)
-    } else {
-      row.add_prefix(new Gtk.Image({ iconName: 'image-x-generic-symbolic', pixelSize: 24 }))
-    }
-
-    // Per-row ⋯ menu: Open / Rename / Delete.
-    const actions = new Gio.SimpleActionGroup()
-    const open = new Gio.SimpleAction({ name: 'open' })
-    open.connect('activate', () => this._callbacks?.openAsset(model.id, model.kind))
-    actions.add_action(open)
-    const rename = new Gio.SimpleAction({ name: 'rename' })
-    rename.connect('activate', () => this._callbacks?.renameAsset(model.id, model.name))
-    actions.add_action(rename)
-    const del = new Gio.SimpleAction({ name: 'delete' })
-    del.connect('activate', () => this._callbacks?.deleteAsset(model.id, model.name, model.usedBy))
-    actions.add_action(del)
-    row.insert_action_group('asset', actions)
-
-    const menu = new Gio.Menu()
-    menu.append(_('Open'), 'asset.open')
-    menu.append(_('Rename…'), 'asset.rename')
-    menu.append(_('Delete…'), 'asset.delete')
-    const menuButton = new Gtk.MenuButton({
-      iconName: 'view-more-symbolic',
-      tooltipText: _('Asset actions'),
-      valign: Gtk.Align.CENTER,
-      menuModel: menu,
-      cssClasses: ['flat'],
-    })
-    row.add_suffix(menuButton)
-    row.set_activatable_widget(menuButton)
-
-    return row
+    // Reference-row subtitles: how many + where they're managed.
+    const appearances = model?.appearanceCount ?? 0
+    const tilesets = model?.tilesetCount ?? 0
+    this._appearances_ref_row.set_subtitle(
+      appearances === 1 ? _('1 appearance · used by the Cast') : _(`${appearances} appearances · used by the Cast`),
+    )
+    this._tilesets_ref_row.set_subtitle(
+      tilesets === 1 ? _('1 tileset · used by maps') : _(`${tilesets} tilesets · used by maps`),
+    )
+    this._appearances_open_button.set_sensitive(sensitive)
+    this._tilesets_open_button.set_sensitive(sensitive)
   }
 }
 


### PR DESCRIPTION
Reworks the Data view per `soll-data`: it becomes project **settings only**, with assets shown as references to where they're actually managed — no duplicated import/rename/delete surface.

## What

- **Removed** the per-asset management rows (thumbnail · metadata · ⋯ open/rename/delete) + the import buttons that duplicated Cast/Sheets.
- **Linked assets** group instead: **Appearances** and **Tilesets** reference rows with a live count + a jump link — **Open in Cast** / **Open in Sheets** (`win.mode`). The assets are owned + edited in those views.
- Settings regrouped into **Project** (name / author / version / description) + **Tile settings** (default tile size + project file).
- `DataController` drops the async thumbnail row-building in favour of simple counts.

## Verified

- `gjsify foreach check` clean; maker **456** tests green; build OK; lint at the 1 pre-existing warning.
- Control D-Bus screenshot on `zelda-like`: Project + Tile settings + Linked assets ("2 appearances · used by the Cast" → Open in Cast; "4 tilesets · used by maps" → Open in Sheets). No duplicated editors.

## Notes

- The old `DataController` asset-dialog event path + the window's `_presentAssetImport`/`_openAsset`/`_presentRenameAsset`/`_presentDeleteAsset` handlers are now **inert** (no UI triggers them); left in place to keep this PR contained, with a TODO to remove them.
- The design's left anchor-nav is omitted — after the dedup the page is three short groups that fit without scrolling, so it adds little.

https://claude.ai/code/session_011B9ADCSnzUm3dXaPzbSBWe