### PR TITLE
feat(runtime): hide editor placement chrome during playtest

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,7 +39,7 @@ Conventions:
 - **Engine canvas transparency** — `Gtk.GLArea` `has_alpha(true)` + `Color.Transparent` clear + `.engine-canvas` CSS — all three failed on this stack. Report filed at `../../gjsify/docs/reports/webgl-bridge-resize-observer.md` (also covers the resize issue). *owner: gjsify, blocked: external release*
 - **`FillContainer` resize** — switching to `DisplayMode.FillContainer` is in but Excalibur's `ResizeObserver(parent)` never fires on this stack. Same handoff report. *owner: gjsify, blocked: external release*
 
-- **Play-mode presentation gaps (found building the zelda-like teleport loop)** — (a) editor placement chrome (spawn-point / teleport marker frames) stays visible while playing; runtime mode should hide editor-only markers. (b) entering play does not snap the camera to the player until the first movement — on a small interior map the room can sit off-centre (or off-screen entirely before the map had a spawn-point). (c) scene chrome (inspector tabs, scene title) stays on the previous scene when a teleport switches maps mid-play. *owner: engine + maker*
+- **Play-mode presentation gaps (found building the zelda-like teleport loop)** — (a) DONE: entering play now drops the editor placement chrome (cell frames + spawn-point/teleport/trigger diamond markers) via `SceneEditor.refreshPlacementGraphicsForMode` on `setRuntimeMode`; editor restores it. Remaining: (b) entering play does not snap the camera to the player until the first movement — on a small interior map the room can sit off-centre (or off-screen entirely before the map had a spawn-point). (c) scene chrome (inspector tabs, scene title) stays on the previous scene when a teleport switches maps mid-play. *owner: engine + maker*
 
 ## Atlas / world
 

--- a/packages/engine/src/engine.ts
+++ b/packages/engine/src/engine.ts
@@ -1025,6 +1025,9 @@ export class Engine {
       SessionState.unset(scene, RuntimeModeComponent)
       SessionState.set(scene, new EditorModeComponent())
     }
+    // Swap placement chrome (cell frames + logic markers) out of / back
+    // into the render so a playtest shows only the real sprites.
+    scene.refreshPlacementGraphicsForMode(active)
   }
 
   /** Current runtime-mode state on the active scene (`false` if no scene). */

--- a/packages/engine/src/entity/placement-graphic.spec.ts
+++ b/packages/engine/src/entity/placement-graphic.spec.ts
@@ -165,5 +165,25 @@ export default async () => {
       // Contain-fitted into the 14×14 framed area: 16×32 cell → bound by height.
       expect((content as Animation).scale.y).toBe(14 / 32)
     })
+
+    await it('runtime mode: sprite-less placement renders nothing (no frame, no marker)', async () => {
+      if (!domAvailable) return
+      const def: EntityDefinition = { id: 'tp', name: 'Door', components: [{ type: 'trigger', on: 'walk-onto' }] }
+      const group = buildPlacementGraphic(def, fakeMapResource, 16, 16, undefined, { runtime: true })
+      expect(group.members.length).toBe(0)
+    })
+
+    await it('runtime mode: sprite placement shows only the sprite, no editor frame', async () => {
+      if (!domAvailable) return
+      const def: EntityDefinition = {
+        id: 'scientist',
+        name: 'Scientist',
+        components: [{ type: 'visual', spriteSetId: 'scientist', spriteId: 0, animationId: 'idle-down' }],
+      }
+      const group = buildPlacementGraphic(def, characterMapResource, 16, 16, undefined, { runtime: true })
+      expect(group.members.length).toBe(1)
+      expect(memberGraphic(group, 0) instanceof Rectangle).toBe(false) // no cell frame
+      expect(memberGraphic(group, 0) instanceof Animation).toBe(true)
+    })
   })
 }

--- a/packages/engine/src/entity/placement-graphic.ts
+++ b/packages/engine/src/entity/placement-graphic.ts
@@ -63,11 +63,26 @@ export function frameInset(tileWidth: number, tileHeight: number): number {
   return Math.max(1, Math.round(Math.min(tileWidth, tileHeight) * 0.07))
 }
 
