### PR TITLE
feat(objects): deliberate empty-state with relationship diagram

### DIFF
--- a/apps/maker-gjs/src/application.css
+++ b/apps/maker-gjs/src/application.css
@@ -2,4 +2,5 @@
 @import "./widgets/application-window.css";
 @import "./widgets/atlas-view.css";
 @import "./widgets/cast-view.css";
+@import "./widgets/objects-view.css";
 @import "./widgets/tiles-view.css";

--- a/apps/maker-gjs/src/widgets/objects-view.blp
+++ b/apps/maker-gjs/src/widgets/objects-view.blp
@@ -70,10 +70,48 @@ template $ObjectsView : $PixelRpgResponsiveEditorView {
                 Gtk.StackPage {
                   name: "empty";
 
-                  child: Adw.StatusPage {
-                    icon-name: "view-grid-symbolic";
-                    title: _("No objects yet");
-                    description: _("Create reusable NPCs, items, teleports and events from a template.");
+                  // Deliberate empty-state (soll-objects): what objects are
+                  // (the Sheets → Cast → Objects relationship diagram) + a
+                  // row of template tiles to create one. The diagram + tiles
+                  // are built in objects-view.ts and dropped into the slots.
+                  child: Gtk.Box {
+                    orientation: vertical;
+                    spacing: 24;
+                    valign: center;
+
+                    Adw.StatusPage {
+                      icon-name: "view-grid-symbolic";
+                      title: _("No objects yet");
+                      description: _("Objects are the placeable things in your scenes — chests, signs, doors, triggers. Build one from a template, then drop it onto any map.");
+                      vexpand: false;
+                    }
+
+                    Gtk.Box empty_diagram_slot {
+                      orientation: horizontal;
+                      halign: center;
+                    }
+
+                    Gtk.Box {
+                      orientation: vertical;
+                      spacing: 8;
+                      halign: center;
+
+                      Gtk.Label {
+                        label: _("Start from a template");
+                        halign: center;
+                        styles ["caption-heading", "dim-label"]
+                      }
+
+                      Gtk.FlowBox empty_templates {
+                        selection-mode: none;
+                        halign: center;
+                        min-children-per-line: 2;
+                        max-children-per-line: 4;
+                        column-spacing: 8;
+                        row-spacing: 8;
+                        homogeneous: true;
+                      }
+                    }
                   };
                 }
 

--- a/apps/maker-gjs/src/widgets/objects-view.css
+++ b/apps/maker-gjs/src/widgets/objects-view.css
@@ -1,0 +1,19 @@
+/*
+ * Objects empty-state (soll-objects): the Sheets → Cast → Objects
+ * relationship diagram chips + the template tiles.
+ */
+.objects-rel-chip {
+  padding: 10px 16px;
+  min-width: 96px;
+}
+
+.objects-rel-accent {
+  background-color: alpha(@accent_bg_color, 0.15);
+  box-shadow: inset 0 0 0 1px @accent_bg_color;
+}
+
+.objects-template-tile {
+  border: 1px dashed alpha(@window_fg_color, 0.25);
+  border-radius: 10px;
+  padding: 8px 16px;
+}

--- a/apps/maker-gjs/src/widgets/objects-view.ts
+++ b/apps/maker-gjs/src/widgets/objects-view.ts
@@ -31,6 +31,8 @@ export class ObjectsView extends ResponsiveEditorView {
   declare _new_object_button: Gtk.Button
   declare _list_stack: Gtk.Stack
   declare _objects_list: Gtk.ListBox
+  declare _empty_diagram_slot: Gtk.Box
+  declare _empty_templates: Gtk.FlowBox
   declare _detail_page: Adw.NavigationPage
   declare _delete_button: Gtk.Button
   declare _detail_slot: Gtk.Box
@@ -57,6 +59,8 @@ export class ObjectsView extends ResponsiveEditorView {
           'new_object_button',
           'list_stack',
           'objects_list',
+          'empty_diagram_slot',
+          'empty_templates',
           'detail_page',
           'delete_button',
           'detail_slot',
@@ -97,6 +101,56 @@ export class ObjectsView extends ResponsiveEditorView {
     this._editor = new EntityComponentsEditor()
     this._detail_slot.append(nameGroup)
     this._detail_slot.append(this._editor)
+
+    this._buildEmptyState()
+  }
+
+  /**
+   * Populate the empty-state's relationship diagram (Sheets → Cast →
+   * Objects) + the template tiles (chest / sign / door / trigger). The
+   * tiles reuse the same `object-create-requested` path as the "New
+   * object" chooser (soll-objects).
+   */
+  private _buildEmptyState(): void {
+    // Relationship diagram — Sheets (art) → Cast (characters) → Objects.
+    const chips: [string, string, boolean][] = [
+      [_('Sheets'), _('art'), false],
+      [_('Cast'), _('characters'), false],
+      [_('Objects'), _('placed in scenes'), true],
+    ]
+    chips.forEach(([title, sub, accent], i) => {
+      if (i > 0) {
+        this._empty_diagram_slot.append(
+          new Gtk.Image({
+            iconName: 'go-next-symbolic',
+            cssClasses: ['dim-label'],
+            valign: Gtk.Align.CENTER,
+            marginStart: 8,
+            marginEnd: 8,
+          }),
+        )
+      }
+      const chip = new Gtk.Box({
+        orientation: Gtk.Orientation.VERTICAL,
+        cssClasses: accent ? ['card', 'objects-rel-chip', 'objects-rel-accent'] : ['card', 'objects-rel-chip'],
+      })
+      chip.append(new Gtk.Label({ label: title, cssClasses: accent ? ['heading', 'accent'] : ['heading'] }))
+      chip.append(new Gtk.Label({ label: sub, cssClasses: ['caption', 'dim-label'] }))
+      this._empty_diagram_slot.append(chip)
+    })
+
+    // Template tiles — the placeable-object archetypes.
+    for (const id of ['chest', 'sign', 'door', 'trigger']) {
+      const template = ENTITY_TEMPLATES.find((t) => t.id === id)
+      if (!template) continue
+      const button = new Gtk.Button({ cssClasses: ['flat', 'objects-template-tile'] })
+      const row = new Gtk.Box({ orientation: Gtk.Orientation.HORIZONTAL, spacing: 8 })
+      row.append(new Gtk.Image({ iconName: template.icon }))
+      row.append(new Gtk.Label({ label: template.label }))
+      button.set_child(row)
+      button.connect('clicked', () => this.emit('object-create-requested', template.id))
+      this._empty_templates.append(button)
+    }
   }
 
   vfunc_map(): void {


### PR DESCRIPTION
Redesigns the Objects empty-state per `soll-objects` — from a bare status page into an onboarding surface.

## What

- Explains what objects are (chests / signs / doors / triggers).
- A **Sheets → Cast → Objects** relationship diagram (Objects accented) showing where art + characters come from.
- **Template tiles** (Chest / Sign / Door / Trigger) that create a library entry via the existing `object-create-requested` path (same as the "New object" chooser).

## Verified

- `gjsify foreach check` clean; maker **456** tests green; build OK; lint at the 1 pre-existing warning.
- Control D-Bus screenshot on an empty-library project: "No objects yet" + the diagram + the four template tiles — matches the artboard.

Depends on #259 (event action-list model, merged). Completes the visual `soll-objects`; the friendly per-action `EventActionListEditor` (vs the current JSON row) + the runtime `EventActionSystem` remain (TODO / PR6b).

https://claude.ai/code/session_011B9ADCSnzUm3dXaPzbSBWe