+/** Options for {@link buildPlacementGraphic}. */
+export interface PlacementGraphicOptions {
+  /**
+   * Runtime (playtest) mode: drop the editor-only cell frame, and render
+   * *nothing* for a sprite-less placement (spawn-point / teleport /
+   * trigger markers are editor chrome — the player must not see the
+   * diamonds). In editor mode (default) the frame + marker/sprite show.
+   */
+  runtime?: boolean
+}
+
 /**
  * Build the tile-like graphic for one resolved placement definition:
  * a `GraphicsGroup` of [cell frame, content]. Content is the `visual`
  * component's sprite/animation contain-fitted into the framed cell, or
  * the type-coloured diamond marker when no sprite resolves.
+ *
+ * In `runtime` mode the editor cell frame is dropped and a marker-only
+ * placement renders as an empty group (invisible) — so a playtest shows
+ * just the actual sprites, not the editor's frames + logic markers.
  *
  * The group's local bounds are exactly `tileWidth × tileHeight`, so an
  * anchor of (0.5, 0.5) centres it on a tile-centre actor and (0, 0)
@@ -79,15 +94,21 @@ export function buildPlacementGraphic(
   tileWidth: number,
   tileHeight: number,
   registry: ComponentSpecRegistry = BUILT_IN_COMPONENT_SPECS,
+  options: PlacementGraphicOptions = {},
 ): GraphicsGroup {
-  const frame = new Rectangle({
-    width: tileWidth,
-    height: tileHeight,
-    color: Color.Transparent,
-    strokeColor: Color.fromHex(EDITOR_CONSTANTS.HOVER_OBJECT_BORDER_COLOR),
-    lineWidth: 1,
-  })
-  const members: GraphicsGrouping[] = [{ offset: vec(0, 0), graphic: frame }]
+  const members: GraphicsGrouping[] = []
+  // Editor-only cell frame — omitted in runtime so the player sees no
+  // outline around placed objects.
+  if (!options.runtime) {
+    const frame = new Rectangle({
+      width: tileWidth,
+      height: tileHeight,
+      color: Color.Transparent,
+      strokeColor: Color.fromHex(EDITOR_CONSTANTS.HOVER_OBJECT_BORDER_COLOR),
+      lineWidth: 1,
+    })
+    members.push({ offset: vec(0, 0), graphic: frame })
+  }
 
   const visualData = def.components.find((c) => c.type === 'visual')
   const sprite = visualData ? buildVisualGraphic(visualData, mapResource) : null
@@ -100,7 +121,10 @@ export function buildPlacementGraphic(
       offset: vec((tileWidth - sprite.width) / 2, (tileHeight - sprite.height) / 2),
       graphic: sprite,
     })
-  } else {
+  } else if (!options.runtime) {
+    // Sprite-less placement: the editor diamond marker. Skipped in
+    // runtime — spawn-point / teleport / trigger placements are
+    // invisible logic in-game, so the group renders empty.
     const r = Math.max(2, Math.round(Math.min(tileWidth, tileHeight) * 0.25))
     const diamond = new Polygon({
       points: [vec(r, 0), vec(2 * r, r), vec(r, 2 * r), vec(0, r)],

--- a/packages/engine/src/entity/spawn-placement.ts
+++ b/packages/engine/src/entity/spawn-placement.ts
@@ -7,7 +7,7 @@ import type { EntityDefinition, ObjectPlacement } from '../types/data/index.ts'
 import { DEFAULT_LAYER_TIER, type LayerData } from '../types/data/LayerData.ts'
 import { EDITOR_CONSTANTS } from '../utils/constants.ts'
 import type { ComponentSpecRegistry } from './component-spec.ts'
-import { buildPlacementGraphic } from './placement-graphic.ts'
+import { buildPlacementGraphic, type PlacementGraphicOptions } from './placement-graphic.ts'
 import { BUILT_IN_COMPONENT_SPECS } from './registry.ts'
 import { validateEntityDefinition } from './validate.ts'
 
@@ -26,6 +26,7 @@ export function buildPlacementEntity(
   mapResource: MapResource,
   layersById: ReadonlyMap<string, LayerData>,
   registry: ComponentSpecRegistry = BUILT_IN_COMPONENT_SPECS,
+  options: PlacementGraphicOptions = {},
 ): Entity {
   const mapData = mapResource.mapData
   const tileWidth = mapData?.tileWidth ?? EDITOR_CONSTANTS.DEFAULT_TILE_SIZE
@@ -50,14 +51,34 @@ export function buildPlacementEntity(
       for (const c of Array.isArray(built) ? built : [built]) actor.addComponent(c)
     }
   }
-  actor.graphics.use(buildPlacementGraphic(def, mapResource, tileWidth, tileHeight, registry))
-  actor.graphics.anchor = vec(0.5, 0.5)
+  applyPlacementGraphic(actor, def, mapResource, registry, options)
 
   const layer = layersById.get(placement.layerId)
   actor.z = TIER_Z[layer?.tier ?? DEFAULT_LAYER_TIER]
   if (!isLayerVisible(mapResource, placement.layerId)) actor.graphics.visible = false
 
   return actor
+}
+
+/**
+ * (Re)apply a placement actor's tile-like graphic for the given mode.
+ * Shared by {@link buildPlacementEntity} (spawn) and the editor↔runtime
+ * toggle (`MapScene.refreshPlacementGraphicsForMode`), so switching into
+ * playtest re-renders every placement without its editor chrome (frame +
+ * logic markers) and switching back restores it.
+ */
+export function applyPlacementGraphic(
+  actor: Actor,
+  def: EntityDefinition,
+  mapResource: MapResource,
+  registry: ComponentSpecRegistry = BUILT_IN_COMPONENT_SPECS,
+  options: PlacementGraphicOptions = {},
+): void {
+  const mapData = mapResource.mapData
+  const tileWidth = mapData?.tileWidth ?? EDITOR_CONSTANTS.DEFAULT_TILE_SIZE
+  const tileHeight = mapData?.tileHeight ?? EDITOR_CONSTANTS.DEFAULT_TILE_SIZE
+  actor.graphics.use(buildPlacementGraphic(def, mapResource, tileWidth, tileHeight, registry, options))
+  actor.graphics.anchor = vec(0.5, 0.5)
 }
 
 /**

--- a/packages/engine/src/scenes/map.scene.ts
+++ b/packages/engine/src/scenes/map.scene.ts
@@ -1,7 +1,7 @@
 import { Actor, type EventEmitter, Logger, Scene } from 'excalibur'
 import { EditorModeComponent, PlacementIdComponent } from '../components/index.ts'
 import { resolvePlacementDefinition } from '../entity/data-access.ts'
-import { buildPlacementEntity } from '../entity/spawn-placement.ts'
+import { applyPlacementGraphic, buildPlacementEntity } from '../entity/spawn-placement.ts'
 import type { MapResource } from '../resource/MapResource.ts'
 import type { SpriteSetResource } from '../resource/SpriteSetResource.ts'
 import { areObjectsVisible } from '../services/editor-view.ts'
@@ -104,6 +104,28 @@ export class MapScene extends Scene {
     // Respect the global objects toggle for live spawns (place / undo).
     if (entity instanceof Actor && !areObjectsVisible(this)) entity.graphics.visible = false
     this.add(entity)
+  }
+
+  /**
+   * Rebuild every placement actor's graphic for editor vs runtime mode.
+   * In runtime the editor cell frame + logic markers (spawn-point /
+   * teleport / trigger diamonds) are dropped so a playtest shows only
+   * the real sprites; switching back restores the editor chrome. Called
+   * by `Engine.setRuntimeMode`.
+   */
+  refreshPlacementGraphicsForMode(runtime: boolean): void {
+    const placements = this.mapResource.mapData?.objectPlacements ?? []
+    const byId = new Map(placements.map((p) => [p.id, p]))
+    for (const entity of this.world.entityManager.entities) {
+      if (!(entity instanceof Actor)) continue
+      const placementId = entity.get(PlacementIdComponent)?.id
+      if (!placementId) continue
+      const placement = byId.get(placementId)
+      if (!placement) continue
+      const def = resolvePlacementDefinition(placement, this.entityLibrary)
+      if (!def) continue
+      applyPlacementGraphic(entity, def, this.mapResource, undefined, { runtime })
+    }
   }
 
   /** Despawn the live entity for a placement id (used by `RemoveObjectCommand`). */


### PR DESCRIPTION
## What

Entering play (playtest) left the editor's placement chrome — cell frames + logic markers (spawn-point / teleport / trigger diamonds) — drawn over the map, so a playtest didn't look like the actual game.

## Changes

- **`buildPlacementGraphic`** gains a `runtime` option: drops the editor cell frame, and renders **nothing** for a sprite-less placement (its diamond marker is editor-only chrome for invisible logic). Sprite placements render just the sprite.
- **`applyPlacementGraphic`** (extracted from `buildPlacementEntity`) rebuilds a single actor's graphic for a mode; **`MapScene.refreshPlacementGraphicsForMode`** re-renders every placement on the editor↔runtime toggle.
- **`Engine.setRuntimeMode`** calls it — Play hides the chrome, Stop restores it.

## Verification

- **On-device via MCP**: entered play on kokiri-forest → cell frames + diamond markers gone, only the real sprites + the player show; left play → editor chrome restored. (Screenshotted the round-trip autonomously.)
- Unit tests: runtime graphic is empty for marker-only placements and frameless for sprite placements (Node + GJS).

Covers item (a) of the "play-mode presentation gaps" TODO; (b) camera-snap-to-player and (c) scene-chrome-on-teleport remain.

https://claude.ai/code/session_011B9ADCSnzUm3dXaPzbSBWe